### PR TITLE
Feat: add info about DSP to StreamDetails

### DIFF
--- a/music_assistant_models/dsp.py
+++ b/music_assistant_models/dsp.py
@@ -137,3 +137,28 @@ class DSPConfig(DataClassDictMixin):
         # Validate filters
         for f in self.filters:
             f.validate()
+
+
+class DSPState(StrEnum):
+    """Enum of all DSP states of DSPDetails."""
+
+    ENABLED = "enabled"
+    DISABLED = "disabled"
+    DISABLED_BY_UNSUPPORTED_GROUP = "disabled_by_unsupported_group"
+
+
+@dataclass(kw_only=True)
+class DSPDetails(DataClassDictMixin):
+    """Model for information about a DSP applied to a stream.
+
+    This describes the DSP configuration as applied,
+    even when the DSP state is disabled. For example,
+    output_limiter can remain true while the DSP is disabled.
+    All filters in the list are guaranteed to be enabled.
+    """
+
+    state: DSPState = DSPState.DISABLED
+    input_gain: float = 0.0
+    filters: list[DSPFilter] = field(default_factory=list)
+    output_gain: float = 0.0
+    output_limiter: bool = True

--- a/music_assistant_models/dsp.py
+++ b/music_assistant_models/dsp.py
@@ -158,6 +158,7 @@ class DSPDetails(DataClassDictMixin):
     """
 
     state: DSPState = DSPState.DISABLED
+    is_leader: bool = False
     input_gain: float = 0.0
     filters: list[DSPFilter] = field(default_factory=list)
     output_gain: float = 0.0

--- a/music_assistant_models/streamdetails.py
+++ b/music_assistant_models/streamdetails.py
@@ -80,7 +80,12 @@ class StreamDetails(DataClassDictMixin):
     strip_silence_begin: bool = False
     strip_silence_end: bool = False
     stream_error: bool | None = None
+    # In case of grouped playback, this will contain the DSP details for
+    # the leader (keep in mind that PlayerGroups has no leader!)
     dsp: DSPDetails | None = None
+    # In case of grouped playback, this will contain the DSP details for
+    # all other players of the group (indexed by player_id)
+    dsp_grouped_childs: dict[str, DSPDetails] | None = None
 
     def __str__(self) -> str:
         """Return pretty printable string of object."""

--- a/music_assistant_models/streamdetails.py
+++ b/music_assistant_models/streamdetails.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from mashumaro import DataClassDictMixin
 
+from .dsp import DSPDetails
 from .enums import MediaType, StreamType, VolumeNormalizationMode
 from .media_items import AudioFormat
 
@@ -79,6 +80,7 @@ class StreamDetails(DataClassDictMixin):
     strip_silence_begin: bool = False
     strip_silence_end: bool = False
     stream_error: bool | None = None
+    dsp: DSPDetails | None = None
 
     def __str__(self) -> str:
         """Return pretty printable string of object."""

--- a/music_assistant_models/streamdetails.py
+++ b/music_assistant_models/streamdetails.py
@@ -80,12 +80,11 @@ class StreamDetails(DataClassDictMixin):
     strip_silence_begin: bool = False
     strip_silence_end: bool = False
     stream_error: bool | None = None
-    # In case of grouped playback, this will contain the DSP details for
-    # the leader (keep in mind that PlayerGroups has no leader!)
-    dsp: DSPDetails | None = None
-    # In case of grouped playback, this will contain the DSP details for
-    # all other players of the group (indexed by player_id)
-    dsp_grouped_childs: dict[str, DSPDetails] | None = None
+    # This contains the DSPDetails of all players in the group.
+    # In case of single player playback, dict will contain only one entry.
+    # The leader will have is_leader set to True.
+    # (keep in mind that PlayerGroups have no (explicit) leader!)
+    dsp: dict[str, DSPDetails] | None = None
 
     def __str__(self) -> str:
         """Return pretty printable string of object."""


### PR DESCRIPTION
This will allow the player to display information about the applied DSP (including all individual devices in grouped playback), including a reason in case the DSP was disabled by Music Assistant.

A PR for server and fronted will follow later.