### PR TITLE
feat: add models required for knowing each players output format

### DIFF
--- a/music_assistant_models/dsp.py
+++ b/music_assistant_models/dsp.py
@@ -8,6 +8,8 @@ from typing import Literal
 
 from mashumaro import DataClassDictMixin
 
+from .media_items.audio_format import AudioFormat
+
 # ruff: noqa: S105
 
 
@@ -155,6 +157,7 @@ class DSPDetails(DataClassDictMixin):
     even when the DSP state is disabled. For example,
     output_limiter can remain true while the DSP is disabled.
     All filters in the list are guaranteed to be enabled.
+    output_format is the format that will be sent to the output device (if known).
     """
 
     state: DSPState = DSPState.DISABLED
@@ -163,3 +166,4 @@ class DSPDetails(DataClassDictMixin):
     filters: list[DSPFilter] = field(default_factory=list)
     output_gain: float = 0.0
     output_limiter: bool = True
+    output_format: AudioFormat | None = None

--- a/music_assistant_models/player.py
+++ b/music_assistant_models/player.py
@@ -10,6 +10,7 @@ from mashumaro import DataClassDictMixin, field_options, pass_through
 
 from .constants import PLAYER_CONTROL_NATIVE
 from .enums import MediaType, PlayerFeature, PlayerState, PlayerType
+from .media_items.audio_format import AudioFormat
 from .unique_list import UniqueList
 
 
@@ -184,6 +185,15 @@ class Player(DataClassDictMixin):
     # last_poll: when was the player last polled (used with needs_poll)
     last_poll: float = field(
         default=0.0,
+        compare=False,
+        metadata=field_options(serialize="omit", deserialize=pass_through),
+        repr=False,
+    )
+
+    # The output format that is sent to the player
+    # (or to the library/application that is used to send audio to the player)
+    output_format: AudioFormat | None = field(
+        default=None,
         compare=False,
         metadata=field_options(serialize="omit", deserialize=pass_through),
         repr=False,


### PR DESCRIPTION
This new information will be used to show the users what sample rate is truly sent to each player.

The `output_format` is attached to the `DSPDetails` and not to the player (publically), since using the raw `_output_format` is not that straight forward with grouped playback.