### PR TITLE
feat: add codec information to the `AudioFormat` model

### DIFF
--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -158,12 +158,30 @@ class ContentType(StrEnum):
     FLAC = "flac"  # FLAC lossless audio
     MP3 = "mp3"  # MPEG-1 Audio Layer III
     WMA = "wma"  # Windows Media Audio
+    WMAV2 = "wmav2"  # Windows Media Audio v2
+    WMAPRO = "wmapro"  # Windows Media Audio Professional
     WAVPACK = "wavpack"  # WavPack lossless
+    TAK = "tak"  # Tom's Lossless Audio Kompressor
+    APE = "ape"  # Monkey's Audio
+    MUSEPACK = "mpc"  # MusePack
 
     # --- Codecs ---
     AAC = "aac"  # Advanced Audio Coding
     ALAC = "alac"  # Apple Lossless Audio Codec
     OPUS = "opus"  # Opus audio codec
+    VORBIS = "vorbis"  # Ogg Vorbis compression
+    AC3 = "ac3"  # Dolby Digital (common in DVDs)
+    EAC3 = "eac3"  # Dolby Digital Plus (streaming/4K)
+    DTS = "dts"  # Digital Theater System
+    TRUEHD = "truehd"  # Dolby TrueHD (lossless)
+    DTSHD = "dtshd"  # DTS-HD Master Audio
+    DTSX = "dtsx"  # DTS:X immersive audio
+    COOK = "cook"  # RealAudio Cook Codec
+    RA_144 = "ralf"  # RealAudio Lossless
+    MP2 = "mp2"  # MPEG-1 Audio Layer II
+    MP1 = "mp1"  # MPEG-1 Audio Layer I
+    DRA = "dra"  # Chinese Digital Rise Audio
+    ATRAC3 = "atrac3"  # Sony MiniDisc format
 
     # --- PCM Codecs ---
     PCM_S16LE = "s16le"  # PCM 16-bit little-endian
@@ -171,6 +189,31 @@ class ContentType(StrEnum):
     PCM_S32LE = "s32le"  # PCM 32-bit little-endian
     PCM_F32LE = "f32le"  # PCM 32-bit float
     PCM_F64LE = "f64le"  # PCM 64-bit float
+    PCM_S16BE = "s16be"  # PCM 16-bit big-endian
+    PCM_S24BE = "s24be"  # PCM 24-bit big-endian
+    PCM_S32BE = "s32be"  # PCM 32-bit big-endian
+    PCM_BLURAY = "pcm_bluray"  # Blu-ray specific PCM
+    PCM_DVD = "pcm_dvd"  # DVD specific PCM
+
+    # --- ADPCM Codecs ---
+    ADPCM_IMA = "adpcm_ima_qt"  # QuickTime variant
+    ADPCM_MS = "adpcm_ms"  # Microsoft variant
+    ADPCM_SWF = "adpcm_swf"  # Flash audio
+
+    # --- PDM Codecs ---
+    DSD_LSBF = "dsd_lsbf"  # DSD least-significant-bit first
+    DSD_MSBF = "dsd_msbf"  # DSD most-significant-bit first
+    DSD_LSBF_PLANAR = "dsd_lsbf_planar"  # DSD planar least-significant-bit first
+    DSD_MSBF_PLANAR = "dsd_msbf_planar"  # DSD planar most-significant-bit first
+
+    # --- Voice Codecs ---
+    AMR = "amr_nb"  # Adaptive Multi-Rate Narrowband, voice codec
+    AMR_WB = "amr_wb"  # Adaptive Multi-Rate Wideband, voice codec
+    SPEEX = "speex"  # Open-source voice codec, voice codec
+    PCM_ALAW = "alaw"  # G.711 A-law, voice codec
+    PCM_MULAW = "mulaw"  # G.711 µ-law, voice codec
+    G722 = "g722"  # ITU-T 7 kHz audio
+    G726 = "g726"  # ADPCM telephone quality
 
     # --- Special ---
     PCM = "pcm"  # PCM generic (details determined later)
@@ -219,6 +262,14 @@ class ContentType(StrEnum):
             ContentType.WAV,
             ContentType.ALAC,
             ContentType.WAVPACK,
+            ContentType.TAK,
+            ContentType.APE,
+            ContentType.TRUEHD,
+            ContentType.DSD_LSBF,
+            ContentType.DSD_MSBF,
+            ContentType.DSD_LSBF_PLANAR,
+            ContentType.DSD_MSBF_PLANAR,
+            ContentType.RA_144,
         )
 
     @classmethod

--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -158,7 +158,7 @@ class ContentType(StrEnum):
     M4B = "m4b"
     DSF = "dsf"
     OPUS = "opus"
-    WAVPACK = "wv"
+    WAVPACK = "wavpack"
     PCM_S16LE = "s16le"  # PCM signed 16-bit little-endian
     PCM_S24LE = "s24le"  # PCM signed 24-bit little-endian
     PCM_S32LE = "s32le"  # PCM signed 32-bit little-endian
@@ -190,6 +190,7 @@ class ContentType(StrEnum):
         tempstr = tempstr.split(";")[0]
         tempstr = tempstr.replace("mp4", "m4a")
         tempstr = tempstr.replace("mp4a", "m4a")
+        tempstr = tempstr.replace("wv", "wavpack")
         try:
             return cls(tempstr)
         except ValueError:

--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -151,6 +151,7 @@ class ContentType(StrEnum):
     MPEG = "mpeg"  # MPEG-PS/MPEG-TS container
     M4A = "m4a"  # MPEG-4 Audio (AAC/ALAC)
     MP4 = "mp4"  # MPEG-4 container
+    MP4A = "mp4a"  # MPEG-4 Audio (AAC/ALAC)
     M4B = "m4b"  # MPEG-4 Audiobook
     DSF = "dsf"  # DSD Stream File
 
@@ -240,8 +241,6 @@ class ContentType(StrEnum):
         tempstr = tempstr.split("?")[0]
         tempstr = tempstr.split("&")[0]
         tempstr = tempstr.split(";")[0]
-        tempstr = tempstr.replace("mp4", "m4a")
-        tempstr = tempstr.replace("mp4a", "m4a")
         tempstr = tempstr.replace("wv", "wavpack")
         tempstr = tempstr.replace("pcm_", "")
         try:

--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -144,28 +144,37 @@ class AlbumType(StrEnum):
 class ContentType(StrEnum):
     """Enum with audio content/container types supported by ffmpeg."""
 
-    OGG = "ogg"
-    FLAC = "flac"
-    MP3 = "mp3"
-    AAC = "aac"
-    MPEG = "mpeg"
-    ALAC = "alac"
-    WAV = "wav"
-    AIFF = "aiff"
-    WMA = "wma"
-    M4A = "m4a"
-    MP4 = "mp4"
-    M4B = "m4b"
-    DSF = "dsf"
-    OPUS = "opus"
-    WAVPACK = "wavpack"
-    PCM_S16LE = "s16le"  # PCM signed 16-bit little-endian
-    PCM_S24LE = "s24le"  # PCM signed 24-bit little-endian
-    PCM_S32LE = "s32le"  # PCM signed 32-bit little-endian
-    PCM_F32LE = "f32le"  # PCM 32-bit floating-point little-endian
-    PCM_F64LE = "f64le"  # PCM 64-bit floating-point little-endian
+    # --- Containers ---
+    OGG = "ogg"  # Ogg container (Vorbis/Opus/FLAC)
+    WAV = "wav"  # WAV container (usually PCM)
+    AIFF = "aiff"  # AIFF container
+    MPEG = "mpeg"  # MPEG-PS/MPEG-TS container
+    M4A = "m4a"  # MPEG-4 Audio (AAC/ALAC)
+    MP4 = "mp4"  # MPEG-4 container
+    M4B = "m4b"  # MPEG-4 Audiobook
+    DSF = "dsf"  # DSD Stream File
+
+    # --- Can both be a container and codec ---
+    FLAC = "flac"  # FLAC lossless audio
+    MP3 = "mp3"  # MPEG-1 Audio Layer III
+    WMA = "wma"  # Windows Media Audio
+    WAVPACK = "wavpack"  # WavPack lossless
+
+    # --- Codecs ---
+    AAC = "aac"  # Advanced Audio Coding
+    ALAC = "alac"  # Apple Lossless Audio Codec
+    OPUS = "opus"  # Opus audio codec
+
+    # --- PCM Codecs ---
+    PCM_S16LE = "s16le"  # PCM 16-bit little-endian
+    PCM_S24LE = "s24le"  # PCM 24-bit little-endian
+    PCM_S32LE = "s32le"  # PCM 32-bit little-endian
+    PCM_F32LE = "f32le"  # PCM 32-bit float
+    PCM_F64LE = "f64le"  # PCM 64-bit float
+
+    # --- Special ---
     PCM = "pcm"  # PCM generic (details determined later)
-    UNKNOWN = "?"
+    UNKNOWN = "?"  # Unknown type
 
     @classmethod
     def _missing_(cls, value: object) -> ContentType:  # noqa: ARG003

--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -191,6 +191,7 @@ class ContentType(StrEnum):
         tempstr = tempstr.replace("mp4", "m4a")
         tempstr = tempstr.replace("mp4a", "m4a")
         tempstr = tempstr.replace("wv", "wavpack")
+        tempstr = tempstr.replace("pcm_", "")
         try:
             return cls(tempstr)
         except ValueError:

--- a/music_assistant_models/media_items/audio_format.py
+++ b/music_assistant_models/media_items/audio_format.py
@@ -17,6 +17,7 @@ class AudioFormat(DataClassDictMixin):
     """Model for AudioFormat details."""
 
     content_type: ContentType = ContentType.UNKNOWN
+    codec_type: ContentType = ContentType.UNKNOWN
     sample_rate: int = 44100
     bit_depth: int = 16
     channels: int = 2


### PR DESCRIPTION
This also considerably expands the list of known codecs in `ContentType`, since this enum is now responsible for storing both container and codec types.

While `ContentType` is still not a complete list, it now should know about all most common container and codec types, including even many obscure ones.

Also some adjustments to parsing was made to:
- support ffmpegs pcm names
- show "wavpack" to the user, instead of just "wv"