### PR TITLE
chore: remove `is_leader` from `DSPDetails

### DIFF
--- a/music_assistant_models/dsp.py
+++ b/music_assistant_models/dsp.py
@@ -164,7 +164,6 @@ class DSPDetails(DataClassDictMixin):
     """
 
     state: DSPState = DSPState.DISABLED
-    is_leader: bool = False
     input_gain: float = 0.0
     filters: list[DSPFilter] = field(default_factory=list)
     output_gain: float = 0.0

--- a/music_assistant_models/streamdetails.py
+++ b/music_assistant_models/streamdetails.py
@@ -127,8 +127,6 @@ class StreamDetails(DataClassDictMixin):
 
     # This contains the DSPDetails of all players in the group.
     # In case of single player playback, dict will contain only one entry.
-    # The leader will have is_leader set to True.
-    # (keep in mind that PlayerGroups have no (explicit) leader!)
     dsp: dict[str, DSPDetails] | None = None
 
     # the fields below are managed by the queue/stream controller and may not be set by providers


### PR DESCRIPTION
This should only be merged after https://github.com/music-assistant/server/pull/1940. See that PR for details.