### PR TITLE
chore: delete the old `DSPConfig.output_limiter`

### DIFF
--- a/music_assistant_models/dsp.py
+++ b/music_assistant_models/dsp.py
@@ -127,10 +127,6 @@ class DSPConfig(DataClassDictMixin):
     input_gain: float = 0.0
     # Output gain in dB, will be applied after all other DSP filters
     output_gain: float = 0.0
-    # This option is no longer used and just kept for migrating
-    # to the player settings
-    # TODO: remove in a future release
-    output_limiter: bool = True
 
     def validate(self) -> None:
         """Validate the DSP configuration."""


### PR DESCRIPTION
Since the migration logic now runs earlier, we don't need this key anymore.

Should only be merged after https://github.com/music-assistant/server/pull/1981