### PR TITLE
Add artists and album mbids to MediaItemPlaybackProgressReport

### DIFF
--- a/music_assistant_models/playback_progress_report.py
+++ b/music_assistant_models/playback_progress_report.py
@@ -21,7 +21,9 @@ class MediaItemPlaybackProgressReport(DataClassDictMixin):
     media_type: MediaType
     name: str
     artist: str | None
+    artist_mbids: list[str] | None
     album: str | None
+    album_mbid: str | None
     image_url: str | None
     duration: int
     mbid: str | None


### PR DESCRIPTION
These will initially be used by the listenbrainz scrobbler.

See https://github.com/music-assistant/server/pull/2048 for the consumer.