### PR TITLE
Add hash function to PlayerSource

### DIFF
--- a/music_assistant_models/player.py
+++ b/music_assistant_models/player.py
@@ -59,6 +59,10 @@ class PlayerSource(DataClassDictMixin):
     # can_next_previous: this source can be skipped to next/previous item
     can_next_previous: bool = False
 
+    def __hash__(self) -> int:
+        """Return custom hash."""
+        return hash(self.id)
+
 
 @dataclass
 class Player(DataClassDictMixin):


### PR DESCRIPTION
This class requires a hash method, because we use it in a UniqueList [here](https://github.com/music-assistant/server/blob/4751658c0abec1134960c5a181d03511eb81c4ee/music_assistant/models/player.py#L759)