### PR TITLE
Add live and soundtrack album types

### DIFF
--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -136,6 +136,8 @@ class AlbumType(StrEnum):
 
     ALBUM = "album"
     SINGLE = "single"
+    LIVE = "live"
+    SOUNDTRACK = "soundtrack"
     COMPILATION = "compilation"
     EP = "ep"
     UNKNOWN = "unknown"


### PR DESCRIPTION
As discussed on Discord. This is the first step to adding new album types to allow filtering in the frontend for live and soundtrack albums