### PR TITLE
Expose `grouping` field on media items

### DIFF
--- a/music_assistant_models/media_items/metadata.py
+++ b/music_assistant_models/media_items/metadata.py
@@ -78,6 +78,7 @@ class MediaItemMetadata(DataClassDictMixin):
     explicit: bool | None = None
     # NOTE: images is a list of available images, sorted by preference
     images: UniqueList[MediaItemImage] | None = None
+    grouping: str | None = None
     genres: set[str] | None = None
     mood: str | None = None
     style: str | None = None


### PR DESCRIPTION
The `grouping` field is supported by major tools like [MusicBrainz Picard](https://picard.musicbrainz.org/), [Mixxx](https://mixxx.org/) and `ffprobe`. It is most often used as a kind of additional single-line comment field for music libraries with very extensive tagging schemes.

It is mapped [to the `TIT1` field for MP3 files](https://git.ffmpeg.org/gitweb/ffmpeg.git/blob/9ee7796c540ce9cec3fdff0dd246de842228707b:/libavformat/id3v2.c#l73) and to the `GROUPING` field for FLAC files.

(My personal use case is that I'm working as a dance DJ and have a professional DJ setup using Mixxx, but would like my metadata to be accessible in Music Assistant when I'm playing music casually as well).