### PR TITLE
Add permissions and claims fields to User model

### DIFF
--- a/music_assistant_models/auth.py
+++ b/music_assistant_models/auth.py
@@ -39,6 +39,8 @@ class User(DataClassORJSONMixin):
     preferences: dict[str, Any] = field(default_factory=dict)
     provider_filter: list[str] = field(default_factory=list)
     player_filter: list[str] = field(default_factory=list)
+    permissions: list[str] = field(default_factory=list)
+    claims: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass


### PR DESCRIPTION
## Summary

- Adds `permissions: list[str]` and `claims: dict[str, Any]` fields to the `User` dataclass
- Supports the claims-based permission system being added in [server PR #2892](https://github.com/music-assistant/server/pull/2892)

## Fields

- **`permissions`** — holds permission scope strings (e.g. `library:read`, `players:control`). Set by the server's auth layer after JWT decode or role-based generation. Replaces the `getattr(user, "_permissions")` hack with a proper model attribute.
- **`claims`** — holds arbitrary JWT claims for future OIDC provider integration and provider-contributed custom claims (e.g. `spotify:premium`, `tidal:subscription_tier`).

## Backward Compatibility

Both fields use `field(default_factory=...)` so they default to empty. Existing serialized `User` objects deserialize without issue — no breaking changes.