### PR TITLE
Revert "Build(deps): Bump pypa/gh-action-pypi-publish from 1.13.0 to 1.14.0"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,7 @@ jobs:
           python3 -m build
 
       - name: Publish release to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.14.0
+        uses: pypa/gh-action-pypi-publish@v1.13.0
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Reverts music-assistant/models#200

It breaks the release process