### PR TITLE
Add playback_speed for variable-speed elapsed-time tracking

### DIFF
--- a/music_assistant_models/player_queue.py
+++ b/music_assistant_models/player_queue.py
@@ -21,6 +21,7 @@ class PlayLogEntry:
     queue_item_id: str
     duration: int | None = None
     seconds_streamed: float | None = None
+    playback_speed: float = 1.0
 
 
 @dataclass
@@ -43,6 +44,9 @@ class PlayerQueue(DataClassDictMixin):
 
     elapsed_time: float = 0
     elapsed_time_last_updated: float = field(default_factory=time.time)
+    # playback_speed in effect at elapsed_time_last_updated
+    # Used to calculate the corrected elapsed time to advance the wallcloack delta in media-time
+    playback_speed: float = 1.0
     state: PlaybackState = PlaybackState.IDLE
     current_item: QueueItem | None = None
     next_item: QueueItem | None = None
@@ -101,7 +105,9 @@ class PlayerQueue(DataClassDictMixin):
     def corrected_elapsed_time(self) -> float:
         """Return the corrected/realtime elapsed time."""
         if self.state == PlaybackState.PLAYING:
-            return self.elapsed_time + (time.time() - self.elapsed_time_last_updated)
+            return self.elapsed_time + (
+                (time.time() - self.elapsed_time_last_updated) * self.playback_speed
+            )
         return self.elapsed_time
 
     def to_cache(self) -> dict[str, Any]:

--- a/music_assistant_models/player_queue.py
+++ b/music_assistant_models/player_queue.py
@@ -21,7 +21,6 @@ class PlayLogEntry:
     queue_item_id: str
     duration: int | None = None
     seconds_streamed: float | None = None
-    playback_speed: float = 1.0
 
 
 @dataclass


### PR DESCRIPTION
Looking to satisfy https://github.com/orgs/music-assistant/discussions/3790

Music Assistant already supports variable playback speed by applying ffmpeg's atempo filter to speed up the audio before it reaches the player. However, this will break elapsed-time accounting because the player only knows how long it has been playing the (sped-up) audio — it has no idea how much of the original content the listener has heard.                                                                           
                                                                                                                                                  
Without knowing the speed, the queue and the progress bar can't tell those two values apart, which causes:
                                                                                                                                                  
1. The progress bar to drift from the listener's actual position between server updates, because the realtime tick advances using real-world seconds instead of audiobook seconds; and                                                                                                         
 
2. Flow mode (where MA stitches multiple tracks into one continuous stream for players that can't gap-lessly switch tracks) to pick the wrong track boundary when the speed varies across items in the stream.                                                
                                                                                                                                                  
This PR adds two new fields, both defaulting to 1.0, so the speed travels alongside the timing data:
                                                                                                                                                  
- `PlayerQueue.playback_speed`: the speed in effect at the moment of the last `elapsed_time` update. The `corrected_elapsed_time` property is updated to multiply its between-update delta by this value, so the progress bar ticks in audiobook/podcast playback seconds rather than real-world seconds.                                                      
                                                                                                                                                  
- `PlayLogEntry.playback_speed`: the speed at which each flow-mode segment was streamed. The MA controller uses this to figure out which track is currently playing when the speed has varied across segments in a single stream.                                                                                                                    
                                                                                                                                                  
The new fields default to 1.0 which means the current callers get exactly the same behaviour.
                                                                                                                                                  
The corresponding server PR uses these fields to record `elapsed_time` in audiobook/podcast playback seconds and to step through the flow-mode playlog with the correct speed for each segment.