### PR TITLE
Add DeviceInfo.connections for cross-integration HA card merge

### DIFF
--- a/music_assistant_models/player.py
+++ b/music_assistant_models/player.py
@@ -51,6 +51,14 @@ class DeviceInfo(DataClassDictMixin):
     # Maps IdentifierType to value (e.g., MAC_ADDRESS -> "AA:BB:CC:DD:EE:FF")
     identifiers: dict[IdentifierType, str] = field(default_factory=dict)
 
+    # Hardware connections mirroring HA's device_registry shape — a set of
+    # (connection_type, value) tuples. Provider-defined; HA's MA integration
+    # forwards verbatim into device_registry. Standard HA connection types
+    # ("mac", "bluetooth", "zigbee", "upnp", "cast") are recommended but
+    # not enforced — any string is accepted so new transports work without
+    # taxonomy changes.
+    connections: set[tuple[str, str]] = field(default_factory=set)
+
     @property
     def ip_address(self) -> str | None:
         """Get IP address from identifiers."""
@@ -96,6 +104,30 @@ class DeviceInfo(DataClassDictMixin):
         if identifier_type == IdentifierType.MAC_ADDRESS:
             value = value.upper().replace("-", ":")
         self.identifiers[identifier_type] = value
+
+    def add_connection(self, connection_type: str, value: str) -> None:
+        """Add a hardware connection tuple, normalizing MAC-shaped values.
+
+        Mirrors Home Assistant's ``device_registry.DeviceInfo.connections``
+        shape so MA's HA integration can forward the set verbatim. MAC-shaped
+        values are normalized to HA's canonical ``aa:bb:cc:dd:ee:ff`` form
+        regardless of input separator (``AA:BB``, ``aa-bb``, ``AABBCC``);
+        all other connection types are stored as-is so future transports
+        (zigbee EUI-64, Matter device-id, Thread MLE, …) work without
+        taxonomy changes.
+
+        :param connection_type: HA-style connection type — ``"mac"``,
+            ``"bluetooth"``, ``"zigbee"``, ``"upnp"``, ``"cast"`` or any
+            provider-defined string.
+        :param value: The address; empty values are silently ignored.
+        """
+        if not value:
+            return
+        if connection_type in {"mac", "bluetooth"}:
+            cleaned = value.replace(":", "").replace("-", "").lower()
+            if len(cleaned) == 12 and all(ch in "0123456789abcdef" for ch in cleaned):
+                value = ":".join(cleaned[i : i + 2] for i in range(0, 12, 2))
+        self.connections.add((connection_type, value))
 
 
 @dataclass(kw_only=True)

--- a/tests/test_player_device_info.py
+++ b/tests/test_player_device_info.py
@@ -1,0 +1,92 @@
+"""Tests for ``DeviceInfo.connections`` and ``add_connection`` helper."""
+
+from music_assistant_models.player import DeviceInfo
+
+
+def test_device_info_connections_default_empty() -> None:
+    """A fresh ``DeviceInfo`` has an empty connections set, not None."""
+    info = DeviceInfo()
+    assert info.connections == set()
+
+
+def test_add_connection_normalizes_mac_with_colons() -> None:
+    """Colon-separated MAC is lowercased verbatim."""
+    info = DeviceInfo()
+    info.add_connection("mac", "AA:BB:CC:DD:EE:FF")
+    assert info.connections == {("mac", "aa:bb:cc:dd:ee:ff")}
+
+
+def test_add_connection_normalizes_bluetooth_mac_with_dashes() -> None:
+    """Dash-separated MAC under the ``bluetooth`` type is normalized."""
+    info = DeviceInfo()
+    info.add_connection("bluetooth", "AA-BB-CC-DD-EE-FF")
+    assert info.connections == {("bluetooth", "aa:bb:cc:dd:ee:ff")}
+
+
+def test_add_connection_normalizes_mac_without_separator() -> None:
+    """No-separator MAC gets canonicalized with colons inserted."""
+    info = DeviceInfo()
+    info.add_connection("mac", "AABBCCDDEEFF")
+    assert info.connections == {("mac", "aa:bb:cc:dd:ee:ff")}
+
+
+def test_add_connection_already_canonical_mac_unchanged() -> None:
+    """Already-canonical MAC round-trips through normalization."""
+    info = DeviceInfo()
+    info.add_connection("bluetooth", "aa:bb:cc:dd:ee:ff")
+    assert info.connections == {("bluetooth", "aa:bb:cc:dd:ee:ff")}
+
+
+def test_add_connection_unknown_type_stored_verbatim() -> None:
+    """Provider-defined connection types pass through without filtering."""
+    info = DeviceInfo()
+    info.add_connection("zigbee", "00:0d:6f:00:00:00:11:22")
+    info.add_connection("matter", "vendor-1234/product-5678")
+    info.add_connection("custom_proto", "any-string")
+    assert ("zigbee", "00:0d:6f:00:00:00:11:22") in info.connections
+    assert ("matter", "vendor-1234/product-5678") in info.connections
+    assert ("custom_proto", "any-string") in info.connections
+
+
+def test_add_connection_non_mac_value_under_mac_type_passes_through() -> None:
+    """A ``mac``-typed value that isn't 12-hex stays unchanged so we don't
+    silently mangle vendor-specific identifiers."""
+    info = DeviceInfo()
+    info.add_connection("mac", "not-actually-a-mac")
+    assert info.connections == {("mac", "not-actually-a-mac")}
+
+
+def test_add_connection_empty_value_ignored() -> None:
+    """Empty / None-equivalent values don't pollute the set."""
+    info = DeviceInfo()
+    info.add_connection("mac", "")
+    assert info.connections == set()
+
+
+def test_add_connection_dedupes() -> None:
+    """Set semantics: same tuple added twice stays as one entry."""
+    info = DeviceInfo()
+    info.add_connection("mac", "AA:BB:CC:DD:EE:FF")
+    info.add_connection("mac", "aa:bb:cc:dd:ee:ff")
+    info.add_connection("mac", "aabbccddeeff")
+    assert info.connections == {("mac", "aa:bb:cc:dd:ee:ff")}
+
+
+def test_device_info_round_trip_through_dict() -> None:
+    """``to_dict`` / ``from_dict`` preserves the connections set across the wire."""
+    info = DeviceInfo(model="Speaker", manufacturer="Acme")
+    info.add_connection("bluetooth", "AA:BB:CC:DD:EE:FF")
+    info.add_connection("zigbee", "00:0d:6f:00:00:00:11:22")
+    payload = info.to_dict()
+    restored = DeviceInfo.from_dict(payload)
+    assert restored.connections == info.connections
+    assert restored.model == "Speaker"
+    assert restored.manufacturer == "Acme"
+
+
+def test_device_info_connections_independent_from_identifiers() -> None:
+    """Connections set and identifiers dict are separate fields — no leakage."""
+    info = DeviceInfo()
+    info.add_connection("bluetooth", "AA:BB:CC:DD:EE:FF")
+    assert info.identifiers == {}
+    assert info.connections == {("bluetooth", "aa:bb:cc:dd:ee:ff")}


### PR DESCRIPTION
# `DeviceInfo`: add open-ended `connections` set for cross-integration HA device-card merge

## Summary

Adds a new optional `connections: set[tuple[str, str]]` field to
`music_assistant_models.player.DeviceInfo`, mirroring Home Assistant's
`homeassistant.helpers.device_registry.DeviceInfo.connections` shape, plus
a small `add_connection()` helper that normalizes MAC-shaped values to
HA's canonical lowercase-with-colons form.

This is the data-model side of a coordinated change across four repos
(see Coordination below). The downstream `music-assistant/server` PR
populates the field from `aiosendspin` `client_hello.device_info.connections`,
and the `home-assistant/core` PR forwards the set verbatim into HA's
`DeviceInfo.connections` so HA's device-registry can dedupe device cards
across integrations that know the same hardware.

## Motivation

Today every player provider that knows hardware identity (WiiM,
hass_players, AirPlay-via-Sendspin, BT-via-Sendspin, future
Zigbee/Thread/Matter bridges) sets `IdentifierType.MAC_ADDRESS` /
`IdentifierType.IP_ADDRESS` on its player's `DeviceInfo.identifiers` —
but **none of that propagates into HA's `device_info.connections`**.
The MA HA integration constructs `DeviceInfo` with only `identifiers`,
`manufacturer`, `model`, `name`, `configuration_url` (see
`homeassistant/components/music_assistant/entity.py`).

Result: every MA `media_player.<name>` lands in HA's device-registry
with `connections=[]`. When another HA integration (e.g. the official
`bluetooth` integration, or a vendor-specific custom_component) creates
its own card for the **same physical device**, HA can't merge them
because there's no common connection tuple. Operators see two device
cards per speaker.

This is **not** Sendspin-specific — it affects every MA player provider
that has hardware identity but no path to surface it to HA. Fixing the
data model (this PR) + MA HA integration (separate PR) unblocks
identity-passthrough for the whole org.

## Design

`identifiers: dict[IdentifierType, str]` — the **existing** field — keeps
serving MA-internal cross-protocol matching (universal_player ranks
`MAC_ADDRESS` > `UUID` > fallback). Closed enum is intentional there —
the matcher reasons about each type's reliability ranking.

`connections: set[tuple[str, str]]` — the **new** field — is open-ended
on purpose. HA's device_registry accepts any string as
`connection_type`; standard values are `"mac"`, `"bluetooth"`,
`"zigbee"`, `"upnp"` but new transports (Matter device-id, Thread MLE,
custom protocols) should work without taxonomy changes here.

The two fields have different lifecycles and different audiences (MA
internals vs. HA forwarding) so they live side by side rather than
overloading one.

## API

```python
@dataclass
class DeviceInfo(DataClassDictMixin):
    # existing fields …
    connections: set[tuple[str, str]] = field(default_factory=set)

    def add_connection(self, connection_type: str, value: str) -> None:
        """Add a hardware connection tuple, normalizing MAC-shaped values."""
        # MAC values: any of "AA:BB:CC:DD:EE:FF" / "aa-bb-cc-dd-ee-ff" /
        # "AABBCCDDEEFF" → "aa:bb:cc:dd:ee:ff" (HA's canonical form).
        # All other connection types stored verbatim.
```

## Tests

`tests/test_player_device_info.py` covers:

- empty default,
- MAC normalization for all 4 input forms (colons / dashes / no
  separator / already-canonical) under both `mac` and `bluetooth` types,
- pass-through for unknown connection types (`zigbee`, `matter`, custom),
- non-MAC value under `mac` type stored verbatim (no false coercion),
- empty value silently ignored,
- set semantics (dedupes cross-format duplicates),
- `to_dict` / `from_dict` round-trip preserves the set,
- independence from `identifiers` (no leakage between fields).

11 new tests, 100% pass. Coverage of `player.py` improved
(see `.local-ci-output.txt`).

## Backwards compatibility

- New field with `default_factory=set` — existing
  `DeviceInfo()` constructions work unchanged.
- `to_dict` / `from_dict` round-trip preserves the set; old serialized
  payloads without `connections` deserialize to `set()` (default).
- No change to `identifiers`, `add_identifier`, `mac_address`, or any
  existing API surface.
- No new dependency on Home Assistant — the connection-type strings are
  conventionally HA-aligned but the model itself stays HA-agnostic.

## Coordination

This PR is one of four in a coordinated change. Land order:

1. **THIS PR** — data model (`music-assistant/models`).
2. PR-C — [`Sendspin/aiosendspin#226`](https://github.com/Sendspin/aiosendspin/pull/226)
   — protocol-level `DeviceInfo.connections` field.
3. PR-D — [`music-assistant/server#3813`](https://github.com/music-assistant/server/pull/3813)
   — Sendspin provider passthrough + opportunistic
   `IdentifierType.MAC_ADDRESS` mirror for `mac`/`bluetooth` tuples.
4. PR-A — [`home-assistant/core#169541`](https://github.com/home-assistant/core/pull/169541)
   — MA integration forwards `player.device_info.connections` into HA
   `DeviceInfo.connections`.

**Umbrella discussion** with full design context, status, and cross-links:
https://github.com/orgs/music-assistant/discussions/5415

PR-D and PR-A both depend on this PR landing & a `music_assistant_models`
release.

## Test plan locally

```sh
python -m venv .venv
source .venv/bin/activate
pip install ".[test]"
pre-commit install
pre-commit run --all-files
pytest --durations 10 tests/
```

Output captured in `.local-ci-output.txt` next to this description.
