### PR TITLE
Add playerid to PlaybackProgressReport

### DIFF
--- a/music_assistant_models/playback_progress_report.py
+++ b/music_assistant_models/playback_progress_report.py
@@ -38,4 +38,4 @@ class MediaItemPlaybackProgressReport(DataClassDictMixin):
     image_url: str | None = None
     version: str | None = None
     userid: str | None = None  # the user(id) that initiated the playback
-    playerid: str | None = None  # the playerid that is playing the media
+    player_id: str | None = None  # the player_id that is playing the media

--- a/music_assistant_models/playback_progress_report.py
+++ b/music_assistant_models/playback_progress_report.py
@@ -38,3 +38,4 @@ class MediaItemPlaybackProgressReport(DataClassDictMixin):
     image_url: str | None = None
     version: str | None = None
     userid: str | None = None  # the user(id) that initiated the playback
+    playerid: str | None = None  # the playerid that is playing the media


### PR DESCRIPTION
To enable player filtering on scrobble providers, we need to know what player the report is coming from.
See PR: https://github.com/music-assistant/server/pull/3823