### PR TITLE
Add AUDIO_OVERLAY to ProviderFeature enum

### DIFF
--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -620,6 +620,7 @@ class ProviderFeature(StrEnum):
     # PLUGIN FEATURES
     #
     AUDIO_SOURCE = "audio_source"
+    AUDIO_OVERLAY = "audio_overlay"  # plugin can mix an audio overlay into queue playback
 
     #
     # OTHER FEATURES (plugin-only)


### PR DESCRIPTION
## Summary

- Adds `AUDIO_OVERLAY = "audio_overlay"` to the `ProviderFeature` enum
- Allows plugin providers to declare overlay capability so the streams controller can discover them by feature flag 
- Required by [music-assistant/server#3844](https://github.com/music-assistant/server/pull/3844) to address review feedback on the generic overlay architecture

## Test plan

- [ ] Server PR #3844 (updated) uses this feature flag to look up active overlay providers
- [ ] Rainy Mood plugin declares `ProviderFeature.AUDIO_OVERLAY` in its `SUPPORTED_FEATURES`

🤖 Generated with [Claude Code](https://claude.com/claude-code)