### PR TITLE
Add is_dynamic field to PlayerQueue

### DIFF
--- a/music_assistant_models/player_queue.py
+++ b/music_assistant_models/player_queue.py
@@ -50,8 +50,7 @@ class PlayerQueue(DataClassDictMixin):
 
     flow_mode: bool = False
     resume_pos: int = 0
-    # True when a single dynamic playlist (Playlist.is_dynamic) is the active radio source.
-    # Set by the server on every radio_source update so clients can read this directly.
+    # True if exactly one playlist in the queue is dynamic; set by the server.
     is_dynamic: bool = False
 
     # extra_attributes: additional attributes for this player_queue to store/forward

--- a/music_assistant_models/player_queue.py
+++ b/music_assistant_models/player_queue.py
@@ -50,6 +50,9 @@ class PlayerQueue(DataClassDictMixin):
 
     flow_mode: bool = False
     resume_pos: int = 0
+    # True when a single dynamic playlist (Playlist.is_dynamic) is the active radio source.
+    # Set by the server on every radio_source update so clients can read this directly.
+    is_dynamic: bool = False
 
     # extra_attributes: additional attributes for this player_queue to store/forward
     # additional data that is not part of the standard model


### PR DESCRIPTION
## Summary

Adds an `is_dynamic` field to `PlayerQueue` so all clients can check directly whether a dynamic playlist is the active radio source, without having to inspect `radio_source` manually.

## Background

Previously, clients had to implement the detection logic themselves:

```python
len(queue.radio_source) == 1
and isinstance(queue.radio_source[0], Playlist)
and queue.radio_source[0].is_dynamic
```

This was duplicated in the web frontend and would need to be reimplemented in every client (mobile app, etc.).

## Change

Adds `is_dynamic: bool = False` as a serialized field on `PlayerQueue`. The server sets this field whenever `radio_source` changes.

**Why a stored field instead of `@property`:** `PlayerQueue` uses mashumaro's `DataClassDictMixin`. Its `to_dict()` / `to_cache()` serialization only processes dataclass fields — `@property` accessors are silently skipped and would never reach the wire or the cache, so clients would always see the default value. Verified with a minimal test against the installed mashumaro version.

## Related

- Server PR: music-assistant/server#3886
- Frontend PR: music-assistant/frontend#1773
- Mobile app issue: music-assistant/mobile-app#370