### PR TITLE
Attach the color palette to `PlayerMedia`

### DIFF
--- a/music_assistant_models/media_items/__init__.py
+++ b/music_assistant_models/media_items/__init__.py
@@ -30,7 +30,13 @@ from .media_item import (
     RecommendationFolder,
     Track,
 )
-from .metadata import MediaItemChapter, MediaItemImage, MediaItemLink, MediaItemMetadata
+from .metadata import (
+    MediaItemChapter,
+    MediaItemImage,
+    MediaItemLink,
+    MediaItemMetadata,
+    MediaItemPalette,
+)
 from .provider_mapping import ProviderMapping
 
 __all__ = [
@@ -46,6 +52,7 @@ __all__ = [
     "MediaItemImage",
     "MediaItemLink",
     "MediaItemMetadata",
+    "MediaItemPalette",
     "MediaItemType",
     "Metadata",
     "MetadataProvider",

--- a/music_assistant_models/media_items/metadata.py
+++ b/music_assistant_models/media_items/metadata.py
@@ -51,6 +51,18 @@ class MediaItemImage(DataClassDictMixin):
 
 
 @dataclass(frozen=True, kw_only=True)
+class MediaItemPalette(DataClassDictMixin):
+    """Color palette derived from a MediaItem's artwork. Mirrors the Sendspin color@v1 spec."""
+
+    background_dark: tuple[int, int, int] | None = None
+    background_light: tuple[int, int, int] | None = None
+    primary: tuple[int, int, int] | None = None
+    accent: tuple[int, int, int] | None = None
+    on_dark: tuple[int, int, int] | None = None
+    on_light: tuple[int, int, int] | None = None
+
+
+@dataclass(frozen=True, kw_only=True)
 class MediaItemChapter(DataClassDictMixin):
     """Model for a MediaItem's chapter/bookmark."""
 

--- a/music_assistant_models/player.py
+++ b/music_assistant_models/player.py
@@ -11,7 +11,7 @@ from mashumaro import DataClassDictMixin
 
 from .constants import EXTRA_ATTRIBUTES_TYPES, PLAYER_CONTROL_NONE
 from .enums import IdentifierType, MediaType, PlaybackState, PlayerFeature, PlayerType
-from .media_items.metadata import MediaItemPalette
+from .media_items import MediaItemPalette
 from .unique_list import UniqueList
 
 

--- a/music_assistant_models/player.py
+++ b/music_assistant_models/player.py
@@ -11,6 +11,7 @@ from mashumaro import DataClassDictMixin
 
 from .constants import EXTRA_ATTRIBUTES_TYPES, PLAYER_CONTROL_NONE
 from .enums import IdentifierType, MediaType, PlaybackState, PlayerFeature, PlayerType
+from .media_items.metadata import MediaItemPalette
 from .unique_list import UniqueList
 
 
@@ -108,6 +109,7 @@ class PlayerMedia(DataClassDictMixin):
     artist: str | None = None  # optional
     album: str | None = None  # optional
     image_url: str | None = None  # optional
+    palette: MediaItemPalette | None = None  # optional
     duration: int | None = None  # optional
     source_id: str | None = None  # optional (ID of the source, may be a queue id)
     queue_item_id: str | None = None  # only present for requests from queue controller


### PR DESCRIPTION
Required for moving the color extraction from the frontend to the backend.
Attached to `PlayerMedia` so the server can ship an artwork-derived palette to the frontend alongside the current media.
Mirrors the `color@v1` spec from the Sendspin Specification.