### PR TITLE
Add `AudioSource` MediaItem and related types

### DIFF
--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -38,13 +38,39 @@ class MediaType(StrEnum, metaclass=MediaTypeMeta):
     FOLDER = "folder"
     ANNOUNCEMENT = "announcement"
     FLOW_STREAM = "flow_stream"
+    # deprecated: replaced by AUDIO_SOURCE, kept for one release for backwards compatibility
     PLUGIN_SOURCE = "plugin_source"
+    AUDIO_SOURCE = "audio_source"
     SOUND_EFFECT = "sound_effect"
     GENRE = "genre"
     UNKNOWN = "unknown"
 
     @classmethod
     def _missing_(cls, value: object) -> MediaType:  # noqa: ARG003
+        """Set default enum member if an unknown value is provided."""
+        return cls.UNKNOWN
+
+
+class SourceControl(StrEnum):
+    """
+    Control actions that can be issued to a live AudioSource.
+
+    Used by the player controller when proxying playback control
+    commands to the plugin that owns the active AudioSource.
+    """
+
+    PLAY = "play"
+    PAUSE = "pause"
+    STOP = "stop"
+    NEXT = "next"
+    PREVIOUS = "previous"
+    SEEK = "seek"
+    VOLUME = "volume"
+    SELECT = "select"
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def _missing_(cls, value: object) -> SourceControl:  # noqa: ARG003
         """Set default enum member if an unknown value is provided."""
         return cls.UNKNOWN
 

--- a/music_assistant_models/errors.py
+++ b/music_assistant_models/errors.py
@@ -123,19 +123,6 @@ class ResourceTemporarilyUnavailable(MusicAssistantError):
     error_code = 17
 
 
-class ResourceBusyError(MusicAssistantError):
-    """
-    Raised when an exclusive resource is already in use.
-
-    Used by providers when a resource that only allows a single
-    concurrent consumer (e.g. an exclusive AudioSource, a hardware
-    bridge, or any other single-stream media item) is requested
-    while it is already in use elsewhere.
-    """
-
-    error_code = 24
-
-
 class ProviderPermissionDenied(MusicAssistantError):
     """Error thrown when a provider action is denied because of permissions."""
 
@@ -170,3 +157,16 @@ class InvalidToken(MusicAssistantError):
     """Error raised when an access token is invalid or expired."""
 
     error_code = 23
+
+
+class ResourceBusyError(MusicAssistantError):
+    """
+    Raised when an exclusive resource is already in use.
+
+    Used by providers when a resource that only allows a single
+    concurrent consumer (e.g. an exclusive AudioSource, a hardware
+    bridge, or any other single-stream media item) is requested
+    while it is already in use elsewhere.
+    """
+
+    error_code = 24

--- a/music_assistant_models/errors.py
+++ b/music_assistant_models/errors.py
@@ -123,6 +123,17 @@ class ResourceTemporarilyUnavailable(MusicAssistantError):
     error_code = 17
 
 
+class ResourceBusyError(MusicAssistantError):
+    """
+    Raised when an exclusive resource is already in use.
+
+    Used by plugin providers when an exclusive AudioSource is requested
+    while it is already streaming to another player/queue.
+    """
+
+    error_code = 24
+
+
 class ProviderPermissionDenied(MusicAssistantError):
     """Error thrown when a provider action is denied because of permissions."""
 

--- a/music_assistant_models/errors.py
+++ b/music_assistant_models/errors.py
@@ -127,8 +127,10 @@ class ResourceBusyError(MusicAssistantError):
     """
     Raised when an exclusive resource is already in use.
 
-    Used by plugin providers when an exclusive AudioSource is requested
-    while it is already streaming to another player/queue.
+    Used by providers when a resource that only allows a single
+    concurrent consumer (e.g. an exclusive AudioSource, a hardware
+    bridge, or any other single-stream media item) is requested
+    while it is already in use elsewhere.
     """
 
     error_code = 24

--- a/music_assistant_models/media_items/__init__.py
+++ b/music_assistant_models/media_items/__init__.py
@@ -17,6 +17,7 @@ from .media_item import (
     Album,
     Artist,
     Audiobook,
+    AudioSource,
     BrowseFolder,
     Genre,
     ItemMapping,
@@ -43,6 +44,7 @@ __all__ = [
     "Album",
     "Artist",
     "AudioFormat",
+    "AudioSource",
     "Audiobook",
     "BrowseFolder",
     "Genre",
@@ -107,9 +109,16 @@ def media_from_dict(media_item: dict[str, Any]) -> MediaItemType | ItemMapping:
         return Podcast.from_dict(media_item)
     if media_item["media_type"] == "podcast_episode":
         return PodcastEpisode.from_dict(media_item)
+    if media_item["media_type"] == "audio_source":
+        return AudioSource.from_dict(media_item)
     raise InvalidDataError("Unknown media type")
 
 
 def is_track(val: MediaItem) -> TypeGuard[Track]:
     """Return true if this MediaItem is a track."""
     return val.media_type == MediaType.TRACK
+
+
+def is_audio_source(val: MediaItem) -> TypeGuard[AudioSource]:
+    """Return true if this MediaItem is an AudioSource."""
+    return val.media_type == MediaType.AUDIO_SOURCE

--- a/music_assistant_models/media_items/media_item.py
+++ b/music_assistant_models/media_items/media_item.py
@@ -364,6 +364,43 @@ class SoundEffect(MediaItem):
 
 
 @dataclass(kw_only=True)
+class AudioSource(MediaItem):
+    """
+    Model for a live audio source provided by a plugin.
+
+    Examples include an AirPlay receiver, Spotify Connect device,
+    DLNA renderer, VBAN receiver, or a hardware bridge favorite.
+
+    Conceptually behaves like a live media item (similar to Radio):
+    enqueued as a single queue item, streamed continuously, with
+    optional metadata updates pushed by the owning plugin.
+    """
+
+    __hash__ = _MediaItemBase.__hash__
+    __eq__ = _MediaItemBase.__eq__
+
+    media_type: MediaType = MediaType.AUDIO_SOURCE
+
+    # a live source has no fixed duration; kept for QueueItem compatibility
+    duration: int | None = None
+
+    # capability flags drive which control buttons the UI shows
+    # and which commands the player controller proxies to the plugin
+    can_play_pause: bool = False
+    can_seek: bool = False
+    can_next_previous: bool = False
+
+    # whether the same source can stream to >1 player concurrently
+    # False = MA fans the single stream out via sync-group machinery (default)
+    # True = plugin is responsible for serving independent streams per consumer
+    exclusive: bool = True
+
+    # whether the plugin can initiate playback itself
+    # (e.g. the Spotify app picking MA as a device)
+    allow_external_trigger: bool = False
+
+
+@dataclass(kw_only=True)
 class BrowseFolder(_MediaItemBase):
     """Representation of a Folder used in Browse (which contains media items)."""
 
@@ -409,6 +446,15 @@ class RecommendationFolder(BrowseFolder):
 # NOTE: BrowseFolder is not part of the MediaItemType alias, as it lacks
 # provider mappings, i.e. we do not map a provider item to a BrowseFolder.
 MediaItemType = (
-    Artist | Album | Track | Radio | Playlist | Audiobook | Podcast | PodcastEpisode | Genre
+    Artist
+    | Album
+    | Track
+    | Radio
+    | Playlist
+    | Audiobook
+    | Podcast
+    | PodcastEpisode
+    | Genre
+    | AudioSource
 )
-PlayableMediaItemType = Track | Radio | Audiobook | PodcastEpisode
+PlayableMediaItemType = Track | Radio | Audiobook | PodcastEpisode | AudioSource

--- a/music_assistant_models/media_items/media_item.py
+++ b/music_assistant_models/media_items/media_item.py
@@ -390,9 +390,10 @@ class AudioSource(MediaItem):
     can_seek: bool = False
     can_next_previous: bool = False
 
-    # whether the same source can stream to >1 player concurrently
-    # False = MA fans the single stream out via sync-group machinery (default)
-    # True = plugin is responsible for serving independent streams per consumer
+    # whether this source allows only a single concurrent consumer
+    # True (default) = MA fans the single stream out via sync-group machinery
+    # when multiple players target the same source
+    # False = plugin is responsible for serving independent streams per consumer
     exclusive: bool = True
 
     # whether the plugin can initiate playback itself

--- a/tests/test_audio_source.py
+++ b/tests/test_audio_source.py
@@ -62,11 +62,11 @@ def test_audio_source_defaults() -> None:
 def test_audio_source_serialize_roundtrip() -> None:
     """AudioSource survives a to_dict -> from_dict round-trip."""
     original = _make_audio_source()
-    restored = AudioSource.from_dict(original.to_dict())
-    assert restored == original
-    assert restored.can_play_pause is True
-    assert restored.exclusive is False
-    assert restored.allow_external_trigger is True
+    data = original.to_dict()
+    restored = AudioSource.from_dict(data)
+    # MediaItem.__eq__ only checks the URI, so compare the serialized form to
+    # verify the full payload (capability flags, exclusivity, provider mappings, ...)
+    assert restored.to_dict() == data
 
 
 def test_media_from_dict_returns_audio_source() -> None:

--- a/tests/test_audio_source.py
+++ b/tests/test_audio_source.py
@@ -1,0 +1,83 @@
+"""Tests for the AudioSource MediaItem and related types."""
+
+from music_assistant_models.enums import MediaType, SourceControl
+from music_assistant_models.media_items import (
+    AudioSource,
+    ItemMapping,
+    media_from_dict,
+)
+from music_assistant_models.media_items.provider_mapping import ProviderMapping
+
+
+def _make_audio_source() -> AudioSource:
+    return AudioSource(
+        item_id="airplay-living-room",
+        provider="airplay",
+        name="Living Room",
+        provider_mappings={
+            ProviderMapping(
+                item_id="airplay-living-room",
+                provider_domain="airplay",
+                provider_instance="airplay",
+            )
+        },
+        can_play_pause=True,
+        can_seek=False,
+        can_next_previous=True,
+        exclusive=False,
+        allow_external_trigger=True,
+    )
+
+
+def test_media_type_audio_source_roundtrips() -> None:
+    """MediaType.AUDIO_SOURCE is reachable and round-trips through StrEnum."""
+    assert MediaType("audio_source") is MediaType.AUDIO_SOURCE
+    assert MediaType.AUDIO_SOURCE.value == "audio_source"
+
+
+def test_source_control_missing_returns_unknown() -> None:
+    """Unknown SourceControl values fall back to UNKNOWN."""
+    assert SourceControl("not-a-real-control") is SourceControl.UNKNOWN
+    assert SourceControl.PLAY.value == "play"
+
+
+def test_audio_source_defaults() -> None:
+    """AudioSource has sane defaults aligned with the model contract."""
+    item = AudioSource(
+        item_id="x",
+        provider="y",
+        name="z",
+        provider_mappings=set(),
+    )
+    assert item.media_type == MediaType.AUDIO_SOURCE
+    assert item.can_play_pause is False
+    assert item.can_seek is False
+    assert item.can_next_previous is False
+    # exclusive defaults to True so plugins opt into multi-consumer support explicitly
+    assert item.exclusive is True
+    assert item.allow_external_trigger is False
+    assert item.uri == "y://audio_source/x"
+
+
+def test_audio_source_serialize_roundtrip() -> None:
+    """AudioSource survives a to_dict -> from_dict round-trip."""
+    original = _make_audio_source()
+    restored = AudioSource.from_dict(original.to_dict())
+    assert restored == original
+    assert restored.can_play_pause is True
+    assert restored.exclusive is False
+    assert restored.allow_external_trigger is True
+
+
+def test_media_from_dict_returns_audio_source() -> None:
+    """media_from_dict deserializes audio_source payloads to AudioSource."""
+    result = media_from_dict(_make_audio_source().to_dict())
+    assert isinstance(result, AudioSource)
+    assert result.media_type == MediaType.AUDIO_SOURCE
+
+
+def test_item_mapping_for_audio_source() -> None:
+    """An AudioSource can be reduced to an ItemMapping like other media items."""
+    mapping = ItemMapping.from_item(_make_audio_source())
+    assert mapping.media_type == MediaType.AUDIO_SOURCE
+    assert mapping.item_id == "airplay-living-room"


### PR DESCRIPTION
First of three coordinated PRs that refactor Music Assistant's "Plugin Sources" (AirPlay receiver, Spotify Connect, Snapcast, VBAN, etc.) from runtime-mutable `PluginSource` dataclasses into first-class `AudioSource` MediaItems — browseable, favoritable, and played through the standard `play_media` / streamdetails pipeline instead of one-off "fake queue" hacks.

This PR only adds the data types; the server-repo PR pins the resulting release and wires them up.

## Changes
- Add `MediaType.AUDIO_SOURCE` and mark `MediaType.PLUGIN_SOURCE` as deprecated (kept one release for back-compat).
- Add `SourceControl` enum for the control actions a plugin can be asked to perform on a live source.
- Add `AudioSource` MediaItem dataclass with capability flags (`can_play_pause`, `can_seek`, `can_next_previous`), `exclusive`, and `allow_external_trigger`.
- Add `ResourceBusyError` for exclusive-resource conflicts.
- Extend `MediaItemType` and `PlayableMediaItemType` unions and `media_from_dict()` to handle `AudioSource`.
- Add `is_audio_source` type guard.