### PR TITLE
Trim SourceControl enum to playback commands only

### DIFF
--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -52,26 +52,18 @@ class MediaType(StrEnum, metaclass=MediaTypeMeta):
 
 
 class SourceControl(StrEnum):
-    """
-    Control actions that can be issued to a live AudioSource.
-
-    Used by the player controller when proxying playback control
-    commands to the plugin that owns the active AudioSource.
-    """
+    """Control actions issued to a live AudioSource by the player controller."""
 
     PLAY = "play"
     PAUSE = "pause"
-    STOP = "stop"
     NEXT = "next"
     PREVIOUS = "previous"
     SEEK = "seek"
-    VOLUME = "volume"
-    SELECT = "select"
     UNKNOWN = "unknown"
 
     @classmethod
     def _missing_(cls, value: object) -> SourceControl:  # noqa: ARG003
-        """Set default enum member if an unknown value is provided."""
+        """Return UNKNOWN if an unknown value is provided."""
         return cls.UNKNOWN
 
 


### PR DESCRIPTION
The `SourceControl` enum was added in #229 with eight entries that 1:1 mirrored the old `PluginSource` callback fields. Three of them don't fit the new `on_source_control(source_id, action, value)` contract and aren't fired anywhere:

- `SELECT` — superseded by the dedicated `on_source_selected(source_id, player_id, queue_id)` hook, which gives plugins the player + queue context they actually need.
- `VOLUME` — volume is a player-state notification, not a user-initiated source command. The server moves volume sync onto a dedicated `on_volume_change(source_id, volume)` hook on `PluginProvider`.
- `STOP` — no cross-plugin meaning (Spotify has no stop, AirPlay can't tell the client to stop, …). The player-level `cmd_stop` already closes the stream via the generator's `finally`; per-plugin cleanup belongs in `get_audio_stream`'s `finally` block.

### Changes
- Remove `STOP`, `VOLUME`, `SELECT` from `SourceControl` in `music_assistant_models/enums.py`.
- Tighten the enum and `_missing_` docstrings.

Coordinated with the matching server PR (music-assistant/server#3938) and the frontend mirror enum trim. Purely subtractive — no replacement enum value needed.