### PR TITLE
Add AudioAnalysisCoverage model for audio_analysis/coverage API response

### DIFF
--- a/music_assistant_models/audio_analysis.py
+++ b/music_assistant_models/audio_analysis.py
@@ -1,0 +1,25 @@
+"""Models for audio analysis results and coverage reporting."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mashumaro import DataClassDictMixin
+
+
+@dataclass(kw_only=True)
+class AudioAnalysisCoverage(DataClassDictMixin):
+    """Coverage / health counts for an audio analysis provider's analyzed library.
+
+    Returned by the server's ``audio_analysis/coverage`` API command. ``analyzed``
+    is the count of unique tracks the provider has stored analysis data for;
+    ``pending`` is the count of candidate tracks awaiting analysis;
+    ``stale_version`` is the count of stored rows whose ``analysis_version`` is
+    older than the provider's current version; ``analysis_version`` is the
+    provider's current schema version.
+    """
+
+    analyzed: int
+    pending: int
+    stale_version: int
+    analysis_version: int

--- a/music_assistant_models/audio_analysis.py
+++ b/music_assistant_models/audio_analysis.py
@@ -9,14 +9,14 @@ from mashumaro import DataClassDictMixin
 
 @dataclass(kw_only=True)
 class AudioAnalysisCoverage(DataClassDictMixin):
-    """Coverage / health counts for an audio analysis provider's analyzed library.
+    """
+    Coverage / health counts for an audio analysis provider's analyzed library.
 
-    Returned by the server's ``audio_analysis/coverage`` API command. ``analyzed``
-    is the count of unique tracks the provider has stored analysis data for;
-    ``pending`` is the count of candidate tracks awaiting analysis;
-    ``stale_version`` is the count of stored rows whose ``analysis_version`` is
-    older than the provider's current version; ``analysis_version`` is the
-    provider's current schema version.
+    :param analyzed: Count of unique tracks the provider has stored analysis data for.
+    :param pending: Count of candidate tracks awaiting analysis.
+    :param stale_version: Count of stored rows whose analysis_version is older than
+        the provider's current version.
+    :param analysis_version: The provider's current schema version.
     """
 
     analyzed: int


### PR DESCRIPTION
Add a new `music_assistant_models/audio_analysis.py` module containing a single dataclass, `AudioAnalysisCoverage`, with four `int` fields: `analyzed`, `pending`, `stale_version`, `analysis_version`.

This is the typed response shape for the server's `audio_analysis/coverage` API command. Adding it to the upstream models package gives the server (and any future client — e.g. the frontend's audio-analysis coverage panel) a single source of truth for the wire shape.

Music Assistant server PR [music-assistant/server#3851](https://github.com/music-assistant/server/pull/3851) imports `AudioAnalysisCoverage` from this module and returns it from the `audio_analysis/coverage` API command. That server PR will pin `music-assistant-models` to whatever released version ships this change.
