### PR TITLE
Allow description and description_language to overwrite in MediaItemMetadata.update()

### DIFF
--- a/music_assistant_models/media_items/metadata.py
+++ b/music_assistant_models/media_items/metadata.py
@@ -139,6 +139,8 @@ class MediaItemMetadata(DataClassDictMixin):
                 setattr(self, fld.name, new_val)
             elif isinstance(cur_val, set) and isinstance(new_val, set | list | tuple):
                 cur_val.update(new_val)
+            # some fields are always allowed to be overwritten
+            # (such as popularity and last_refresh)
             elif (
                 new_val
                 and fld.name

--- a/music_assistant_models/media_items/metadata.py
+++ b/music_assistant_models/media_items/metadata.py
@@ -113,40 +113,42 @@ class MediaItemMetadata(DataClassDictMixin):
     last_refresh: int | None = None
 
     def update(
-      self,
-      new_values: MediaItemMetadata,
+        self,
+        new_values: MediaItemMetadata,
     ) -> MediaItemMetadata:
-      """Update metadata (in-place) with new values."""
-      if not new_values:
-          return self
-      # description paired with description_language: overwrite on language change,
-      # otherwise fill-the-gap (preserves higher-priority provider's bio)
-      if new_values.description is not None:
-          new_lang = new_values.description_language
-          lang_changed = new_lang is not None and new_lang != self.description_language
-          if lang_changed or self.description is None:
-              self.description = new_values.description
-              self.description_language = new_lang
-      for fld in fields(self):
-          if fld.name in ("description", "description_language"):
-              continue
-          new_val = getattr(new_values, fld.name)
-          if new_val is None:
-              continue
-          cur_val = getattr(self, fld.name)
-          if isinstance(cur_val, list) and isinstance(new_val, list):
-              new_val = UniqueList(merge_lists(cur_val, new_val))
-              setattr(self, fld.name, new_val)
-          elif isinstance(cur_val, set) and isinstance(new_val, set | list | tuple):
-              cur_val.update(new_val)
-          elif new_val and fld.name in (
-              "popularity",
-              "last_refresh",
-          ):
-              setattr(self, fld.name, new_val)
-          elif cur_val is None:
-              setattr(self, fld.name, new_val)
-      return self
+        """Update metadata (in-place) with new values."""
+        if not new_values:
+            return self
+        # description paired with description_language: overwrite on language change,
+        # otherwise fill-the-gap (preserves higher-priority provider's bio)
+        if new_values.description is not None:
+            new_lang = new_values.description_language
+            lang_changed = new_lang is not None and new_lang != self.description_language
+            if lang_changed or self.description is None:
+                self.description = new_values.description
+                self.description_language = new_lang
+        for fld in fields(self):
+            if fld.name in ("description", "description_language"):
+                continue
+            new_val = getattr(new_values, fld.name)
+            if new_val is None:
+                continue
+            cur_val = getattr(self, fld.name)
+            if isinstance(cur_val, list) and isinstance(new_val, list):
+                new_val = UniqueList(merge_lists(cur_val, new_val))
+                setattr(self, fld.name, new_val)
+            elif isinstance(cur_val, set) and isinstance(new_val, set | list | tuple):
+                cur_val.update(new_val)
+            elif (
+                new_val
+                and fld.name
+                in (
+                    "popularity",
+                    "last_refresh",
+                )
+            ) or cur_val is None:
+                setattr(self, fld.name, new_val)
+        return self
 
     def add_image(self, image: MediaItemImage) -> None:
         """Add an image to the list."""

--- a/music_assistant_models/media_items/metadata.py
+++ b/music_assistant_models/media_items/metadata.py
@@ -123,10 +123,8 @@ class MediaItemMetadata(DataClassDictMixin):
       # otherwise fill-the-gap (preserves higher-priority provider's bio)
       if new_values.description is not None:
           new_lang = new_values.description_language
-          if new_lang is not None and new_lang != self.description_language:
-              self.description = new_values.description
-              self.description_language = new_lang
-          elif self.description is None:
+          lang_changed = new_lang is not None and new_lang != self.description_language
+          if lang_changed or self.description is None:
               self.description = new_values.description
               self.description_language = new_lang
       for fld in fields(self):

--- a/music_assistant_models/media_items/metadata.py
+++ b/music_assistant_models/media_items/metadata.py
@@ -113,34 +113,42 @@ class MediaItemMetadata(DataClassDictMixin):
     last_refresh: int | None = None
 
     def update(
-        self,
-        new_values: MediaItemMetadata,
+      self,
+      new_values: MediaItemMetadata,
     ) -> MediaItemMetadata:
-        """Update metadata (in-place) with new values."""
-        if not new_values:
-            return self
-        for fld in fields(self):
-            new_val = getattr(new_values, fld.name)
-            if new_val is None:
-                continue
-            cur_val = getattr(self, fld.name)
-            if isinstance(cur_val, list) and isinstance(new_val, list):
-                new_val = UniqueList(merge_lists(cur_val, new_val))
-                setattr(self, fld.name, new_val)
-            elif isinstance(cur_val, set) and isinstance(new_val, set | list | tuple):
-                cur_val.update(new_val)
-            elif new_val and fld.name in (
-                "popularity",
-                "last_refresh",
-                "description",
-                "description_language",
-            ):
-                # some fields are always allowed to be overwritten
-                # (such as popularity and last_refresh)
-                setattr(self, fld.name, new_val)
-            elif cur_val is None:
-                setattr(self, fld.name, new_val)
-        return self
+      """Update metadata (in-place) with new values."""
+      if not new_values:
+          return self
+      # description paired with description_language: overwrite on language change,
+      # otherwise fill-the-gap (preserves higher-priority provider's bio)
+      if new_values.description is not None:
+          new_lang = new_values.description_language
+          if new_lang is not None and new_lang != self.description_language:
+              self.description = new_values.description
+              self.description_language = new_lang
+          elif self.description is None:
+              self.description = new_values.description
+              self.description_language = new_lang
+      for fld in fields(self):
+          if fld.name in ("description", "description_language"):
+              continue
+          new_val = getattr(new_values, fld.name)
+          if new_val is None:
+              continue
+          cur_val = getattr(self, fld.name)
+          if isinstance(cur_val, list) and isinstance(new_val, list):
+              new_val = UniqueList(merge_lists(cur_val, new_val))
+              setattr(self, fld.name, new_val)
+          elif isinstance(cur_val, set) and isinstance(new_val, set | list | tuple):
+              cur_val.update(new_val)
+          elif new_val and fld.name in (
+              "popularity",
+              "last_refresh",
+          ):
+              setattr(self, fld.name, new_val)
+          elif cur_val is None:
+              setattr(self, fld.name, new_val)
+      return self
 
     def add_image(self, image: MediaItemImage) -> None:
         """Add an image to the list."""

--- a/music_assistant_models/media_items/metadata.py
+++ b/music_assistant_models/media_items/metadata.py
@@ -132,6 +132,8 @@ class MediaItemMetadata(DataClassDictMixin):
             elif new_val and fld.name in (
                 "popularity",
                 "last_refresh",
+                "description",
+                "description_language",
             ):
                 # some fields are always allowed to be overwritten
                 # (such as popularity and last_refresh)


### PR DESCRIPTION
Biographical information can change over time, and the user can change the preferred language for metadata, so description needs to be allowed to refresh but only when the incoming language actually differs from the stored one. Otherwise it follows the same fill-the-gap rule as the other scalar fields, so provider priority is honoured (e.g. a higher-priority provider that ran first keeps its bio if a lower-priority one would have provided the same language).

The language may differ from the stored one because a higher level provider may not have a bio in the users prefered language.