### PR TITLE
Add proxy_id field + IMAGE_PROXY_ID_RESOLVER hook to MediaItemImage

### DIFF
--- a/music_assistant_models/media_items/metadata.py
+++ b/music_assistant_models/media_items/metadata.py
@@ -2,14 +2,27 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from contextvars import ContextVar
 from dataclasses import dataclass, fields
 from datetime import datetime
+from typing import Any
 
 from mashumaro import DataClassDictMixin
 
 from music_assistant_models.enums import ImageType, LinkType
 from music_assistant_models.helpers import merge_lists
 from music_assistant_models.unique_list import UniqueList
+
+# ContextVar set by the Music Assistant server during outbound API serialization.
+# When set, MediaItemImage.__post_serialize__ uses the resolver to fill `proxy_id`
+# on the serialized dict, so clients can build the imageproxy URL by appending
+# the id to their own connection's base URL — no need to construct the long
+# legacy `/imageproxy?provider=…&path=…` form themselves. The resolver receives
+# (provider, path) and returns the opaque image id (a 64-hex sha256 hash).
+IMAGE_PROXY_ID_RESOLVER: ContextVar[Callable[[str, str], str] | None] = ContextVar(
+    "image_proxy_id_resolver", default=None
+)
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -38,6 +51,10 @@ class MediaItemImage(DataClassDictMixin):
     path: str
     provider: str  # provider lookup key (only use instance id for fileproviders)
     remotely_accessible: bool = False  # url that is accessible from anywhere
+    # Opaque server-side imageproxy id. Populated only by the MA server during
+    # outbound API serialization (via __post_serialize__ + IMAGE_PROXY_ID_RESOLVER).
+    # Clients fetch the image at `<api_base>/imageproxy/<proxy_id>?size=...&fmt=...`.
+    proxy_id: str | None = None
 
     def __hash__(self) -> int:
         """Return custom hash."""
@@ -48,6 +65,15 @@ class MediaItemImage(DataClassDictMixin):
         if not isinstance(other, MediaItemImage):
             return False
         return self.__hash__() == other.__hash__()
+
+    def __post_serialize__(self, d: dict[str, Any]) -> dict[str, Any]:
+        """Inject `proxy_id` when a resolver is set on the current context."""
+        if self.remotely_accessible:
+            return d
+        resolver = IMAGE_PROXY_ID_RESOLVER.get()
+        if resolver is not None:
+            d["proxy_id"] = resolver(self.provider, self.path)
+        return d
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/music_assistant_models/media_items/metadata.py
+++ b/music_assistant_models/media_items/metadata.py
@@ -19,7 +19,10 @@ from music_assistant_models.unique_list import UniqueList
 # on the serialized dict, so clients can build the imageproxy URL by appending
 # the id to their own connection's base URL — no need to construct the long
 # legacy `/imageproxy?provider=…&path=…` form themselves. The resolver receives
-# (provider, path) and returns an opaque, server-defined image id.
+# (provider, path) and must return an opaque, server-defined image id that is
+# safe to embed directly as a single URL path segment (URL-safe, no `/`, `?`,
+# `#`, or whitespace), so clients can build `<api_base>/imageproxy/<proxy_id>`
+# without any extra escaping.
 IMAGE_PROXY_ID_RESOLVER: ContextVar[Callable[[str, str], str] | None] = ContextVar(
     "image_proxy_id_resolver", default=None
 )

--- a/music_assistant_models/media_items/metadata.py
+++ b/music_assistant_models/media_items/metadata.py
@@ -19,7 +19,7 @@ from music_assistant_models.unique_list import UniqueList
 # on the serialized dict, so clients can build the imageproxy URL by appending
 # the id to their own connection's base URL — no need to construct the long
 # legacy `/imageproxy?provider=…&path=…` form themselves. The resolver receives
-# (provider, path) and returns the opaque image id (a 64-hex sha256 hash).
+# (provider, path) and returns an opaque, server-defined image id.
 IMAGE_PROXY_ID_RESOLVER: ContextVar[Callable[[str, str], str] | None] = ContextVar(
     "image_proxy_id_resolver", default=None
 )
@@ -69,6 +69,10 @@ class MediaItemImage(DataClassDictMixin):
     def __post_serialize__(self, d: dict[str, Any]) -> dict[str, Any]:
         """Inject `proxy_id` when a resolver is set on the current context."""
         if self.remotely_accessible:
+            return d
+        # only inject when proxy_id was not already provided so that values
+        # round-tripped via from_dict (or set explicitly by the caller) survive
+        if d.get("proxy_id") is not None:
             return d
         resolver = IMAGE_PROXY_ID_RESOLVER.get()
         if resolver is not None:

--- a/tests/test_media_item_image.py
+++ b/tests/test_media_item_image.py
@@ -1,5 +1,7 @@
 """Tests for MediaItemImage serialization and proxy id injection."""
 
+import hashlib
+
 from music_assistant_models.enums import ImageType
 from music_assistant_models.media_items.metadata import (
     IMAGE_PROXY_ID_RESOLVER,
@@ -8,7 +10,9 @@ from music_assistant_models.media_items.metadata import (
 
 
 def _resolver(provider: str, path: str) -> str:
-    return f"id-for-{provider}-{path}"
+    # url-path-segment-safe synthetic id (no '/', '?', '#') — mirrors the
+    # opaque-id contract the server-side resolver is expected to honor
+    return hashlib.sha256(f"{provider}/{path}".encode()).hexdigest()
 
 
 def test_image_without_resolver_leaves_proxy_id_none() -> None:
@@ -25,7 +29,7 @@ def test_image_with_resolver_injects_proxy_id() -> None:
         d = image.to_dict()
     finally:
         IMAGE_PROXY_ID_RESOLVER.reset(token)
-    assert d["proxy_id"] == "id-for-filesystem-/local/cover.jpg"
+    assert d["proxy_id"] == hashlib.sha256(b"filesystem//local/cover.jpg").hexdigest()
 
 
 def test_remotely_accessible_image_skips_injection() -> None:

--- a/tests/test_media_item_image.py
+++ b/tests/test_media_item_image.py
@@ -1,0 +1,57 @@
+"""Tests for MediaItemImage serialization and proxy id injection."""
+
+from music_assistant_models.enums import ImageType
+from music_assistant_models.media_items.metadata import (
+    IMAGE_PROXY_ID_RESOLVER,
+    MediaItemImage,
+)
+
+
+def _resolver(provider: str, path: str) -> str:
+    return f"id-for-{provider}-{path}"
+
+
+def test_image_without_resolver_leaves_proxy_id_none() -> None:
+    """When no resolver is set on the context, proxy_id stays None."""
+    image = MediaItemImage(type=ImageType.THUMB, path="/local/cover.jpg", provider="filesystem")
+    assert image.to_dict()["proxy_id"] is None
+
+
+def test_image_with_resolver_injects_proxy_id() -> None:
+    """When a resolver is set, proxy_id is filled for non-public images."""
+    image = MediaItemImage(type=ImageType.THUMB, path="/local/cover.jpg", provider="filesystem")
+    token = IMAGE_PROXY_ID_RESOLVER.set(_resolver)
+    try:
+        d = image.to_dict()
+    finally:
+        IMAGE_PROXY_ID_RESOLVER.reset(token)
+    assert d["proxy_id"] == "id-for-filesystem-/local/cover.jpg"
+
+
+def test_remotely_accessible_image_skips_injection() -> None:
+    """Public images that clients can fetch directly must not get a proxy_id."""
+    image = MediaItemImage(
+        type=ImageType.THUMB,
+        path="https://cdn.example.com/a.jpg",
+        provider="spotify",
+        remotely_accessible=True,
+    )
+    token = IMAGE_PROXY_ID_RESOLVER.set(_resolver)
+    try:
+        d = image.to_dict()
+    finally:
+        IMAGE_PROXY_ID_RESOLVER.reset(token)
+    assert d["proxy_id"] is None
+
+
+def test_proxy_id_round_trips_through_from_dict() -> None:
+    """Deserializing a dict with a proxy_id preserves it on the instance."""
+    raw = {
+        "type": "thumb",
+        "path": "/local/cover.jpg",
+        "provider": "filesystem",
+        "remotely_accessible": False,
+        "proxy_id": "abc123",
+    }
+    image = MediaItemImage.from_dict(raw)
+    assert image.proxy_id == "abc123"

--- a/tests/test_media_item_image.py
+++ b/tests/test_media_item_image.py
@@ -55,3 +55,19 @@ def test_proxy_id_round_trips_through_from_dict() -> None:
     }
     image = MediaItemImage.from_dict(raw)
     assert image.proxy_id == "abc123"
+
+
+def test_existing_proxy_id_is_not_overwritten_by_resolver() -> None:
+    """A pre-set proxy_id must survive serialization even when a resolver is active."""
+    image = MediaItemImage(
+        type=ImageType.THUMB,
+        path="/local/cover.jpg",
+        provider="filesystem",
+        proxy_id="pre-existing-id",
+    )
+    token = IMAGE_PROXY_ID_RESOLVER.set(_resolver)
+    try:
+        d = image.to_dict()
+    finally:
+        IMAGE_PROXY_ID_RESOLVER.reset(token)
+    assert d["proxy_id"] == "pre-existing-id"


### PR DESCRIPTION
## Problem

Today's clients build the imageproxy URL themselves from `MediaItemImage.path` + `MediaItemImage.provider`, producing very long double-encoded `/imageproxy?provider=…&path=…` URLs. Some players/clients reject them, special characters break them, and the path is effectively client-controlled which makes the server-side endpoint hard to secure.

The server side of the fix (in `music-assistant/server`) needs a hook in the model so it can attach a short opaque image id to each `MediaItemImage` as it goes out over the API. Clients then fetch `…/imageproxy/<id>?size=&fmt=` instead.

## Changes

- Add `proxy_id: str | None = None` field on `MediaItemImage`.
- Add `IMAGE_PROXY_ID_RESOLVER` ContextVar; when set by the server during outbound serialization, `__post_serialize__` fills `proxy_id` for non-public images.
- Public images (`remotely_accessible=True`) still skip injection — clients use the path directly.
- When the resolver isn't set, the field stays `None` so non-server consumers see no behavioural change.
- Tests for both injection paths and dict round-trip.