### PR TITLE
Add artist_str property to Audiobook model

### DIFF
--- a/music_assistant_models/media_items/media_item.py
+++ b/music_assistant_models/media_items/media_item.py
@@ -319,6 +319,11 @@ class Audiobook(MediaItem):
 
     media_type: MediaType = MediaType.AUDIOBOOK
 
+    @property
+    def artist_str(self) -> str:
+        """Return (combined) author string for audiobook."""
+        return "/".join(a.name if isinstance(a, Artist) else a for a in self.authors)
+
 
 @dataclass(kw_only=True)
 class Podcast(MediaItem):


### PR DESCRIPTION
## Problem

The `Audiobook` model has no `artist_str` property, unlike `Album` and `Track`. Multiple places in the server use `getattr(media_item, "artist_str", "")` to display the creator name in now-playing metadata. For audiobooks this always returns an empty string, leaving the artist line blank in the player UI.

## Changes

- Add `artist_str` property to `Audiobook` that joins author names with `/`, matching the existing pattern on `Album` and `Track`.
- Handles both `str` and `Artist` entries in the `authors: UniqueList[str | Artist]` field.
