### PR TITLE
Revert "Allow description and description_language to overwrite in MediaItemMetadata.update()"

### DIFF
--- a/music_assistant_models/media_items/metadata.py
+++ b/music_assistant_models/media_items/metadata.py
@@ -152,17 +152,7 @@ class MediaItemMetadata(DataClassDictMixin):
         """Update metadata (in-place) with new values."""
         if not new_values:
             return self
-        # description paired with description_language: overwrite on language change,
-        # otherwise fill-the-gap (preserves higher-priority provider's bio)
-        if new_values.description is not None:
-            new_lang = new_values.description_language
-            lang_changed = new_lang is not None and new_lang != self.description_language
-            if lang_changed or self.description is None:
-                self.description = new_values.description
-                self.description_language = new_lang
         for fld in fields(self):
-            if fld.name in ("description", "description_language"):
-                continue
             new_val = getattr(new_values, fld.name)
             if new_val is None:
                 continue
@@ -172,16 +162,14 @@ class MediaItemMetadata(DataClassDictMixin):
                 setattr(self, fld.name, new_val)
             elif isinstance(cur_val, set) and isinstance(new_val, set | list | tuple):
                 cur_val.update(new_val)
-            # some fields are always allowed to be overwritten
-            # (such as popularity and last_refresh)
-            elif (
-                new_val
-                and fld.name
-                in (
-                    "popularity",
-                    "last_refresh",
-                )
-            ) or cur_val is None:
+            elif new_val and fld.name in (
+                "popularity",
+                "last_refresh",
+            ):
+                # some fields are always allowed to be overwritten
+                # (such as popularity and last_refresh)
+                setattr(self, fld.name, new_val)
+            elif cur_val is None:
                 setattr(self, fld.name, new_val)
         return self
 


### PR DESCRIPTION
Reverts music-assistant/models#232

Sorry I have now realised an edge case I didnt consider before and the intent of this change needs to go into the controller on the server. 

The overwrite-on-language-change rule turned out to be too broad: because it fires on any language difference, it also overwrites a stored preferred-language bio with a lower-priority provider's fallback which I don't want.

So I will be moving this logic to the metadata controller, which knows the preferred language and can act on that.