### PR TITLE
widen StreamDetails.seek_position from int to float

### DIFF
--- a/music_assistant_models/streamdetails.py
+++ b/music_assistant_models/streamdetails.py
@@ -199,7 +199,7 @@ class StreamDetails(DataClassDictMixin):
         metadata=field_options(serialize="omit", deserialize=pass_through),
         repr=False,
     )
-    seek_position: int = field(
+    seek_position: float = field(
         default=0,
         compare=False,
         metadata=field_options(serialize="omit", deserialize=pass_through),


### PR DESCRIPTION
## Summary

Widen `StreamDetails.seek_position` from `int` to `float` so the server can report sub-second precision for crossfade-induced start positions.

## Why

Companion to [music-assistant/server#3990](https://github.com/music-assistant/server/pull/3990) (smart-crossfade lyrics sync). That PR sets `streamdetails.seek_position = round(TRIM + CF)` at two sites because the field is currently `int`. The rounding discards the fractional second — a `TRIM=0.84, CF=16.63` transition reports `17` instead of `17.47`, leaving lyrics ~0.5s behind audio. Once this lands, the server PR drops the `round()` calls (TODO markers are already in place).

## Audit

Done across server, client, and frontend before this PR:

- All server writers either use int literals/casts or are the two `round()` sites that get unwound.
- Server readers either go through an explicit `int(...)` cast (e.g. `int(seek_position * 1000)` for ffmpeg `-ss`) or feed into float-typed receivers (`queue.elapsed_time`). Three readers that still pass the value into int-typed APIs (`AudioBuffer.is_valid`, `AudioBuffer.get_buffer`, `PlayerMedia.duration` arithmetic) get explicit `int(...)` wraps in the server PR.
- No `isinstance(x, int)` guards anywhere.
- Client's `play_index(seek_position: int = 0)` is the user-requested-seek API param, unrelated to this field.
- Frontend has no references to the field.
- Mashumaro tolerates `int` JSON on a `float` field on deserialize, so cached payloads keep working — no migration needed.

## Test plan

- [x] `pre-commit run --all-files` passes
- [x] `pytest` passes (13/13)
- [ ] Server companion PR validated end-to-end after this releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)