### PR TITLE
Fix Union deserialization for RecommendationFolder.items

### DIFF
--- a/music_assistant_models/media_items/media_item.py
+++ b/music_assistant_models/media_items/media_item.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, cast
 
-from mashumaro import DataClassDictMixin
+from mashumaro import DataClassDictMixin, field_options
 
 from music_assistant_models.enums import AlbumType, ArtistType, ExternalID, ImageType, MediaType
 from music_assistant_models.errors import InvalidDataError
@@ -433,6 +433,36 @@ class BrowseFolder(_MediaItemBase):
             self.path = f"{self.provider}://{self.item_id}"
 
 
+def _deserialize_recommendation_items(
+    raw: list[dict[str, Any]],
+) -> UniqueList[MediaItem | ItemMapping | BrowseFolder]:
+    """Deserialize RecommendationFolder items using media_type discrimination."""
+    media_type_class_map: dict[str, type[MediaItem]] = {
+        MediaType.ARTIST: Artist,
+        MediaType.ALBUM: Album,
+        MediaType.TRACK: Track,
+        MediaType.RADIO: Radio,
+        MediaType.PLAYLIST: Playlist,
+        MediaType.AUDIOBOOK: Audiobook,
+        MediaType.PODCAST: Podcast,
+        MediaType.PODCAST_EPISODE: PodcastEpisode,
+        MediaType.GENRE: Genre,
+        MediaType.AUDIO_SOURCE: AudioSource,
+    }
+    result: list[MediaItem | ItemMapping | BrowseFolder] = []
+    for item in raw:
+        if "provider_mappings" not in item:
+            if item.get("media_type") in (MediaType.FOLDER, "folder"):
+                result.append(BrowseFolder.from_dict(item))
+            else:
+                result.append(ItemMapping.from_dict(item))
+        elif cls := media_type_class_map.get(item.get("media_type", "")):
+            result.append(cls.from_dict(item))
+        else:
+            result.append(ItemMapping.from_dict(item))
+    return UniqueList(result)
+
+
 @dataclass(kw_only=True)
 class RecommendationFolder(BrowseFolder):
     """Representation of a Recommendation folder."""
@@ -447,7 +477,8 @@ class RecommendationFolder(BrowseFolder):
     is_playable: bool = False
     icon: str | None = None  # optional material design icon name
     items: UniqueList[MediaItemType | ItemMapping | BrowseFolder] = field(
-        default_factory=UniqueList
+        default_factory=UniqueList,
+        metadata=field_options(deserialize=_deserialize_recommendation_items),
     )
     subtitle: str | None = None  # optional subtitle for the recommendation
 

--- a/tests/test_recommendation_folder_roundtrip.py
+++ b/tests/test_recommendation_folder_roundtrip.py
@@ -1,0 +1,72 @@
+"""Tests for RecommendationFolder Union deserialization."""
+
+from music_assistant_models.enums import MediaType
+from music_assistant_models.media_items import (
+    Album,
+    Artist,
+    ItemMapping,
+    Playlist,
+    ProviderMapping,
+    RecommendationFolder,
+    Track,
+)
+from music_assistant_models.unique_list import UniqueList
+
+
+def _make_provider_mapping(provider: str = "test", item_id: str = "1") -> set[ProviderMapping]:
+    return {ProviderMapping(item_id=item_id, provider_domain="test", provider_instance=provider)}
+
+
+def test_mixed_items_roundtrip_preserves_all_types() -> None:
+    """Multiple different media types in items all survive roundtrip."""
+    folder = RecommendationFolder(
+        item_id="rec_mixed",
+        provider="deezer",
+        name="Mixed Recommendations",
+        items=UniqueList([
+            Artist(
+                item_id="ar_1",
+                provider="deezer",
+                name="Test Artist",
+                provider_mappings=_make_provider_mapping("deezer", "ar_1"),
+            ),
+            Album(
+                item_id="al_1",
+                provider="deezer",
+                name="Test Album",
+                provider_mappings=_make_provider_mapping("deezer", "al_1"),
+                year=2024,
+            ),
+            Track(
+                item_id="tr_1",
+                provider="deezer",
+                name="Test Track",
+                provider_mappings=_make_provider_mapping("deezer", "tr_1"),
+                duration=240,
+            ),
+            Playlist(
+                item_id="pl_1",
+                provider="deezer",
+                name="Test Playlist",
+                provider_mappings=_make_provider_mapping("deezer", "pl_1"),
+                is_dynamic=True,
+            ),
+            ItemMapping(
+                item_id="im_1",
+                provider="deezer",
+                name="Mapped Item",
+                media_type=MediaType.TRACK,
+            ),
+        ]),
+    )
+
+    deserialized = RecommendationFolder.from_dict(folder.to_dict())
+
+    assert len(deserialized.items) == 5
+    assert [(type(i).__name__, i.media_type) for i in deserialized.items] == [
+        ("Artist", MediaType.ARTIST),
+        ("Album", MediaType.ALBUM),
+        ("Track", MediaType.TRACK),
+        ("Playlist", MediaType.PLAYLIST),
+        ("ItemMapping", MediaType.TRACK),
+    ]

--- a/tests/test_recommendation_folder_roundtrip.py
+++ b/tests/test_recommendation_folder_roundtrip.py
@@ -23,41 +23,43 @@ def test_mixed_items_roundtrip_preserves_all_types() -> None:
         item_id="rec_mixed",
         provider="deezer",
         name="Mixed Recommendations",
-        items=UniqueList([
-            Artist(
-                item_id="ar_1",
-                provider="deezer",
-                name="Test Artist",
-                provider_mappings=_make_provider_mapping("deezer", "ar_1"),
-            ),
-            Album(
-                item_id="al_1",
-                provider="deezer",
-                name="Test Album",
-                provider_mappings=_make_provider_mapping("deezer", "al_1"),
-                year=2024,
-            ),
-            Track(
-                item_id="tr_1",
-                provider="deezer",
-                name="Test Track",
-                provider_mappings=_make_provider_mapping("deezer", "tr_1"),
-                duration=240,
-            ),
-            Playlist(
-                item_id="pl_1",
-                provider="deezer",
-                name="Test Playlist",
-                provider_mappings=_make_provider_mapping("deezer", "pl_1"),
-                is_dynamic=True,
-            ),
-            ItemMapping(
-                item_id="im_1",
-                provider="deezer",
-                name="Mapped Item",
-                media_type=MediaType.TRACK,
-            ),
-        ]),
+        items=UniqueList(
+            [
+                Artist(
+                    item_id="ar_1",
+                    provider="deezer",
+                    name="Test Artist",
+                    provider_mappings=_make_provider_mapping("deezer", "ar_1"),
+                ),
+                Album(
+                    item_id="al_1",
+                    provider="deezer",
+                    name="Test Album",
+                    provider_mappings=_make_provider_mapping("deezer", "al_1"),
+                    year=2024,
+                ),
+                Track(
+                    item_id="tr_1",
+                    provider="deezer",
+                    name="Test Track",
+                    provider_mappings=_make_provider_mapping("deezer", "tr_1"),
+                    duration=240,
+                ),
+                Playlist(
+                    item_id="pl_1",
+                    provider="deezer",
+                    name="Test Playlist",
+                    provider_mappings=_make_provider_mapping("deezer", "pl_1"),
+                    is_dynamic=True,
+                ),
+                ItemMapping(
+                    item_id="im_1",
+                    provider="deezer",
+                    name="Mapped Item",
+                    media_type=MediaType.TRACK,
+                ),
+            ]
+        ),
     )
 
     deserialized = RecommendationFolder.from_dict(folder.to_dict())


### PR DESCRIPTION
mashumaro deserializes Union types by trying each variant in declaration order and picking the first one that doesn't raise. Since `Artist` has the fewest required fields, every item in `RecommendationFolder.items` gets deserialized as `Artist` regardless of its actual `media_type`.

This adds a custom deserializer via `field_options(deserialize=...)` that dispatches to the correct class based on the `media_type` field value and the presence of `provider_mappings` (to distinguish full `MediaItem` types from `ItemMapping`/`BrowseFolder`).

Includes a roundtrip test covering Artist, Album, Track, Playlist, and ItemMapping.