### PR TITLE
Add decoded_audio_format field to StreamDetails

### DIFF
--- a/music_assistant_models/streamdetails.py
+++ b/music_assistant_models/streamdetails.py
@@ -116,6 +116,19 @@ class StreamDetails(DataClassDictMixin):
         metadata=field_options(serialize="omit", deserialize=pass_through),
         repr=False,
     )
+    # decoded_audio_format: the format MA actually receives on the input side.
+    # Set this when the upstream provider/daemon decodes the original source
+    # before handing it to MA (e.g. Spotify Connect / AirPlay receivers pipe
+    # raw PCM into MA after their own decode). The streams controller passes
+    # this to ffmpeg so it can read the input correctly, while audio_format
+    # keeps describing the original source for display purposes.
+    # Leave None when the on-the-wire format equals audio_format.
+    decoded_audio_format: AudioFormat | None = field(
+        default=None,
+        compare=False,
+        metadata=field_options(serialize="omit", deserialize=pass_through),
+        repr=False,
+    )
     # extra_input_args: any additional input args to pass along to ffmpeg
     # this field may be set by the provider when creating the streamdetails
     extra_input_args: list[str] = field(

--- a/tests/test_streamdetails.py
+++ b/tests/test_streamdetails.py
@@ -1,0 +1,57 @@
+"""Tests for the StreamDetails model."""
+
+from music_assistant_models.enums import ContentType, MediaType, StreamType
+from music_assistant_models.media_items import AudioFormat
+from music_assistant_models.streamdetails import StreamDetails
+
+
+def _make_streamdetails(**overrides: object) -> StreamDetails:
+    kwargs: dict[str, object] = {
+        "provider": "spotify_connect",
+        "item_id": "main",
+        "audio_format": AudioFormat(
+            content_type=ContentType.OGG,
+            codec_type=ContentType.OGG,
+            sample_rate=44100,
+            bit_depth=16,
+            channels=2,
+            bit_rate=320,
+        ),
+        "media_type": MediaType.AUDIO_SOURCE,
+        "stream_type": StreamType.NAMED_PIPE,
+    }
+    kwargs.update(overrides)
+    return StreamDetails(**kwargs)  # type: ignore[arg-type]
+
+
+def test_decoded_audio_format_defaults_to_none() -> None:
+    """decoded_audio_format is optional and defaults to None."""
+    sd = _make_streamdetails()
+    assert sd.decoded_audio_format is None
+
+
+def test_decoded_audio_format_accepts_value() -> None:
+    """decoded_audio_format accepts an AudioFormat distinct from audio_format."""
+    decoded = AudioFormat(
+        content_type=ContentType.PCM_S16LE,
+        codec_type=ContentType.PCM_S16LE,
+        sample_rate=44100,
+        bit_depth=16,
+        channels=2,
+    )
+    sd = _make_streamdetails(decoded_audio_format=decoded)
+    assert sd.decoded_audio_format is decoded
+    assert sd.audio_format.content_type is ContentType.OGG
+
+
+def test_decoded_audio_format_is_not_serialized() -> None:
+    """decoded_audio_format is server-internal and must not be sent to clients."""
+    decoded = AudioFormat(
+        content_type=ContentType.PCM_S16LE,
+        codec_type=ContentType.PCM_S16LE,
+        sample_rate=44100,
+        bit_depth=16,
+        channels=2,
+    )
+    sd = _make_streamdetails(decoded_audio_format=decoded)
+    assert "decoded_audio_format" not in sd.to_dict()


### PR DESCRIPTION
## What does this implement/fix?

Some providers receive audio from an upstream daemon that decodes the
original source before handing it to MA (e.g. Spotify Connect via
librespot pipes PCM after decoding Ogg Vorbis; AirPlay receivers via
shairport-sync pipe PCM after decoding ALAC). Today the provider has to
set `audio_format` to the on-the-wire PCM so ffmpeg can read the pipe,
but that same field is also surfaced via the API for source-format
display — so clients (incl. the frontend) show PCM 44.1/16 instead of
the real source format (Ogg Vorbis 320 / ALAC).

This adds an optional, server-internal `decoded_audio_format` field on
`StreamDetails`. Providers can describe the post-decode format there,
keeping `audio_format` free to describe the original source for clients.

## Changes

- New `decoded_audio_format: AudioFormat | None` on `StreamDetails`, with `serialize="omit"` (server-internal only).
- Added `tests/test_streamdetails.py` covering default, accepted value, and serialization behaviour.

## Companion PR

- music-assistant/server — wires this through the streams controller and updates the Spotify Connect / AirPlay receiver providers.

## Types of changes

- [x] New feature (non-breaking change which adds functionality) — `new-feature`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.