### PR TITLE
Add RateLimited error for HTTP 429 rate-limiting

### DIFF
--- a/music_assistant_models/errors.py
+++ b/music_assistant_models/errors.py
@@ -170,3 +170,14 @@ class ResourceBusyError(MusicAssistantError):
     """
 
     error_code = 24
+
+
+class RateLimited(ResourceTemporarilyUnavailable):
+    """
+    Error thrown when a provider is rate-limiting us (HTTP 429).
+
+    Unlike the base class, ``backoff_time`` (a server ``Retry-After``) is treated
+    as a floor rather than a target: the retry helper backs off exponentially above it.
+    """
+
+    error_code = 25


### PR DESCRIPTION
This is the model-side change for the [main server PR](https://github.com/music-assistant/server/pull/4067).

`RateLimited` subclasses `ResourceTemporarilyUnavailable` but carries a distinct meaning: the provider is rate-limiting us, so its `backoff_time` (typically a `Retry-After` value from an HTTP response) is a floor to stay above rather than an exact target to wait. This lets the retry helper tell rate-limiting apart from generic temporary unavailability (e.g., a 503) and back off accordingly.