### PR TITLE
Add server-side translation resolution for config entries, media items and manifests

### DIFF
--- a/music_assistant_models/config_entries.py
+++ b/music_assistant_models/config_entries.py
@@ -13,6 +13,7 @@ from mashumaro import DataClassDictMixin, field_options, pass_through
 
 from .constants import SECURE_STRING_SUBSTITUTE
 from .enums import ConfigEntryType, PlayerType, ProviderType
+from .translations import resolve_translation
 
 LOGGER = logging.getLogger(__name__)
 
@@ -59,8 +60,13 @@ UI_ONLY = (
 class ConfigValueOption(DataClassDictMixin):
     """Model for a value with separated name/value."""
 
-    title: str
-    value: ConfigValueType
+    # value: the stored value identifying this option (the natural first positional argument,
+    # so a value-only option can be written as ConfigValueOption("the_value")).
+    value: ConfigValueType = None
+    # title: display title for the option. Optional: when omitted it is resolved from the
+    # catalog at serialization (keyed by the owning entry + this option's value). Dynamic,
+    # data-driven options (player names, sample rates, ...) still pass a title directly.
+    title: str | None = None
 
 
 MULTI_VALUE_SPLITTER: Final[str] = "||"
@@ -78,8 +84,6 @@ class ConfigEntry(DataClassDictMixin):
     # key: used as identifier for the entry, also for localization
     key: str
     type: ConfigEntryType
-    # label: default label when no translation for the key is present
-    label: str
     default_value: ConfigValueType = None
     required: bool = True
     # options [optional]: select from list of possible values/options
@@ -115,18 +119,19 @@ class ConfigEntry(DataClassDictMixin):
     # requires_reload: indicates that a reload of the provider (or player playback)
     # is required when this setting is changed
     requires_reload: bool = False
-    # translation_key: optional translation key for this entry (defaults to settings.{key})
-    translation_key: str | None = None
-    # translation_params: optional parameters for the translation key
-    translation_params: list[str] | None = None
-    # category_translation_key: optional translation key for the category
-    category_translation_key: str | None = None
-    # category_translation_params: optional parameters for the category translation key
-    category_translation_params: list[str] | None = None
     # advanced: mark this setting as advanced (e.g. hide behind an advanced toggle in frontend)
     advanced: bool = False
+    # translation_params / category_translation_params: optional positional arguments for the
+    # {0}/{1} placeholders in this entry's label/description and category translation, provided
+    # by the implementer.
+    translation_params: list[str] | None = field(
+        default=None, metadata=field_options(serialize="omit"), repr=False
+    )
+    category_translation_params: list[str] | None = field(
+        default=None, metadata=field_options(serialize="omit"), repr=False
+    )
 
-    # validate: an optional custom validation callback
+    # validate: an optional custom validation callback (author-provided)
     validate: Callable[[ConfigValueType], bool] | None = field(
         default=None,
         compare=False,
@@ -134,18 +139,76 @@ class ConfigEntry(DataClassDictMixin):
         repr=False,
     )
 
-    # value: set by the config manager/flow
-    # (or in rare cases by the provider itself during action flows)
+    # ----------------------------------------------------------------------------------
+    # The fields below are populated by the server at runtime — consumers/providers
+    # should NOT set these; they are filled in by Music Assistant.
+    # ----------------------------------------------------------------------------------
+
+    # label: localized display label, resolved from the catalog at serialization.
+    label: str | None = None
+    # category_label: localized category display name, resolved from the catalog at serialization.
+    # The stable `category` value is still used for grouping.
+    category_label: str | None = None
+    # translation_owner: the namespace ("provider.<domain>"/"core.<domain>") this entry's strings
+    # are resolved under; stamped by the config controller when the entry is served. Not serialized.
+    translation_owner: str | None = field(
+        default=None, metadata=field_options(serialize="omit"), repr=False
+    )
+
+    # translation_key / category_translation_key: server-set catalog-key overrides (e.g. the
+    # protocol-output block re-keys copied entries to keep their original catalog key). Not
+    # author-facing and not serialized; the structural defaults are config_entries.<key> /
+    # config_categories.<category>.
+    translation_key: str | None = field(
+        default=None, metadata=field_options(serialize="omit"), repr=False
+    )
+    category_translation_key: str | None = field(
+        default=None, metadata=field_options(serialize="omit"), repr=False
+    )
+
+    # value: the current value, set by the config manager/flow
+    # (or in rare cases by the provider itself during action flows).
     value: ConfigValueType = None
 
     def __post_init__(self) -> None:
         """Run some basic sanity checks after init."""
         if self.type in UI_ONLY:
             self.required = False
-        if self.translation_key is None:
-            self.translation_key = f"settings.{self.key}"
-        if self.category_translation_key is None:
-            self.category_translation_key = f"settings.category.{self.category}"
+
+    def __post_serialize__(self, d: dict[str, Any]) -> dict[str, Any]:
+        """
+        Localize human-readable fields from the catalog for the connection locale.
+
+        Resolves label/description/option titles and the category name under this entry's owner
+        namespace (keyed by config_entries.<key> / config_categories.<category>, or a server-set
+        translation_key/category_translation_key override). No-op when nothing matches, so the
+        in-code values are kept. The translation machinery fields are not serialized.
+        """
+        owner = self.translation_owner
+        base = self.translation_key or f"config_entries.{self.key}"
+        label = resolve_translation(f"{base}.label", owner=owner, params=self.translation_params)
+        if label is not None:
+            d["label"] = label
+        description = resolve_translation(
+            f"{base}.description", owner=owner, params=self.translation_params
+        )
+        if description is not None:
+            d["description"] = description
+        if self.action is not None:
+            action_label = resolve_translation(f"{base}.action_label", owner=owner)
+            if action_label is not None:
+                d["action_label"] = action_label
+        for option_dict, option in zip(d.get("options", []), self.options, strict=False):
+            title = resolve_translation(f"{base}.options.{option.value}", owner=owner)
+            if title is not None:
+                option_dict["title"] = title
+        category_key = self.category_translation_key or f"config_categories.{self.category}"
+        category_label = resolve_translation(
+            category_key, owner=owner, params=self.category_translation_params
+        )
+        if category_label is not None:
+            d["category_label"] = category_label
+        return d
 
     def parse_value(
         self,
@@ -242,18 +305,25 @@ class Config(DataClassDictMixin):
     ) -> Config:
         """Parse Config from the raw values (as stored in persistent storage)."""
         conf = cls.from_dict({**raw, "values": {}})
+        owner = conf._translation_owner()  # noqa: SLF001 - own protected method on a same-class instance
         for entry in config_entries:
             # unpack Enum value in default_value
             if isinstance(entry.default_value, Enum):
                 entry.default_value = entry.default_value.value  # type: ignore[unreachable]
-            # copy original entry to prevent mutation
-            conf.values[entry.key] = deepcopy(entry)
-            conf.values[entry.key].parse_value(
+            # copy original entry to prevent mutation, and stamp the owner for string resolution
+            copied = deepcopy(entry)
+            copied.translation_owner = owner
+            conf.values[entry.key] = copied
+            copied.parse_value(
                 raw.get("values", {}).get(entry.key),
                 allow_none=True,
                 raise_on_error=False,
             )
         return conf
+
+    def _translation_owner(self) -> str | None:
+        """Return the catalog owner namespace for this config's entries (None = common only)."""
+        return None
 
     def to_raw(self) -> dict[str, Any]:
         """Return minimized/raw dict to store in persistent storage."""
@@ -338,6 +408,9 @@ class ProviderConfig(Config):
     # last_error: an optional error message if the provider could not be setup with this config
     last_error: str | None = None
 
+    def _translation_owner(self) -> str | None:
+        return f"provider.{self.domain}"
+
 
 @dataclass
 class PlayerConfig(Config):
@@ -354,6 +427,9 @@ class PlayerConfig(Config):
     # player_type: type of player (player, protocol, group etc.)
     player_type: PlayerType = PlayerType.PLAYER
 
+    def _translation_owner(self) -> str | None:
+        return f"provider.{self.provider}"
+
 
 @dataclass
 class CoreConfig(Config):
@@ -362,3 +438,6 @@ class CoreConfig(Config):
     domain: str  # domain/name of the core module
     # last_error: an optional error message if the module could not be setup with this config
     last_error: str | None = None
+
+    def _translation_owner(self) -> str | None:
+        return f"core.{self.domain}"

--- a/music_assistant_models/config_entries.py
+++ b/music_assistant_models/config_entries.py
@@ -65,7 +65,7 @@ class ConfigValueOption(DataClassDictMixin):
     # explicitly only when None is a meaningful sentinel).
     value: ConfigValueType
     # title: display title for the option. Optional: when omitted it is resolved from the
-    # catalog at serialization (keyed by the owning entry + this option's value). Dynamic,
+    # translations at serialization (keyed by the owning entry + this option's value). Dynamic,
     # data-driven options (player names, sample rates, ...) still pass a title directly.
     title: str | None = None
 
@@ -145,10 +145,10 @@ class ConfigEntry(DataClassDictMixin):
     # should NOT set these; they are filled in by Music Assistant.
     # ----------------------------------------------------------------------------------
 
-    # label: localized display label, resolved from the catalog at serialization.
+    # label: localized display label, resolved from the translations at serialization.
     label: str | None = None
-    # category_label: localized category display name, resolved from the catalog at serialization.
-    # The stable `category` value is still used for grouping.
+    # category_label: localized category display name, resolved from the translations at
+    # serialization. The stable `category` value is still used for grouping.
     category_label: str | None = None
     # translation_owner: the namespace ("provider.<domain>"/"core.<domain>") this entry's strings
     # are resolved under; stamped by the config controller when the entry is served. Not serialized.
@@ -156,8 +156,8 @@ class ConfigEntry(DataClassDictMixin):
         default=None, metadata=field_options(serialize="omit"), repr=False
     )
 
-    # translation_key / category_translation_key: server-set catalog-key overrides (e.g. the
-    # protocol-output block re-keys copied entries to keep their original catalog key). Not
+    # translation_key / category_translation_key: server-set translation-key overrides (e.g. the
+    # protocol-output block re-keys copied entries to keep their original translation key). Not
     # author-facing and not serialized; the structural defaults are config_entries.<key> /
     # config_categories.<category>.
     translation_key: str | None = field(
@@ -178,7 +178,7 @@ class ConfigEntry(DataClassDictMixin):
 
     def __post_serialize__(self, d: dict[str, Any]) -> dict[str, Any]:
         """
-        Localize human-readable fields from the catalog for the connection locale.
+        Localize human-readable fields from the translations for the connection locale.
 
         Resolves label/description/option titles and the category name under this entry's owner
         namespace (keyed by config_entries.<key> / config_categories.<category>, or a server-set
@@ -323,7 +323,7 @@ class Config(DataClassDictMixin):
         return conf
 
     def _translation_owner(self) -> str | None:
-        """Return the catalog owner namespace for this config's entries (None = common only)."""
+        """Return the translations owner namespace for this config's entries (None = common)."""
         return None
 
     def to_raw(self) -> dict[str, Any]:

--- a/music_assistant_models/config_entries.py
+++ b/music_assistant_models/config_entries.py
@@ -60,9 +60,10 @@ UI_ONLY = (
 class ConfigValueOption(DataClassDictMixin):
     """Model for a value with separated name/value."""
 
-    # value: the stored value identifying this option (the natural first positional argument,
-    # so a value-only option can be written as ConfigValueOption("the_value")).
-    value: ConfigValueType = None
+    # value: the stored value identifying this option, and the first positional argument so a
+    # value-only option can be written as ConfigValueOption("the_value"). Required (pass None
+    # explicitly only when None is a meaningful sentinel).
+    value: ConfigValueType
     # title: display title for the option. Optional: when omitted it is resolved from the
     # catalog at serialization (keyed by the owning entry + this option's value). Dynamic,
     # data-driven options (player names, sample rates, ...) still pass a title directly.

--- a/music_assistant_models/media_items/media_item.py
+++ b/music_assistant_models/media_items/media_item.py
@@ -58,7 +58,7 @@ class _MediaItemBase(DataClassDictMixin):
             self.sort_name = create_sort_name(self.name)
 
     def _translation_base(self) -> str | None:
-        """Return the catalog key base for this item's translation_key (None if unset)."""
+        """Return the translation key base for this item's translation_key (None if unset)."""
         if self.translation_key is None:
             return None
         key = self.translation_key

--- a/music_assistant_models/media_items/media_item.py
+++ b/music_assistant_models/media_items/media_item.py
@@ -18,6 +18,7 @@ from music_assistant_models.helpers import (
     is_valid_uuid,
     remove_diacritics,
 )
+from music_assistant_models.translations import resolve_translation, translations_active
 from music_assistant_models.unique_list import UniqueList
 
 from .metadata import MediaItemImage, MediaItemMetadata
@@ -30,6 +31,8 @@ class _MediaItemBase(DataClassDictMixin):
 
     item_id: str
     provider: str  # provider instance id or provider domain
+    # name: the (English) display name; always set. For localizable items also set a
+    # translation_key, which overrides `name` for the connection locale at serialization.
     name: str
     version: str = ""
     # sort_name will be auto generated if omitted
@@ -39,9 +42,12 @@ class _MediaItemBase(DataClassDictMixin):
     external_ids: set[tuple[ExternalID, str]] = field(default_factory=set)
     # is_playable: if the item is playable (can be used in play_media command)
     is_playable: bool = True
-    # translation_key:
-    # an optional translation key identifier for the frontend (to use instead of name)
+    # translation_key: optional key to localize `name` (e.g. for "Your Mixes"); resolved to the
+    # connection locale at serialization, overriding the in-code `name`.
     translation_key: str | None = None
+    # translation_params: optional positional arguments for {0}/{1} placeholders in the
+    # translated string (e.g. "Liked Songs {0}").
+    translation_params: list[str] | None = None
     media_type: MediaType = MediaType.UNKNOWN
 
     def __post_init__(self) -> None:
@@ -50,6 +56,41 @@ class _MediaItemBase(DataClassDictMixin):
             self.uri = create_uri(self.media_type, self.provider, self.item_id)
         if self.sort_name is None:
             self.sort_name = create_sort_name(self.name)
+
+    def _translation_base(self) -> str | None:
+        """Return the catalog key base for this item's translation_key (None if unset)."""
+        if self.translation_key is None:
+            return None
+        key = self.translation_key
+        return key if key.startswith(("provider.", "core.", "common.")) else f"media.{key}"
+
+    def __post_serialize__(self, d: dict[str, Any]) -> dict[str, Any]:
+        """Localize the display name (and subtitle) when a translation resolver is set."""
+        self._resolve_translation(d)
+        return d
+
+    def _resolve_translation(self, d: dict[str, Any]) -> None:
+        """
+        Replace name/subtitle in the serialized dict with localized strings.
+
+        When a `translation_key` is set and a resolver is active, name/subtitle are localized for
+        the connection locale; otherwise the in-code values are preserved. On localized API output
+        the internal translation_key/translation_params are stripped; they are retained in plain
+        to_dict() calls used for internal round-tripping (caching, item mappings).
+        """
+        base = self._translation_base()
+        if base is not None:
+            for field_name in ("name", "subtitle"):
+                if field_name not in d:
+                    continue
+                localized = resolve_translation(
+                    f"{base}.{field_name}", owner=self.provider, params=self.translation_params
+                )
+                if localized is not None:
+                    d[field_name] = localized
+        if translations_active():
+            d.pop("translation_key", None)
+            d.pop("translation_params", None)
 
     def get_external_id(self, external_id_type: ExternalID) -> str | None:
         """Get (the first instance) of given External ID or None if not found."""
@@ -295,6 +336,7 @@ class Radio(MediaItem):
 
     def __post_serialize__(self, d: dict[str, Any]) -> dict[str, Any]:
         """Adjust dict object after it has been serialized."""
+        self._resolve_translation(d)
         # TEMP 2025-03-14: convert None duration to fake number for backwards compatibility
         d["duration"] = 0 if d["duration"] is None else d["duration"]
         return d

--- a/music_assistant_models/provider.py
+++ b/music_assistant_models/provider.py
@@ -10,6 +10,7 @@ from typing import Any
 from mashumaro.mixins.orjson import DataClassORJSONMixin
 
 from .enums import MediaType, ProviderFeature, ProviderStage, ProviderType
+from .translations import resolve_translation
 
 
 @dataclass
@@ -67,6 +68,16 @@ class ProviderManifest(DataClassORJSONMixin):
         """Parse ProviderManifest from file."""
         file_contents = await asyncio.to_thread(Path(manifest_file).read_text)
         return cls.from_json(file_contents)
+
+    def __post_serialize__(self, d: dict[Any, Any]) -> dict[Any, Any]:
+        """Localize name/description when a translation resolver is set (no-op otherwise)."""
+        if (value := resolve_translation(f"provider.{self.domain}.manifest.name")) is not None:
+            d["name"] = value
+        if (
+            value := resolve_translation(f"provider.{self.domain}.manifest.description")
+        ) is not None:
+            d["description"] = value
+        return d
 
 
 @dataclass

--- a/music_assistant_models/translations.py
+++ b/music_assistant_models/translations.py
@@ -1,0 +1,51 @@
+"""Translation resolution hook used during outbound API serialization."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from contextvars import ContextVar
+from typing import Any
+
+# ContextVar set by the Music Assistant server during outbound API serialization.
+# When set, model __post_serialize__ hooks use the resolver to replace human-readable
+# fields (label/name/title/description/...) with strings localized for the connection's
+# locale. The resolver receives a (relative or fully-qualified) catalog key plus an
+# optional owner hint and positional params, and returns the localized string, or None
+# when nothing matches so the model keeps its existing value rather than a raw key.
+TRANSLATION_RESOLVER: ContextVar[Callable[..., str | None] | None] = ContextVar(
+    "translation_resolver", default=None
+)
+
+
+def translations_active() -> bool:
+    """
+    Return True when an outbound API serialization is in progress (a resolver is bound).
+
+    Models use this to strip internal translation machinery (translation_key/params) from the
+    localized API output while keeping it in plain ``to_dict()`` calls used for internal
+    round-tripping (caching, item mappings, config storage).
+    """
+    return TRANSLATION_RESOLVER.get() is not None
+
+
+def resolve_translation(
+    key: str, owner: str | None = None, params: list[Any] | None = None
+) -> str | None:
+    """
+    Resolve a translation key via the resolver set on the current context.
+
+    Returns None when no resolver is set (e.g. non-API serialization) or when the key
+    cannot be resolved, so callers keep any existing (English) value. Never raises.
+
+    :param key: Catalog key, relative (e.g. "config_entries.username.label") or
+        fully-qualified (e.g. "provider.ytmusic.manifest.name").
+    :param owner: Optional owner hint (provider domain/instance) for relative keys.
+    :param params: Optional positional arguments for ``{0}``/``{1}`` placeholders.
+    """
+    resolver = TRANSLATION_RESOLVER.get()
+    if resolver is None:
+        return None
+    try:
+        return resolver(key, owner=owner, params=params)
+    except Exception:  # noqa: BLE001 - resolution must never break serialization
+        return None

--- a/music_assistant_models/translations.py
+++ b/music_assistant_models/translations.py
@@ -4,12 +4,11 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from contextvars import ContextVar
-from typing import Any
 
 # ContextVar set by the Music Assistant server during outbound API serialization.
 # When set, model __post_serialize__ hooks use the resolver to replace human-readable
 # fields (label/name/title/description/...) with strings localized for the connection's
-# locale. The resolver receives a (relative or fully-qualified) catalog key plus an
+# locale. The resolver receives a (relative or fully-qualified) translation key plus an
 # optional owner hint and positional params, and returns the localized string, or None
 # when nothing matches so the model keeps its existing value rather than a raw key.
 TRANSLATION_RESOLVER: ContextVar[Callable[..., str | None] | None] = ContextVar(
@@ -29,7 +28,7 @@ def translations_active() -> bool:
 
 
 def resolve_translation(
-    key: str, owner: str | None = None, params: list[Any] | None = None
+    key: str, owner: str | None = None, params: list[str] | None = None
 ) -> str | None:
     """
     Resolve a translation key via the resolver set on the current context.
@@ -37,7 +36,7 @@ def resolve_translation(
     Returns None when no resolver is set (e.g. non-API serialization) or when the key
     cannot be resolved, so callers keep any existing (English) value. Never raises.
 
-    :param key: Catalog key, relative (e.g. "config_entries.username.label") or
+    :param key: Translation key, relative (e.g. "config_entries.username.label") or
         fully-qualified (e.g. "provider.ytmusic.manifest.name").
     :param owner: Optional owner hint (provider domain/instance) for relative keys.
     :param params: Optional positional arguments for ``{0}``/``{1}`` placeholders.

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -1,0 +1,98 @@
+"""Tests for the serialization-time translation resolution hooks."""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption
+from music_assistant_models.enums import ConfigEntryType, ProviderType
+from music_assistant_models.media_items import RecommendationFolder
+from music_assistant_models.provider import ProviderManifest
+from music_assistant_models.translations import TRANSLATION_RESOLVER
+
+# the strings a bound resolver would return for the keys the models look up
+_CATALOG = {
+    "config_entries.log_level.label": "Logniveau",
+    "config_categories.generic": "Algemeen",
+    "media.recently_played.name": "Onlangs afgespeeld",
+    "media.recently_played.subtitle": "Ga verder waar je gebleven was",
+    "provider.demo.manifest.name": "Demo-muziekprovider",
+    "provider.demo.manifest.description": "Een demoprovider.",
+}
+
+
+@contextmanager
+def _resolver_active() -> Iterator[None]:
+    """Bind a fake catalog resolver for the duration of the block."""
+
+    def resolve(key: str, owner: str | None = None, params: list[Any] | None = None) -> str | None:
+        for candidate in [f"{owner}.{key}", key] if owner else [key]:
+            if (value := _CATALOG.get(candidate)) is not None:
+                return value.format(*params) if params else value
+        return None
+
+    token = TRANSLATION_RESOLVER.set(resolve)
+    try:
+        yield
+    finally:
+        TRANSLATION_RESOLVER.reset(token)
+
+
+def test_config_entry_resolves_label_and_omits_machinery() -> None:
+    """ConfigEntry resolves its label/category and never serializes the translation machinery."""
+    entry = ConfigEntry(key="log_level", type=ConfigEntryType.STRING)
+    # no resolver -> in-code values kept, machinery never serialized
+    plain = entry.to_dict()
+    assert plain["label"] is None
+    for key in ("translation_key", "translation_params", "category_translation_key"):
+        assert key not in plain
+    # resolver bound -> localized label + category
+    with _resolver_active():
+        localized = entry.to_dict()
+    assert localized["label"] == "Logniveau"
+    assert localized["category_label"] == "Algemeen"
+
+
+def test_media_item_resolves_name_subtitle_and_strips_machinery() -> None:
+    """A media item localizes name/subtitle and strips translation_key/params from API output."""
+    folder = RecommendationFolder(
+        item_id="recently_played",
+        provider="library",
+        name="Recently played",
+        translation_key="recently_played",
+        subtitle="Pick up where you left off",
+    )
+    # plain to_dict keeps the machinery (needed for cache/item-mapping round-trips)
+    plain = folder.to_dict()
+    assert plain["name"] == "Recently played"
+    assert plain["translation_key"] == "recently_played"
+    # resolver bound -> localized name/subtitle, machinery stripped from the wire
+    with _resolver_active():
+        localized = folder.to_dict()
+    assert localized["name"] == "Onlangs afgespeeld"
+    assert localized["subtitle"] == "Ga verder waar je gebleven was"
+    assert "translation_key" not in localized
+    assert "translation_params" not in localized
+
+
+def test_provider_manifest_resolves_name_and_description() -> None:
+    """ProviderManifest resolves name/description from provider.<domain>.manifest.*."""
+    manifest = ProviderManifest(
+        type=ProviderType.MUSIC,
+        domain="demo",
+        name="Demo Music Provider",
+        description="A demo provider.",
+        codeowners=[],
+    )
+    assert manifest.to_dict()["name"] == "Demo Music Provider"
+    with _resolver_active():
+        localized = manifest.to_dict()
+    assert localized["name"] == "Demo-muziekprovider"
+    assert localized["description"] == "Een demoprovider."
+
+
+def test_config_value_option_value_first() -> None:
+    """Value is the first field, so a value-only option needs no keyword."""
+    assert ConfigValueOption("the_value").value == "the_value"
+    option = ConfigValueOption("the_value", title="Title")
+    assert (option.value, option.title) == ("the_value", "Title")


### PR DESCRIPTION
The Music Assistant server is becoming the single source of truth for the strings on server-provided objects (config entries, media item names, provider manifests), so it can serve them already localized for the connecting client's locale. This adds the model-side hooks the server needs to resolve and inject those strings at serialization time.

The change is additive and backward compatible: when no resolver is bound (non-API serialization, older clients/flows) the models keep their existing English values.

- Add `translations.py` with a `TRANSLATION_RESOLVER` ContextVar and `resolve_translation()` / `translations_active()` helpers (never raise; no-op when unset).
- `ConfigEntry`: resolve label/description/option titles/category name from the catalog in `__post_serialize__`; make `label`/`category_label` optional (server-filled); add `translation_owner`, `category_translation_key` and `translation_params`/`category_translation_params` (all `serialize="omit"`).
- `ConfigValueOption`: make `title` optional (resolved from the catalog) and make `value` the first field, so a value-only option can be written as `ConfigValueOption("the_value")`.
- `_MediaItemBase`: add optional `translation_params`; resolve `name` (and `RecommendationFolder.subtitle`) in `__post_serialize__`.
- `ProviderManifest`: resolve `name`/`description` from `provider.<domain>.manifest.*`.
