### PR TITLE
Add server-side translation resolution for background task names

### DIFF
--- a/music_assistant_models/background_task.py
+++ b/music_assistant_models/background_task.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 from mashumaro import DataClassDictMixin
 
 from .enums import TaskScheduleType, TaskStatus
+from .translations import resolve_translation, translations_active
 
 type TaskMetadataValue = (
     None | bool | int | float | str | list[TaskMetadataValue] | dict[str, TaskMetadataValue]
@@ -172,3 +173,15 @@ class BackgroundTask(DataClassDictMixin):
             raise ValueError("BackgroundTask progress must be between 0 and 100")
         if self.failure_count < 0:
             raise ValueError("BackgroundTask failure_count must be >= 0")
+
+    def __post_serialize__(self, d: dict[str, Any]) -> dict[str, Any]:
+        """Localize the task name from its translation_key when a resolver is active."""
+        if self.translation_key:
+            params = [str(a) for a in self.translation_args] if self.translation_args else None
+            localized = resolve_translation(self.translation_key, params=params)
+            if localized is not None:
+                d["name"] = localized
+        if translations_active():
+            d.pop("translation_key", None)
+            d.pop("translation_args", None)
+        return d

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -4,6 +4,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import Any
 
+from music_assistant_models.background_task import BackgroundTask
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption
 from music_assistant_models.enums import ConfigEntryType, ProviderType
 from music_assistant_models.media_items import RecommendationFolder
@@ -18,6 +19,8 @@ _CATALOG = {
     "media.recently_played.subtitle": "Ga verder waar je gebleven was",
     "provider.demo.manifest.name": "Demo-muziekprovider",
     "provider.demo.manifest.description": "Een demoprovider.",
+    "background_task.database_cleanup": "Database opschonen",
+    "background_task.update_metadata": "Metadata bijwerken voor {0}",
 }
 
 
@@ -89,6 +92,35 @@ def test_provider_manifest_resolves_name_and_description() -> None:
         localized = manifest.to_dict()
     assert localized["name"] == "Demo-muziekprovider"
     assert localized["description"] == "Een demoprovider."
+
+
+def test_background_task_resolves_name_and_strips_machinery() -> None:
+    """A background task localizes its name from translation_key and strips the machinery."""
+    task = BackgroundTask(
+        name="Database cleanup", translation_key="background_task.database_cleanup"
+    )
+    # plain to_dict keeps the in-code name and the machinery
+    plain = task.to_dict()
+    assert plain["name"] == "Database cleanup"
+    assert plain["translation_key"] == "background_task.database_cleanup"
+    # resolver bound -> localized name, machinery stripped from the wire
+    with _resolver_active():
+        localized = task.to_dict()
+    assert localized["name"] == "Database opschonen"
+    assert "translation_key" not in localized
+    assert "translation_args" not in localized
+
+
+def test_background_task_interpolates_translation_args() -> None:
+    """translation_args fill positional placeholders in the resolved task name."""
+    task = BackgroundTask(
+        name="Update metadata for My Playlist",
+        translation_key="background_task.update_metadata",
+        translation_args=["My Playlist"],
+    )
+    with _resolver_active():
+        localized = task.to_dict()
+    assert localized["name"] == "Metadata bijwerken voor My Playlist"
 
 
 def test_config_value_option_value_first() -> None:


### PR DESCRIPTION
Background task names are sent to API clients as hardcoded English. Other server-provided objects (config entries, media items, provider manifests) already resolve their human-readable strings server-side at serialization from a `translation_key`, but `BackgroundTask` had no such hook, so task names could not be localized.

This adds the missing resolution hook so the server can emit localized task names, consistent with the other models.

## Changes

- Add a `__post_serialize__` hook to `BackgroundTask` that resolves `name` from `translation_key` (interpolating positional `translation_args`) when a translation resolver is bound.
- Strip `translation_key`/`translation_args` from the serialized output while translations are active, matching `ConfigEntry`/media items.
- Add tests for static resolution, machinery stripping, and `{0}` argument interpolation.

Companion server PR: music-assistant/server#4200
