### PR TITLE
Key media item translation names by media type

### DIFF
--- a/music_assistant_models/media_items/media_item.py
+++ b/music_assistant_models/media_items/media_item.py
@@ -50,6 +50,17 @@ class _MediaItemBase(DataClassDictMixin):
     translation_params: list[str] | None = None
     media_type: MediaType = MediaType.UNKNOWN
 
+    @property
+    def _translation_group(self) -> str:
+        """
+        Namespace segment for a bare translation_key (defaults to the media type).
+
+        Keyed by media type so names group as ``media.<type>.<key>`` (e.g. ``media.genre.jazz``).
+        Special subclasses override this when their media_type doesn't capture the distinction
+        (e.g. recommendation folders, which share ``MediaType.FOLDER`` with browse folders).
+        """
+        return self.media_type.value
+
     def __post_init__(self) -> None:
         """Call after init."""
         if self.uri is None:
@@ -62,7 +73,11 @@ class _MediaItemBase(DataClassDictMixin):
         if self.translation_key is None:
             return None
         key = self.translation_key
-        return key if key.startswith(("provider.", "core.", "common.")) else f"media.{key}"
+        return (
+            key
+            if key.startswith(("provider.", "core.", "common."))
+            else f"media.{self._translation_group}.{key}"
+        )
 
     def __post_serialize__(self, d: dict[str, Any]) -> dict[str, Any]:
         """Localize the display name (and subtitle) when a translation resolver is set."""
@@ -528,6 +543,11 @@ class RecommendationFolder(BrowseFolder):
         metadata=field_options(deserialize=_deserialize_recommendation_items),
     )
     subtitle: str | None = None  # optional subtitle for the recommendation
+
+    @property
+    def _translation_group(self) -> str:
+        """Own namespace: media_type is FOLDER (shared with BrowseFolder), so override it."""
+        return "recommendations"
 
 
 # some type aliases

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -7,7 +7,7 @@ from typing import Any
 from music_assistant_models.background_task import BackgroundTask
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption
 from music_assistant_models.enums import ConfigEntryType, ProviderType
-from music_assistant_models.media_items import RecommendationFolder
+from music_assistant_models.media_items import BrowseFolder, RecommendationFolder
 from music_assistant_models.provider import ProviderManifest
 from music_assistant_models.translations import TRANSLATION_RESOLVER
 
@@ -15,8 +15,9 @@ from music_assistant_models.translations import TRANSLATION_RESOLVER
 _CATALOG = {
     "config_entries.log_level.label": "Logniveau",
     "config_categories.generic": "Algemeen",
-    "media.recently_played.name": "Onlangs afgespeeld",
-    "media.recently_played.subtitle": "Ga verder waar je gebleven was",
+    "media.recommendations.recently_played.name": "Onlangs afgespeeld",
+    "media.recommendations.recently_played.subtitle": "Ga verder waar je gebleven was",
+    "media.folder.libraries.name": "Bibliotheken",
     "provider.demo.manifest.name": "Demo-muziekprovider",
     "provider.demo.manifest.description": "Een demoprovider.",
     "background_task.database_cleanup": "Database opschonen",
@@ -76,6 +77,24 @@ def test_media_item_resolves_name_subtitle_and_strips_machinery() -> None:
     assert localized["subtitle"] == "Ga verder waar je gebleven was"
     assert "translation_key" not in localized
     assert "translation_params" not in localized
+
+
+def test_browse_and_recommendation_folders_use_distinct_namespaces() -> None:
+    """Folder names key by media type; recommendation folders override to recommendations.*."""
+    browse = BrowseFolder(
+        item_id="libraries", provider="library", name="Libraries", translation_key="libraries"
+    )
+    rec = RecommendationFolder(
+        item_id="recently_played",
+        provider="library",
+        name="Recently played",
+        translation_key="recently_played",
+    )
+    with _resolver_active():
+        # browse folder (media_type FOLDER) reads media.folder.libraries.name
+        assert browse.to_dict()["name"] == "Bibliotheken"
+        # recommendation folder overrides its group -> media.recommendations.* (not media.folder.*)
+        assert rec.to_dict()["name"] == "Onlangs afgespeeld"
 
 
 def test_provider_manifest_resolves_name_and_description() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Companion to a server-side catalog change. Today every media item's bare `translation_key` resolves into one flat `media.*` namespace, so unrelated concepts collide — the library "Albums" browse root, the per-genre "Albums" overview shelf and a provider that sets `translation_key=<arbitrary slug>` (Tidal) all land next to genre slugs.

This keys translation names by **media type**: `_translation_group` becomes a property defaulting to `self.media_type.value`, and `_translation_base` produces `media.<group>.<key>` — e.g. `media.genre.jazz`, `media.folder.albums`, `media.playlist.<id>`. Browse folders fall out as `media.folder.*` for free. `RecommendationFolder` overrides the property to `"recommendations"` (it shares `MediaType.FOLDER` with `BrowseFolder`, so the type alone can't separate the two) → `media.recommendations.*`.

Fully-qualified keys (`provider.`/`core.`/`common.`) still pass through unchanged, and no per-subclass `__post_serialize__` is needed (the shared resolver already keys off `_translation_base`). The companion server PR re-nests `strings.json` by type to match.

## Types of changes

- [x] Enhancement to an existing feature — `enhancement`