### PR TITLE
Remove deprecated SyncTask model

### DIFF
--- a/music_assistant_models/provider.py
+++ b/music_assistant_models/provider.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from mashumaro.mixins.orjson import DataClassORJSONMixin
 
-from .enums import MediaType, ProviderFeature, ProviderStage, ProviderType
+from .enums import ProviderFeature, ProviderStage, ProviderType
 from .translations import resolve_translation
 
 
@@ -98,21 +98,3 @@ class ProviderInstance(DataClassORJSONMixin):
         # add lookup_key for backwards compatibility
         d["lookup_key"] = self.domain if self.is_streaming_provider else self.instance_id
         return d
-
-
-@dataclass
-class SyncTask:
-    """Description of a Sync task/job of a musicprovider."""
-
-    provider_domain: str
-    provider_instance: str
-    media_types: tuple[MediaType, ...]
-    task: asyncio.Task[None] | None
-
-    def to_dict(self) -> dict[str, Any]:
-        """Return SyncTask as (serializable) dict."""
-        return {
-            "provider_domain": self.provider_domain,
-            "provider_instance": self.provider_instance,
-            "media_types": [x.value for x in self.media_types],
-        }


### PR DESCRIPTION
The `SyncTask` model is no longer used. Provider sync jobs are now represented by the server's `BackgroundTask` model, leaving this as stale dead code.

- Remove the `SyncTask` dataclass from `provider.py`
- Drop the now-unused `MediaType` import
