### PR TITLE
Localize media item descriptions

### DIFF
--- a/music_assistant_models/media_items/media_item.py
+++ b/music_assistant_models/media_items/media_item.py
@@ -80,18 +80,19 @@ class _MediaItemBase(DataClassDictMixin):
         )
 
     def __post_serialize__(self, d: dict[str, Any]) -> dict[str, Any]:
-        """Localize the display name (and subtitle) when a translation resolver is set."""
+        """Localize name/subtitle/description when a translation resolver is set."""
         self._resolve_translation(d)
         return d
 
     def _resolve_translation(self, d: dict[str, Any]) -> None:
         """
-        Replace name/subtitle in the serialized dict with localized strings.
+        Replace name/subtitle/description in the serialized dict with localized strings.
 
-        When a `translation_key` is set and a resolver is active, name/subtitle are localized for
-        the connection locale; otherwise the in-code values are preserved. On localized API output
-        the internal translation_key/translation_params are stripped; they are retained in plain
-        to_dict() calls used for internal round-tripping (caching, item mappings).
+        When a `translation_key` is set and a resolver is active, the top-level name/subtitle and
+        the nested metadata.description are localized for the connection locale; otherwise the
+        in-code values are preserved. On localized API output the internal
+        translation_key/translation_params are stripped; they are retained in plain to_dict()
+        calls used for internal round-tripping (caching, item mappings).
         """
         base = self._translation_base()
         if base is not None:
@@ -103,6 +104,13 @@ class _MediaItemBase(DataClassDictMixin):
                 )
                 if localized is not None:
                     d[field_name] = localized
+            # description lives on the nested metadata object (MediaItemMetadata), not top-level
+            if isinstance(metadata := d.get("metadata"), dict):
+                localized = resolve_translation(
+                    f"{base}.description", owner=self.provider, params=self.translation_params
+                )
+                if localized is not None:
+                    metadata["description"] = localized
         if translations_active():
             d.pop("translation_key", None)
             d.pop("translation_params", None)

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -7,7 +7,7 @@ from typing import Any
 from music_assistant_models.background_task import BackgroundTask
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption
 from music_assistant_models.enums import ConfigEntryType, ProviderType
-from music_assistant_models.media_items import BrowseFolder, RecommendationFolder
+from music_assistant_models.media_items import BrowseFolder, Genre, RecommendationFolder
 from music_assistant_models.provider import ProviderManifest
 from music_assistant_models.translations import TRANSLATION_RESOLVER
 
@@ -18,6 +18,8 @@ _CATALOG = {
     "media.recommendations.recently_played.name": "Onlangs afgespeeld",
     "media.recommendations.recently_played.subtitle": "Ga verder waar je gebleven was",
     "media.folder.libraries.name": "Bibliotheken",
+    "media.genre.jazz.name": "Jazz (NL)",
+    "media.genre.jazz.description": "Jazz is een Amerikaans muziekgenre.",
     "provider.demo.manifest.name": "Demo-muziekprovider",
     "provider.demo.manifest.description": "Een demoprovider.",
     "background_task.database_cleanup": "Database opschonen",
@@ -77,6 +79,27 @@ def test_media_item_resolves_name_subtitle_and_strips_machinery() -> None:
     assert localized["subtitle"] == "Ga verder waar je gebleven was"
     assert "translation_key" not in localized
     assert "translation_params" not in localized
+
+
+def test_genre_resolves_nested_metadata_description() -> None:
+    """A Genre localizes its name and its nested metadata.description from media.genre.<key>.*."""
+    genre = Genre(
+        item_id="jazz",
+        provider="library",
+        name="Jazz",
+        translation_key="jazz",
+        provider_mappings=set(),
+    )
+    # plain to_dict keeps the in-code values (no description authored in code)
+    plain = genre.to_dict()
+    assert plain["name"] == "Jazz"
+    assert plain["metadata"]["description"] is None
+    # resolver bound -> localized name + nested metadata.description, machinery stripped
+    with _resolver_active():
+        localized = genre.to_dict()
+    assert localized["name"] == "Jazz (NL)"
+    assert localized["metadata"]["description"] == "Jazz is een Amerikaans muziekgenre."
+    assert "translation_key" not in localized
 
 
 def test_browse_and_recommendation_folders_use_distinct_namespaces() -> None:


### PR DESCRIPTION
The serialization-time translation resolver only filled the top-level `name`/`subtitle` from a `translation_key`, never the description — which lives on the nested `metadata` object. This made it impossible to own translatable descriptions centrally (the motivating case being genre descriptions).

- `_resolve_translation` now also resolves `<base>.description` into `metadata.description`, guarded on a dict metadata being present, so items without metadata (`ItemMapping`, `BrowseFolder`, `RecommendationFolder`) are untouched
- Add a test covering a Genre localizing its nested `metadata.description`

Companion PRs: music-assistant/server#4227, music-assistant/frontend#1923