### PR TITLE
Add translation keys to errors for localized API messages

### DIFF
--- a/music_assistant_models/api.py
+++ b/music_assistant_models/api.py
@@ -11,6 +11,7 @@ from music_assistant_models.enums import CoreState
 
 from .event import MassEvent
 from .helpers import get_serializable_value
+from .translations import resolve_translation, translations_active
 
 
 @dataclass
@@ -43,6 +44,23 @@ class ErrorResultMessage(ResultMessageBase):
 
     error_code: int
     details: str | None = None
+    # translation_key + translation_args localize `details` for the connection's locale during
+    # outbound API serialization (resolved in __post_serialize__); both are stripped from the
+    # client payload when a resolver is active.
+    translation_key: str | None = None
+    translation_args: list[Any] = field(default_factory=list)
+
+    def __post_serialize__(self, d: dict[str, Any]) -> dict[str, Any]:
+        """Localize `details` from the translation_key when a resolver is active."""
+        if self.translation_key:
+            params = [str(a) for a in self.translation_args] if self.translation_args else None
+            localized = resolve_translation(self.translation_key, params=params)
+            if localized is not None:
+                d["details"] = localized
+        if translations_active():
+            d.pop("translation_key", None)
+            d.pop("translation_args", None)
+        return d
 
 
 # EventMessage is the same as MassEvent, this is just a alias.

--- a/music_assistant_models/errors.py
+++ b/music_assistant_models/errors.py
@@ -1,10 +1,36 @@
 """Custom errors and exceptions."""
 
+from typing import Any
+
 
 class MusicAssistantError(Exception):
     """Custom Exception for all errors."""
 
     error_code = 0
+    # Default translation key for this error type, resolved against the server's
+    # `common.errors.*` strings during outbound API serialization to localize the message
+    # shown to clients. Subclasses set their own default; callers may override the key (and
+    # provide positional args for {0}/{1} placeholders) per-instance via the constructor.
+    translation_key: str | None = None
+
+    def __init__(
+        self,
+        *args: object,
+        translation_key: str | None = None,
+        translation_args: list[Any] | None = None,
+    ) -> None:
+        """
+        Initialize the error.
+
+        :param translation_key: Optional per-instance override of the error type's default
+            translation key, used to localize the message shown to API clients.
+        :param translation_args: Optional positional arguments for {0}/{1} placeholders in the
+            translated message.
+        """
+        super().__init__(*args)
+        if translation_key is not None:
+            self.translation_key = translation_key
+        self.translation_args: list[Any] = translation_args or []
 
     def __init_subclass__(cls, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
         """Register a subclass."""
@@ -20,143 +46,166 @@ class ProviderUnavailableError(MusicAssistantError):
     """Error raised when trying to access mediaitem of unavailable provider."""
 
     error_code = 1
+    translation_key = "errors.provider_unavailable"
 
 
 class MediaNotFoundError(MusicAssistantError):
     """Error raised when trying to access non existing media item."""
 
     error_code = 2
+    translation_key = "errors.media_not_found"
 
 
 class InvalidDataError(MusicAssistantError):
     """Error raised when an object has invalid data."""
 
     error_code = 3
+    translation_key = "errors.invalid_data"
 
 
 class AlreadyRegisteredError(MusicAssistantError):
     """Error raised when a duplicate music provider or player is registered."""
 
     error_code = 4
+    translation_key = "errors.already_registered"
 
 
 class SetupFailedError(MusicAssistantError):
     """Error raised when setup of a provider or player failed."""
 
     error_code = 5
+    translation_key = "errors.setup_failed"
 
 
 class LoginFailed(MusicAssistantError):
     """Error raised when a login failed."""
 
     error_code = 6
+    translation_key = "errors.login_failed"
 
 
 class AudioError(MusicAssistantError):
     """Error raised when an issue arose when processing audio."""
 
     error_code = 7
+    translation_key = "errors.audio_error"
 
 
 class QueueEmpty(MusicAssistantError):
     """Error raised when trying to start queue stream while queue is empty."""
 
     error_code = 8
+    translation_key = "errors.queue_empty"
 
 
 class UnsupportedFeaturedException(MusicAssistantError):
     """Error raised when a feature is not supported."""
 
     error_code = 9
+    translation_key = "errors.unsupported_feature"
 
 
 class PlayerUnavailableError(MusicAssistantError):
     """Error raised when trying to access non-existing or unavailable player."""
 
     error_code = 10
+    translation_key = "errors.player_unavailable"
 
 
 class PlayerCommandFailed(MusicAssistantError):
     """Error raised when a command to a player failed execution."""
 
     error_code = 11
+    translation_key = "errors.player_command_failed"
 
 
 class InvalidCommand(MusicAssistantError):
     """Error raised when an unknown command is requested on the API."""
 
     error_code = 12
+    translation_key = "errors.invalid_command"
 
 
 class UnplayableMediaError(MusicAssistantError):
     """Error thrown when a MediaItem cannot be played properly."""
 
     error_code = 13
+    translation_key = "errors.unplayable_media"
 
 
 class InvalidProviderURI(MusicAssistantError):
     """Error thrown when a provider URI does not match a known format."""
 
     error_code = 14
+    translation_key = "errors.invalid_provider_uri"
 
 
 class InvalidProviderID(MusicAssistantError):
     """Error thrown when a provider media item identifier does not match a known format."""
 
     error_code = 15
+    translation_key = "errors.invalid_provider_id"
 
 
 class RetriesExhausted(MusicAssistantError):
     """Error thrown when a retries to a given provider URI have been exhausted."""
 
     error_code = 16
+    translation_key = "errors.retries_exhausted"
 
 
 class ResourceTemporarilyUnavailable(MusicAssistantError):
     """Error thrown when a resource is temporarily unavailable."""
 
-    def __init__(self, *args: object, backoff_time: int = 0) -> None:
-        """Initialize."""
-        super().__init__(*args)
-        self.backoff_time = backoff_time
-
     error_code = 17
+    translation_key = "errors.resource_temporarily_unavailable"
+
+    def __init__(self, *args: object, backoff_time: int = 0, **kwargs: Any) -> None:
+        """Initialize."""
+        super().__init__(*args, **kwargs)
+        self.backoff_time = backoff_time
 
 
 class ProviderPermissionDenied(MusicAssistantError):
     """Error thrown when a provider action is denied because of permissions."""
 
     error_code = 18
+    translation_key = "errors.provider_permission_denied"
 
 
 class ActionUnavailable(MusicAssistantError):
     """Error thrown when a action is denied because is is (temporary) unavailable/not possible."""
 
     error_code = 19
+    translation_key = "errors.action_unavailable"
 
 
 class AuthenticationRequired(MusicAssistantError):
     """Error raised when authentication is required but not provided."""
 
     error_code = 20
+    translation_key = "errors.authentication_required"
 
 
 class AuthenticationFailed(MusicAssistantError):
     """Error raised when authentication credentials are invalid."""
 
     error_code = 21
+    translation_key = "errors.authentication_failed"
 
 
 class InsufficientPermissions(MusicAssistantError):
     """Error raised when user lacks required permissions for an action."""
 
     error_code = 22
+    translation_key = "errors.insufficient_permissions"
 
 
 class InvalidToken(MusicAssistantError):
     """Error raised when an access token is invalid or expired."""
 
     error_code = 23
+    translation_key = "errors.invalid_token"
 
 
 class ResourceBusyError(MusicAssistantError):
@@ -170,6 +219,7 @@ class ResourceBusyError(MusicAssistantError):
     """
 
     error_code = 24
+    translation_key = "errors.resource_busy"
 
 
 class RateLimited(ResourceTemporarilyUnavailable):
@@ -181,3 +231,4 @@ class RateLimited(ResourceTemporarilyUnavailable):
     """
 
     error_code = 25
+    translation_key = "errors.rate_limited"

--- a/tests/test_error_translations.py
+++ b/tests/test_error_translations.py
@@ -1,0 +1,128 @@
+"""Tests for localized MusicAssistantError messages on ErrorResultMessage."""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+from music_assistant_models.api import ErrorResultMessage
+from music_assistant_models.errors import (
+    ERROR_MAP,
+    InvalidToken,
+    MediaNotFoundError,
+    MusicAssistantError,
+    ProviderUnavailableError,
+    RateLimited,
+    ResourceTemporarilyUnavailable,
+)
+from music_assistant_models.translations import TRANSLATION_RESOLVER
+
+# the strings a bound resolver would return for the keys the error message looks up
+_CATALOG = {
+    "errors.provider_unavailable": "De provider is niet beschikbaar.",
+    "errors.media_count": "{0} items niet gevonden",
+}
+
+
+@contextmanager
+def _resolver_active() -> Iterator[None]:
+    """Bind a fake catalog resolver for the duration of the block."""
+
+    def resolve(key: str, owner: str | None = None, params: list[Any] | None = None) -> str | None:
+        for candidate in [f"{owner}.{key}", key] if owner else [key]:
+            if (value := _CATALOG.get(candidate)) is not None:
+                return value.format(*params) if params else value
+        return None
+
+    token = TRANSLATION_RESOLVER.set(resolve)
+    try:
+        yield
+    finally:
+        TRANSLATION_RESOLVER.reset(token)
+
+
+def test_error_subclasses_expose_default_translation_key() -> None:
+    """Each standard error type carries its default translation key; the base stays None."""
+    assert MusicAssistantError.translation_key is None
+    assert ProviderUnavailableError.translation_key == "errors.provider_unavailable"
+    assert MediaNotFoundError.translation_key == "errors.media_not_found"
+    assert InvalidToken.translation_key == "errors.invalid_token"
+    # RateLimited subclasses ResourceTemporarilyUnavailable but defines its own key
+    assert RateLimited.translation_key == "errors.rate_limited"
+    # default key is readable on an instance too
+    assert ProviderUnavailableError("boom").translation_key == "errors.provider_unavailable"
+
+
+def test_error_per_instance_override() -> None:
+    """A per-instance translation_key/args overrides the type default; backoff is preserved."""
+    err = MediaNotFoundError(
+        "not found", translation_key="provider.demo.errors.x", translation_args=["a"]
+    )
+    assert err.translation_key == "provider.demo.errors.x"
+    assert err.translation_args == ["a"]
+    # custom-__init__ error forwards the translation kwargs and keeps backoff_time
+    rate = RateLimited("Spotify", backoff_time=30, translation_args=["Spotify"])
+    assert rate.translation_key == "errors.rate_limited"
+    assert rate.backoff_time == 30
+    assert rate.translation_args == ["Spotify"]
+    # raised with only a backoff and no message: str() is empty, default key carries the text
+    empty = ResourceTemporarilyUnavailable(backoff_time=5)
+    assert str(empty) == ""
+    assert empty.translation_key == "errors.resource_temporarily_unavailable"
+
+
+def test_error_result_message_localizes_details_and_strips_machinery() -> None:
+    """A bound resolver replaces `details` and strips the translation machinery from the wire."""
+    err = ProviderUnavailableError("Spotify is offline")
+    msg = ErrorResultMessage(
+        "abc",
+        err.error_code,
+        str(err),
+        translation_key=err.translation_key,
+        translation_args=err.translation_args,
+    )
+    with _resolver_active():
+        d = msg.to_dict()
+    assert d["details"] == "De provider is niet beschikbaar."
+    assert d["error_code"] == 1
+    assert d["message_id"] == "abc"
+    # machinery never reaches the client when a resolver is active
+    assert "translation_key" not in d
+    assert "translation_args" not in d
+
+
+def test_error_result_message_unknown_key_keeps_details() -> None:
+    """When the key does not resolve, the in-code `details` (str(err)) is kept."""
+    msg = ErrorResultMessage(
+        "abc", 2, "Track 123 not found", translation_key="errors.media_not_found"
+    )
+    with _resolver_active():
+        d = msg.to_dict()
+    assert d["details"] == "Track 123 not found"
+    assert "translation_key" not in d
+
+
+def test_error_result_message_plain_to_dict_keeps_machinery() -> None:
+    """Without a resolver bound the message keeps details + machinery (round-trip safe)."""
+    msg = ErrorResultMessage(
+        "abc", 1, "Spotify is offline", translation_key="errors.provider_unavailable"
+    )
+    d = msg.to_dict()
+    assert d["details"] == "Spotify is offline"
+    assert d["translation_key"] == "errors.provider_unavailable"
+    assert d["translation_args"] == []
+
+
+def test_error_result_message_substitutes_params() -> None:
+    """Positional translation_args fill {0}/{1} placeholders in the localized message."""
+    msg = ErrorResultMessage(
+        "abc", 2, "raw", translation_key="errors.media_count", translation_args=[3]
+    )
+    with _resolver_active():
+        d = msg.to_dict()
+    assert d["details"] == "3 items niet gevonden"
+
+
+def test_error_map_still_registers_all_subclasses() -> None:
+    """Adding the translation key does not disturb error_code registration."""
+    assert ERROR_MAP[1] is ProviderUnavailableError
+    assert ERROR_MAP[25] is RateLimited


### PR DESCRIPTION
## What & why

`MusicAssistantError` messages are sent to API clients as a plain string (`ErrorResultMessage.details`) and are never localized, unlike config entries, media items, manifests and background-task names. This adds the model-side hooks so the server can localize error messages at serialization.

## Changes

- `MusicAssistantError`: add a `translation_key` (per-type default, overridable per-instance) plus `translation_args`; each standard error type gets a default `errors.<name>` key.
- `ErrorResultMessage`: resolve `translation_key` into `details` in `__post_serialize__` and strip the translation machinery from the client payload, mirroring `BackgroundTask`.

Companion server PR (adds the `common.errors.*` strings and wires resolution into the websocket handler): music-assistant/server#4228
