### PR TITLE
Align ProviderInstance with the served wire format

### DIFF
--- a/music_assistant_models/provider.py
+++ b/music_assistant_models/provider.py
@@ -90,11 +90,6 @@ class ProviderInstance(DataClassORJSONMixin):
     instance_id: str
     supported_features: set[ProviderFeature]
     available: bool
-    icon: str | None = None
     is_streaming_provider: bool | None = None  # music providers only
-
-    def __post_serialize__(self, d: dict[Any, Any]) -> dict[Any, Any]:
-        """Execute action(s) on serialization."""
-        # add lookup_key for backwards compatibility
-        d["lookup_key"] = self.domain if self.is_streaming_provider else self.instance_id
-        return d
+    # lookup_key: kept for backwards compatibility; mirrors the server wire value (== instance_id)
+    lookup_key: str | None = None


### PR DESCRIPTION
`ProviderInstance` (the model API clients and the frontend are generated from) had drifted from what the server actually serializes via `Provider.to_dict`, so the declared schema no longer matched the wire format.

- Drop the dead `icon` field — the server never emits it (provider icons come from the manifest), so clients always received `null`.
- Drop the `__post_serialize__` that computed `lookup_key` as `domain` for streaming providers; the server always sends `instance_id`, and since `ProviderInstance` is never instantiated server-side the computed value was never actually sent.
- Declare `lookup_key` as a plain field that mirrors the served value (`instance_id`).

A companion server PR trims `Provider.to_dict` to match.