### PR TITLE
Add provider status reporting (ProviderStatus + structured errors)

### DIFF
--- a/music_assistant_models/config_entries.py
+++ b/music_assistant_models/config_entries.py
@@ -12,7 +12,7 @@ from typing import Any, Final, cast
 from mashumaro import DataClassDictMixin, field_options, pass_through
 
 from .constants import SECURE_STRING_SUBSTITUTE
-from .enums import ConfigEntryType, PlayerType, ProviderType
+from .enums import ConfigEntryType, PlayerType, ProviderStatus, ProviderType
 from .translations import resolve_translation
 
 LOGGER = logging.getLogger(__name__)
@@ -394,6 +394,25 @@ class Config(DataClassDictMixin):
 
 
 @dataclass
+class ProviderError(DataClassDictMixin):
+    """
+    Structured, localizable error describing why a provider failed to load.
+
+    Clients localize the message via translation_key/translation_args, falling back to
+    the (untranslated) message. error_code maps to a MusicAssistantError via ERROR_MAP.
+    """
+
+    # error_code: the MusicAssistantError.error_code (999 for non-MusicAssistant exceptions)
+    error_code: int
+    # message: untranslated fallback message (str(exc))
+    message: str
+    # translation_key: optional key to localize the message client-side
+    translation_key: str | None = None
+    # translation_args: positional arguments for {0}/{1} placeholders in the translated message
+    translation_args: list[Any] = field(default_factory=list)
+
+
+@dataclass
 class ProviderConfig(Config):
     """Provider(instance) Configuration."""
 
@@ -406,8 +425,25 @@ class ProviderConfig(Config):
     name: str | None = None
     # default_name: default name to use/persist when there is no name set by the user
     default_name: str | None = None
-    # last_error: an optional error message if the provider could not be setup with this config
-    last_error: str | None = None
+    # last_error: structured error if the provider could not be setup with this config
+    last_error: ProviderError | None = None
+    # status: load/lifecycle status, derived and stamped server-side on the api read path.
+    # Never persisted (see to_raw) and not set during normal config save/load.
+    status: ProviderStatus | None = None
+
+    @classmethod
+    def __pre_deserialize__(cls, d: dict[Any, Any]) -> dict[Any, Any]:
+        """Coerce a legacy string last_error (from older settings.json) into a ProviderError."""
+        last_error = d.get("last_error")
+        if isinstance(last_error, str):
+            d["last_error"] = {"error_code": 999, "message": last_error}
+        return d
+
+    def to_raw(self) -> dict[str, Any]:
+        """Return minimized/raw dict to store; the derived `status` is never persisted."""
+        res = super().to_raw()
+        res.pop("status", None)
+        return res
 
     def _translation_owner(self) -> str | None:
         return f"provider.{self.domain}"

--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -831,3 +831,25 @@ class CoreState(StrEnum):
     RUNNING = "running"
     STOPPING = "stopping"
     STOPPED = "stopped"
+
+
+class ProviderStatus(StrEnum):
+    """
+    Enum representing the load/lifecycle status of a provider (instance).
+
+    Derived server-side from the provider's config and (when present) its loaded instance.
+    Runtime reachability of a loaded provider is conveyed separately by ProviderInstance.available.
+    """
+
+    # loaded: setup succeeded; a live instance exists
+    LOADED = "loaded"
+    # loading: enabled and being (re)loaded, or waiting on a dependency; no instance yet, no error
+    LOADING = "loading"
+    # disabled: provider config exists but is disabled by the user
+    DISABLED = "disabled"
+    # auth_required: setup failed because (re)authentication is needed
+    AUTH_REQUIRED = "auth_required"
+    # incompatible: the host does not meet the provider's requirements (permanent)
+    INCOMPATIBLE = "incompatible"
+    # error: setup failed for any other reason (see the provider's last_error)
+    ERROR = "error"

--- a/music_assistant_models/errors.py
+++ b/music_assistant_models/errors.py
@@ -232,3 +232,16 @@ class RateLimited(ResourceTemporarilyUnavailable):
 
     error_code = 25
     translation_key = "errors.rate_limited"
+
+
+class UnsupportedSystemError(SetupFailedError):
+    """
+    Raised when the host does not meet a provider's minimum requirements.
+
+    Subclass of SetupFailedError so existing setup handling still applies, but it
+    marks a permanent condition (RAM, CPU cores, CPU capability) that will not
+    resolve at runtime, so the provider load must not be retried.
+    """
+
+    error_code = 26
+    translation_key = "errors.unsupported_system"

--- a/tests/test_error_translations.py
+++ b/tests/test_error_translations.py
@@ -13,6 +13,7 @@ from music_assistant_models.errors import (
     ProviderUnavailableError,
     RateLimited,
     ResourceTemporarilyUnavailable,
+    UnsupportedSystemError,
 )
 from music_assistant_models.translations import TRANSLATION_RESOLVER
 
@@ -48,6 +49,8 @@ def test_error_subclasses_expose_default_translation_key() -> None:
     assert InvalidToken.translation_key == "errors.invalid_token"
     # RateLimited subclasses ResourceTemporarilyUnavailable but defines its own key
     assert RateLimited.translation_key == "errors.rate_limited"
+    # UnsupportedSystemError subclasses SetupFailedError but defines its own key
+    assert UnsupportedSystemError.translation_key == "errors.unsupported_system"
     # default key is readable on an instance too
     assert ProviderUnavailableError("boom").translation_key == "errors.provider_unavailable"
 
@@ -126,3 +129,4 @@ def test_error_map_still_registers_all_subclasses() -> None:
     """Adding the translation key does not disturb error_code registration."""
     assert ERROR_MAP[1] is ProviderUnavailableError
     assert ERROR_MAP[25] is RateLimited
+    assert ERROR_MAP[26] is UnsupportedSystemError

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -1,0 +1,41 @@
+"""Tests for ProviderConfig structured error and derived status (de)serialization."""
+
+from typing import Any
+
+from music_assistant_models.config_entries import ProviderConfig, ProviderError
+from music_assistant_models.enums import ProviderStatus, ProviderType
+
+
+def _raw(**overrides: Any) -> dict[str, Any]:
+    """Minimal raw ProviderConfig dict as stored in settings.json."""
+    return {
+        "values": {},
+        "type": ProviderType.MUSIC.value,
+        "domain": "demo",
+        "instance_id": "demo--1",
+        **overrides,
+    }
+
+
+def test_legacy_string_last_error_is_coerced() -> None:
+    """A legacy string last_error (from older settings.json) deserializes into a ProviderError."""
+    conf = ProviderConfig.from_dict(_raw(last_error="kaboom"))
+    assert conf.last_error == ProviderError(error_code=999, message="kaboom")
+
+
+def test_structured_last_error_roundtrips() -> None:
+    """A structured last_error survives a from_dict/to_dict round-trip."""
+    err = ProviderError(
+        error_code=21, message="auth", translation_key="errors.authentication_failed"
+    )
+    conf = ProviderConfig.from_dict(_raw(last_error=err.to_dict()))
+    assert conf.last_error == err
+    assert conf.to_dict()["last_error"] == err.to_dict()
+
+
+def test_status_is_served_but_never_persisted() -> None:
+    """The derived status is part of the api payload (to_dict) but excluded from to_raw."""
+    conf = ProviderConfig.from_dict(_raw())
+    conf.status = ProviderStatus.LOADED
+    assert conf.to_dict()["status"] == ProviderStatus.LOADED.value
+    assert "status" not in conf.to_raw()


### PR DESCRIPTION
Adds the model foundation for reporting a provider's load/lifecycle status to clients, and makes a provider's failure reason machine-readable and localizable. Today clients can only infer state from `enabled` plus a free-text `last_error`, and failed/auth/incompatible providers (which never become a loaded instance) are described only by a string.

- Add `ProviderStatus` (loaded / loading / disabled / auth_required / incompatible / error).
- Add `ProviderError` (error_code + message + translation_key + translation_args) and change `ProviderConfig.last_error` from a string to it. A `__pre_deserialize__` hook coerces legacy string values, so no settings migration is needed.
- Add a derived `ProviderConfig.status`, stamped server-side and excluded from `to_raw()` so it is never persisted.
- Move `UnsupportedSystemError` into the models package (`error_code` 26) so the `incompatible` status can be derived from the error code.

Server and frontend changes that consume these will follow in companion PRs.