### PR TITLE
Localize ProviderError server-side

### DIFF
--- a/music_assistant_models/config_entries.py
+++ b/music_assistant_models/config_entries.py
@@ -13,7 +13,7 @@ from mashumaro import DataClassDictMixin, field_options, pass_through
 
 from .constants import SECURE_STRING_SUBSTITUTE
 from .enums import ConfigEntryType, PlayerType, ProviderStatus, ProviderType
-from .translations import resolve_translation
+from .translations import resolve_translation, translations_active
 
 LOGGER = logging.getLogger(__name__)
 
@@ -395,21 +395,24 @@ class Config(DataClassDictMixin):
 
 @dataclass
 class ProviderError(DataClassDictMixin):
-    """
-    Structured, localizable error describing why a provider failed to load.
+    """Structured, localizable error describing why a provider failed to load."""
 
-    Clients localize the message via translation_key/translation_args, falling back to
-    the (untranslated) message. error_code maps to a MusicAssistantError via ERROR_MAP.
-    """
-
-    # error_code: the MusicAssistantError.error_code (999 for non-MusicAssistant exceptions)
-    error_code: int
-    # message: untranslated fallback message (str(exc))
+    error_code: int  # MusicAssistantError.error_code; 999 for non-MusicAssistant exceptions
     message: str
-    # translation_key: optional key to localize the message client-side
     translation_key: str | None = None
-    # translation_args: positional arguments for {0}/{1} placeholders in the translated message
     translation_args: list[Any] = field(default_factory=list)
+
+    def __post_serialize__(self, d: dict[str, Any]) -> dict[str, Any]:
+        """Localize `message` from translation_key when a resolver is active; strip machinery."""
+        if self.translation_key:
+            params = [str(a) for a in self.translation_args] if self.translation_args else None
+            localized = resolve_translation(self.translation_key, params=params)
+            if localized is not None:
+                d["message"] = localized
+        if translations_active():
+            d.pop("translation_key", None)
+            d.pop("translation_args", None)
+        return d
 
 
 @dataclass

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -1,9 +1,29 @@
 """Tests for ProviderConfig structured error and derived status (de)serialization."""
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import Any
 
 from music_assistant_models.config_entries import ProviderConfig, ProviderError
 from music_assistant_models.enums import ProviderStatus, ProviderType
+from music_assistant_models.translations import TRANSLATION_RESOLVER
+
+
+@contextmanager
+def _resolver_active(catalog: dict[str, str]) -> Iterator[None]:
+    """Bind a fake catalog resolver for the duration of the block."""
+
+    def resolve(key: str, owner: str | None = None, params: list[Any] | None = None) -> str | None:
+        for candidate in [f"{owner}.{key}", key] if owner else [key]:
+            if (value := catalog.get(candidate)) is not None:
+                return value.format(*params) if params else value
+        return None
+
+    token = TRANSLATION_RESOLVER.set(resolve)
+    try:
+        yield
+    finally:
+        TRANSLATION_RESOLVER.reset(token)
 
 
 def _raw(**overrides: Any) -> dict[str, Any]:
@@ -39,3 +59,33 @@ def test_status_is_served_but_never_persisted() -> None:
     conf.status = ProviderStatus.LOADED
     assert conf.to_dict()["status"] == ProviderStatus.LOADED.value
     assert "status" not in conf.to_raw()
+
+
+def test_last_error_localized_on_serialize_with_resolver() -> None:
+    """With a resolver active, last_error.message is localized and the machinery is stripped."""
+    err = ProviderError(
+        error_code=26,
+        message="raw English",
+        translation_key="errors.unsupported_system_cpu",
+        translation_args=["Smart Fades", 4, 2],
+    )
+    conf = ProviderConfig.from_dict(_raw(last_error=err.to_dict()))
+    with _resolver_active({"errors.unsupported_system_cpu": "{0} needs {1} cores ({2} detected)"}):
+        served = conf.to_dict()["last_error"]
+    assert served["message"] == "Smart Fades needs 4 cores (2 detected)"
+    assert "translation_key" not in served
+    assert "translation_args" not in served
+
+
+def test_last_error_raw_without_resolver() -> None:
+    """Without a resolver (e.g. during persistence) the raw message + machinery are preserved."""
+    err = ProviderError(
+        error_code=26,
+        message="raw English",
+        translation_key="errors.unsupported_system_cpu",
+        translation_args=["Smart Fades", 4, 2],
+    )
+    served = ProviderConfig.from_dict(_raw(last_error=err.to_dict())).to_dict()["last_error"]
+    assert served["message"] == "raw English"
+    assert served["translation_key"] == "errors.unsupported_system_cpu"
+    assert served["translation_args"] == ["Smart Fades", 4, 2]


### PR DESCRIPTION
Localize `ProviderError` server-side, consistent with `ErrorResultMessage` and the rest of the server-owned i18n.

`ProviderError.__post_serialize__` resolves `message` from `translation_key` (for the connection's locale) during outbound API serialization and strips `translation_key`/`translation_args` from the payload when a resolver is active. During persistence (no resolver) the raw message + machinery are preserved, so it re-localizes per locale on each read.

Lets clients render `last_error.message` directly instead of localizing client-side (companion frontend change drops the client-side helper).