### PR TITLE
Localize PlayerOption and PlayerSoundMode labels server-side

### DIFF
--- a/music_assistant_models/player.py
+++ b/music_assistant_models/player.py
@@ -12,6 +12,7 @@ from mashumaro import DataClassDictMixin
 from .constants import EXTRA_ATTRIBUTES_TYPES, PLAYER_CONTROL_NONE
 from .enums import IdentifierType, MediaType, PlaybackState, PlayerFeature, PlayerType
 from .media_items import MediaItemPalette
+from .translations import resolve_translation, translations_active
 from .unique_list import UniqueList
 
 
@@ -169,6 +170,15 @@ class PlayerSoundMode(DataClassDictMixin):
         if not self.translation_key:
             self.translation_key = self.id
 
+    def __post_serialize__(self, d: dict[str, Any]) -> dict[str, Any]:
+        """Localize the sound mode name from its translation_key when a resolver is active."""
+        localized = resolve_translation(f"sound_mode.{self.translation_key}.name")
+        if localized is not None:
+            d["name"] = localized
+        # translation_key is kept on the wire: the Home Assistant integration relies on it
+        # as a stable identifier, so (unlike other models) it is not stripped here.
+        return d
+
 
 class PlayerOptionType(StrEnum):
     """Enum for the type of a Player Option."""
@@ -256,6 +266,22 @@ class PlayerOption(DataClassDictMixin):
                 f"Value {self.value} must be of type {PlayerOptionTypeMap[self.type]} "
                 "if type is {self.type}"
             )
+
+    def __post_serialize__(self, d: dict[str, Any]) -> dict[str, Any]:
+        """Localize the option name and option titles when a resolver is active."""
+        base = f"player_options.{self.translation_key}"
+        localized = resolve_translation(f"{base}.name", params=self.translation_params)
+        if localized is not None:
+            d["name"] = localized
+        for option_dict, option in zip(d.get("options") or [], self.options or [], strict=False):
+            option_name = resolve_translation(f"{base}.options.{option.translation_key}")
+            if option_name is not None:
+                option_dict["name"] = option_name
+        # translation_key is kept on the wire (the Home Assistant integration relies on it as a
+        # stable identifier); only the resolution input is stripped from localized API output.
+        if translations_active():
+            d.pop("translation_params", None)
+        return d
 
 
 @dataclass

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -8,6 +8,12 @@ from music_assistant_models.background_task import BackgroundTask
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption
 from music_assistant_models.enums import ConfigEntryType, ProviderType
 from music_assistant_models.media_items import BrowseFolder, Genre, RecommendationFolder
+from music_assistant_models.player import (
+    PlayerOption,
+    PlayerOptionEntry,
+    PlayerOptionType,
+    PlayerSoundMode,
+)
 from music_assistant_models.provider import ProviderManifest
 from music_assistant_models.translations import TRANSLATION_RESOLVER
 
@@ -24,6 +30,10 @@ _CATALOG = {
     "provider.demo.manifest.description": "Een demoprovider.",
     "background_task.database_cleanup": "Database opschonen",
     "background_task.update_metadata": "Metadata bijwerken voor {0}",
+    "player_options.surround_decoder_type.name": "Type surround-decoder",
+    "player_options.surround_decoder_type.options.auto": "Automatisch",
+    "player_options.sleep.name": "Slaaptimer na {0} minuten",
+    "sound_mode.stereo.name": "Stereo (NL)",
 }
 
 
@@ -163,6 +173,59 @@ def test_background_task_interpolates_translation_args() -> None:
     with _resolver_active():
         localized = task.to_dict()
     assert localized["name"] == "Metadata bijwerken voor My Playlist"
+
+
+def test_player_option_resolves_name_and_titles_keeps_translation_key() -> None:
+    """A PlayerOption localizes its name + option titles but keeps translation_key for HA."""
+    option = PlayerOption(
+        key="surround_decoder_type",
+        name="Surround decoder type",
+        type=PlayerOptionType.STRING,
+        value="auto",
+        options=[
+            PlayerOptionEntry(key="auto", name="Auto", type=PlayerOptionType.STRING, value="auto"),
+        ],
+    )
+    # plain to_dict keeps the in-code values and the translation machinery
+    plain = option.to_dict()
+    assert plain["name"] == "Surround decoder type"
+    assert plain["translation_key"] == "surround_decoder_type"
+    assert plain["options"][0]["name"] == "Auto"
+    assert "translation_params" in plain
+    # resolver bound -> localized name + option title; translation_key kept (HA depends on it)
+    with _resolver_active():
+        localized = option.to_dict()
+    assert localized["name"] == "Type surround-decoder"
+    assert localized["options"][0]["name"] == "Automatisch"
+    assert localized["translation_key"] == "surround_decoder_type"
+    assert localized["options"][0]["translation_key"] == "auto"
+    assert "translation_params" not in localized
+
+
+def test_player_option_interpolates_translation_params() -> None:
+    """translation_params fill positional placeholders in the resolved option name."""
+    option = PlayerOption(
+        key="sleep",
+        name="Sleep timer",
+        type=PlayerOptionType.INTEGER,
+        value=30,
+        translation_params=["30"],
+    )
+    with _resolver_active():
+        assert option.to_dict()["name"] == "Slaaptimer na 30 minuten"
+
+
+def test_player_sound_mode_resolves_name_and_keeps_translation_key() -> None:
+    """A PlayerSoundMode localizes its name but keeps translation_key for the HA integration."""
+    sound_mode = PlayerSoundMode(id="stereo", name="Stereo", translation_key="stereo")
+    plain = sound_mode.to_dict()
+    assert plain["name"] == "Stereo"
+    assert plain["translation_key"] == "stereo"
+    with _resolver_active():
+        localized = sound_mode.to_dict()
+    assert localized["name"] == "Stereo (NL)"
+    # translation_key is kept on the wire for the HA integration
+    assert localized["translation_key"] == "stereo"
 
 
 def test_config_value_option_value_first() -> None:


### PR DESCRIPTION
## Problem

`PlayerOption`, `PlayerOptionEntry` and `PlayerSoundMode` already carry a `translation_key`, but their labels were only ever translated client-side by the frontend. That left them out of the server-owned i18n system already used by `ConfigEntry`, `BackgroundTask` and media items.

## Changes

- Add a `__post_serialize__` hook to `PlayerSoundMode` and `PlayerOption` that resolves the display `name` (and select-option titles) from the translation catalog when a resolver is active, mirroring the `ConfigEntry`/`BackgroundTask` pattern.
- Deliberately **keep** `translation_key` on the wire: the Home Assistant integration relies on it as a stable identifier (entity keys + option filtering), so — unlike the other localized models — it is not stripped. Only the resolution input (`translation_params`) is dropped from localized output.
- Add tests covering name/title resolution, `translation_params` interpolation, and that `translation_key` survives serialization.

Companion PRs: music-assistant/server#4262 (translation strings) and music-assistant/frontend#1932 (frontend cleanup).
