### PR TITLE
Localize core controller manifest name & description

### DIFF
--- a/music_assistant_models/provider.py
+++ b/music_assistant_models/provider.py
@@ -71,10 +71,12 @@ class ProviderManifest(DataClassORJSONMixin):
 
     def __post_serialize__(self, d: dict[Any, Any]) -> dict[Any, Any]:
         """Localize name/description when a translation resolver is set (no-op otherwise)."""
-        if (value := resolve_translation(f"provider.{self.domain}.manifest.name")) is not None:
+        # core controllers use the core.<domain> namespace, providers use provider.<domain>
+        namespace = "core" if self.type == ProviderType.CORE else "provider"
+        if (value := resolve_translation(f"{namespace}.{self.domain}.manifest.name")) is not None:
             d["name"] = value
         if (
-            value := resolve_translation(f"provider.{self.domain}.manifest.description")
+            value := resolve_translation(f"{namespace}.{self.domain}.manifest.description")
         ) is not None:
             d["description"] = value
         return d

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -22,6 +22,8 @@ _CATALOG = {
     "media.genre.jazz.description": "Jazz is een Amerikaans muziekgenre.",
     "provider.demo.manifest.name": "Demo-muziekprovider",
     "provider.demo.manifest.description": "Een demoprovider.",
+    "core.cache.manifest.name": "Cache (NL)",
+    "core.cache.manifest.description": "Cache-configuratie.",
     "background_task.database_cleanup": "Database opschonen",
     "background_task.update_metadata": "Metadata bijwerken voor {0}",
 }
@@ -134,6 +136,22 @@ def test_provider_manifest_resolves_name_and_description() -> None:
         localized = manifest.to_dict()
     assert localized["name"] == "Demo-muziekprovider"
     assert localized["description"] == "Een demoprovider."
+
+
+def test_core_manifest_resolves_under_core_namespace() -> None:
+    """A CORE manifest resolves name/description from core.<domain>.manifest.*."""
+    manifest = ProviderManifest(
+        type=ProviderType.CORE,
+        domain="cache",
+        name="Cache",
+        description="Cache configuration.",
+        codeowners=[],
+    )
+    assert manifest.to_dict()["name"] == "Cache"
+    with _resolver_active():
+        localized = manifest.to_dict()
+    assert localized["name"] == "Cache (NL)"
+    assert localized["description"] == "Cache-configuratie."
 
 
 def test_background_task_resolves_name_and_strips_machinery() -> None:


### PR DESCRIPTION
## Problem
Core controllers expose their name/description through a `ProviderManifest` (type `core`), but `__post_serialize__` always resolved translations under `provider.<domain>.manifest.*`. Core controller strings are authored under the `core.<domain>` namespace (per the server's `build_translations`), so core module names/descriptions could never be localized server-side — leaving the frontend to translate them client-side.

## Changes
- Resolve `ProviderManifest` name/description under `core.<domain>.manifest.*` for `ProviderType.CORE`; providers keep `provider.<domain>.manifest.*`.
- Add a test covering core-namespace resolution.

Companion server PR: music-assistant/server#4261