### PR TITLE
Add translation_owner to BackgroundTask, PlayerOption and PlayerSoundMode

### DIFF
--- a/music_assistant_models/background_task.py
+++ b/music_assistant_models/background_task.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 from typing import Any
 from uuid import uuid4
 
-from mashumaro import DataClassDictMixin
+from mashumaro import DataClassDictMixin, field_options
 
 from .enums import TaskScheduleType, TaskStatus
 from .translations import resolve_translation, translations_active
@@ -166,6 +166,11 @@ class BackgroundTask(DataClassDictMixin):
     allow_retry: bool = False
     # Whether queued/running work can be interrupted from the UI.
     allow_cancel: bool = True
+    # translation_owner: namespace ("provider.<domain>"/"core.<domain>") the task's
+    # translation_key resolves under; stamped by the tasks controller. Not serialized.
+    translation_owner: str | None = field(
+        default=None, metadata=field_options(serialize="omit"), repr=False
+    )
 
     def __post_init__(self) -> None:
         """Validate background task fields."""
@@ -178,7 +183,9 @@ class BackgroundTask(DataClassDictMixin):
         """Localize the task name from its translation_key when a resolver is active."""
         if self.translation_key:
             params = [str(a) for a in self.translation_args] if self.translation_args else None
-            localized = resolve_translation(self.translation_key, params=params)
+            localized = resolve_translation(
+                self.translation_key, owner=self.translation_owner, params=params
+            )
             if localized is not None:
                 d["name"] = localized
         if translations_active():

--- a/music_assistant_models/player.py
+++ b/music_assistant_models/player.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Any
 
-from mashumaro import DataClassDictMixin
+from mashumaro import DataClassDictMixin, field_options
 
 from .constants import EXTRA_ATTRIBUTES_TYPES, PLAYER_CONTROL_NONE
 from .enums import IdentifierType, MediaType, PlaybackState, PlayerFeature, PlayerType
@@ -160,6 +160,11 @@ class PlayerSoundMode(DataClassDictMixin):
     # optional translation key
     # defaults to id
     translation_key: str = ""
+    # translation_owner: namespace ("provider.<domain>"/"core.<domain>") the sound mode's
+    # strings resolve under; stamped by the player provider/controller. Not serialized.
+    translation_owner: str | None = field(
+        default=None, metadata=field_options(serialize="omit"), repr=False
+    )
 
     def __hash__(self) -> int:
         """Return custom hash."""
@@ -172,7 +177,9 @@ class PlayerSoundMode(DataClassDictMixin):
 
     def __post_serialize__(self, d: dict[str, Any]) -> dict[str, Any]:
         """Localize the sound mode name from its translation_key when a resolver is active."""
-        localized = resolve_translation(f"sound_mode.{self.translation_key}.name")
+        localized = resolve_translation(
+            f"sound_mode.{self.translation_key}.name", owner=self.translation_owner
+        )
         if localized is not None:
             d["name"] = localized
         # translation_key is kept on the wire: the Home Assistant integration relies on it
@@ -239,6 +246,11 @@ class PlayerOption(DataClassDictMixin):
     translation_key: str = ""
     # translation_params: optional parameters for the translation key
     translation_params: list[str] | None = None
+    # translation_owner: namespace ("provider.<domain>"/"core.<domain>") the option's
+    # strings resolve under; stamped by the player provider/controller. Not serialized.
+    translation_owner: str | None = field(
+        default=None, metadata=field_options(serialize="omit"), repr=False
+    )
 
     # current value of the option, see PlayerOptionValueType for serialization order.
     value: PlayerOptionValueType
@@ -270,11 +282,15 @@ class PlayerOption(DataClassDictMixin):
     def __post_serialize__(self, d: dict[str, Any]) -> dict[str, Any]:
         """Localize the option name and option titles when a resolver is active."""
         base = f"player_options.{self.translation_key}"
-        localized = resolve_translation(f"{base}.name", params=self.translation_params)
+        localized = resolve_translation(
+            f"{base}.name", owner=self.translation_owner, params=self.translation_params
+        )
         if localized is not None:
             d["name"] = localized
         for option_dict, option in zip(d.get("options") or [], self.options or [], strict=False):
-            option_name = resolve_translation(f"{base}.options.{option.translation_key}")
+            option_name = resolve_translation(
+                f"{base}.options.{option.translation_key}", owner=self.translation_owner
+            )
             if option_name is not None:
                 option_dict["name"] = option_name
         # translation_key is kept on the wire (the Home Assistant integration relies on it as a


### PR DESCRIPTION
# What does this implement/fix?

`BackgroundTask`, `PlayerOption` and `PlayerSoundMode` currently resolve their `translation_key` with **no owner**, so their strings can only be resolved from the global `common.*` namespace — unlike `ConfigEntry`, whose strings resolve under the owning module (`core.<domain>` / `provider.<domain>`).

This adds a (non-serialized) `translation_owner` to those three models, mirroring `ConfigEntry`, and passes it to `resolve_translation` in their `__post_serialize__`. With it, a provider's or core controller's task / player-option / sound-mode strings can live in that module's own `strings.json` (resolved under `provider.<domain>` / `core.<domain>`), with the common file kept as the fallback.

Backwards compatible: `translation_owner` defaults to `None` (current behaviour — resolves via `common.*`). The server side (stamping the owner + moving strings into per-module `strings.json`) lands separately and consumes this.

- `BackgroundTask`: `translation_owner` field + owner passed in `__post_serialize__`
- `PlayerOption`: same (covers the option name and its option titles)
- `PlayerSoundMode`: same

## Types of changes

- [x] Enhancement to an existing feature — `enhancement`