### PR TITLE
ConfigEntry translation_key is a bare slug under its group

### DIFF
--- a/music_assistant_models/api.py
+++ b/music_assistant_models/api.py
@@ -44,22 +44,27 @@ class ErrorResultMessage(ResultMessageBase):
 
     error_code: int
     details: str | None = None
-    # translation_key + translation_args localize `details` for the connection's locale during
-    # outbound API serialization (resolved in __post_serialize__); both are stripped from the
-    # client payload when a resolver is active.
+    # translation_key (a bare slug) + translation_args + translation_owner localize `details` for
+    # the connection's locale during outbound API serialization: __post_serialize__ derives the
+    # `errors.<slug>` group and resolves it owner-first then against common. All three are stripped
+    # from the client payload when a resolver is active.
     translation_key: str | None = None
     translation_args: list[Any] = field(default_factory=list)
+    translation_owner: str | None = None
 
     def __post_serialize__(self, d: dict[str, Any]) -> dict[str, Any]:
         """Localize `details` from the translation_key when a resolver is active."""
         if self.translation_key:
             params = [str(a) for a in self.translation_args] if self.translation_args else None
-            localized = resolve_translation(self.translation_key, params=params)
+            localized = resolve_translation(
+                f"errors.{self.translation_key}", owner=self.translation_owner, params=params
+            )
             if localized is not None:
                 d["details"] = localized
         if translations_active():
             d.pop("translation_key", None)
             d.pop("translation_args", None)
+            d.pop("translation_owner", None)
         return d
 
 

--- a/music_assistant_models/config_entries.py
+++ b/music_assistant_models/config_entries.py
@@ -20,6 +20,25 @@ LOGGER = logging.getLogger(__name__)
 ENCRYPT_CALLBACK: Callable[[str], str] | None = None
 DECRYPT_CALLBACK: Callable[[str], str] | None = None
 
+# translation keys/overrides starting with one of these are already fully qualified
+_FQ_TRANSLATION_PREFIXES = ("provider.", "core.", "common.")
+
+
+def _localized_base(override: str | None, key: str, group: str) -> str:
+    """
+    Return the translations base for a localized config field.
+
+    The base is the bare ``key`` (or an explicit ``override``) under ``group`` — e.g.
+    ``config_entries.<key>``. A fully-qualified override (``provider.``/``core.``/``common.``) is
+    used as-is so it can reuse a shared string defined elsewhere.
+
+    :param override: Optional caller-supplied key; the bare slug, not the group-qualified path.
+    :param key: The entry's own key (or category) used when no override is given.
+    :param group: The localization group the slug lives under (e.g. ``config_entries``).
+    """
+    base = override if override is not None else key
+    return base if base.startswith(_FQ_TRANSLATION_PREFIXES) else f"{group}.{base}"
+
 
 _ConfigValueTypeSingle = (
     # order is important here for the (de)serialization!
@@ -181,12 +200,13 @@ class ConfigEntry(DataClassDictMixin):
         Localize human-readable fields from the translations for the connection locale.
 
         Resolves label/description/option titles and the category name under this entry's owner
-        namespace (keyed by config_entries.<key> / config_categories.<category>, or a server-set
-        translation_key/category_translation_key override). No-op when nothing matches, so the
-        in-code values are kept. The translation machinery fields are not serialized.
+        namespace (keyed by config_entries.<key> / config_categories.<category>). A server-set
+        translation_key/category_translation_key override is the bare slug under that same group,
+        unless it is fully qualified. No-op when nothing matches, so the in-code values are kept.
+        The translation machinery fields are not serialized.
         """
         owner = self.translation_owner
-        base = self.translation_key or f"config_entries.{self.key}"
+        base = _localized_base(self.translation_key, self.key, "config_entries")
         label = resolve_translation(f"{base}.label", owner=owner, params=self.translation_params)
         if label is not None:
             d["label"] = label
@@ -203,7 +223,9 @@ class ConfigEntry(DataClassDictMixin):
             title = resolve_translation(f"{base}.options.{option.value}", owner=owner)
             if title is not None:
                 option_dict["title"] = title
-        category_key = self.category_translation_key or f"config_categories.{self.category}"
+        category_key = _localized_base(
+            self.category_translation_key, self.category, "config_categories"
+        )
         category_label = resolve_translation(
             category_key, owner=owner, params=self.category_translation_params
         )

--- a/music_assistant_models/config_entries.py
+++ b/music_assistant_models/config_entries.py
@@ -416,19 +416,27 @@ class ProviderError(DataClassDictMixin):
 
     error_code: int  # MusicAssistantError.error_code; 999 for non-MusicAssistant exceptions
     message: str
+    # translation_key: optional bare slug to localize the message; __post_serialize__ derives the
+    # errors.<slug> group and resolves it owner-first then common (mirrors ErrorResultMessage)
     translation_key: str | None = None
     translation_args: list[Any] = field(default_factory=list)
+    # translation_owner: owning namespace ("provider.<domain>"/"core.<domain>") consulted before
+    # common — set when a provider/controller defines its own message for the key
+    translation_owner: str | None = None
 
     def __post_serialize__(self, d: dict[str, Any]) -> dict[str, Any]:
         """Localize `message` from translation_key when a resolver is active; strip machinery."""
         if self.translation_key:
             params = [str(a) for a in self.translation_args] if self.translation_args else None
-            localized = resolve_translation(self.translation_key, params=params)
+            localized = resolve_translation(
+                f"errors.{self.translation_key}", owner=self.translation_owner, params=params
+            )
             if localized is not None:
                 d["message"] = localized
         if translations_active():
             d.pop("translation_key", None)
             d.pop("translation_args", None)
+            d.pop("translation_owner", None)
         return d
 
 

--- a/music_assistant_models/config_entries.py
+++ b/music_assistant_models/config_entries.py
@@ -20,24 +20,19 @@ LOGGER = logging.getLogger(__name__)
 ENCRYPT_CALLBACK: Callable[[str], str] | None = None
 DECRYPT_CALLBACK: Callable[[str], str] | None = None
 
-# translation keys/overrides starting with one of these are already fully qualified
-_FQ_TRANSLATION_PREFIXES = ("provider.", "core.", "common.")
-
 
 def _localized_base(override: str | None, key: str, group: str) -> str:
     """
-    Return the translations base for a localized config field.
+    Return the translations base ``<group>.<slug>`` for a localized config field.
 
-    The base is the bare ``key`` (or an explicit ``override``) under ``group`` — e.g.
-    ``config_entries.<key>``. A fully-qualified override (``provider.``/``core.``/``common.``) is
-    used as-is so it can reuse a shared string defined elsewhere.
+    The slug is the explicit ``override`` (a bare key, never a group-qualified path) or, by
+    default, the entry's own ``key``/category — the group is always derived from the model.
 
-    :param override: Optional caller-supplied key; the bare slug, not the group-qualified path.
+    :param override: Optional caller-supplied key (a bare slug).
     :param key: The entry's own key (or category) used when no override is given.
     :param group: The localization group the slug lives under (e.g. ``config_entries``).
     """
-    base = override if override is not None else key
-    return base if base.startswith(_FQ_TRANSLATION_PREFIXES) else f"{group}.{base}"
+    return f"{group}.{override if override is not None else key}"
 
 
 _ConfigValueTypeSingle = (

--- a/music_assistant_models/errors.py
+++ b/music_assistant_models/errors.py
@@ -7,30 +7,39 @@ class MusicAssistantError(Exception):
     """Custom Exception for all errors."""
 
     error_code = 0
-    # Default translation key for this error type, resolved against the server's
-    # `common.errors.*` strings during outbound API serialization to localize the message
-    # shown to clients. Subclasses set their own default; callers may override the key (and
-    # provide positional args for {0}/{1} placeholders) per-instance via the constructor.
+    # Default translation key for this error type: a bare slug (e.g. ``media_not_found``). During
+    # outbound API serialization the error model derives the ``errors.<slug>`` group and resolves
+    # it owner-first then against the server's ``common.errors.*`` strings to localize the message
+    # shown to clients. Subclasses set their own default; callers may override the key (and provide
+    # an owning provider/controller and positional args for {0}/{1} placeholders) per-instance.
     translation_key: str | None = None
+    # Owning namespace ("provider.<domain>"/"core.<domain>") whose strings.json is consulted before
+    # falling back to common — set when a provider/controller defines its own message for the key.
+    translation_owner: str | None = None
 
     def __init__(
         self,
         *args: object,
         translation_key: str | None = None,
         translation_args: list[Any] | None = None,
+        translation_owner: str | None = None,
     ) -> None:
         """
         Initialize the error.
 
         :param translation_key: Optional per-instance override of the error type's default
-            translation key, used to localize the message shown to API clients.
+            translation key (a bare slug), used to localize the message shown to API clients.
         :param translation_args: Optional positional arguments for {0}/{1} placeholders in the
             translated message.
+        :param translation_owner: Optional owning namespace ("provider.<domain>"/"core.<domain>")
+            consulted before common when resolving the key.
         """
         super().__init__(*args)
         if translation_key is not None:
             self.translation_key = translation_key
         self.translation_args: list[Any] = translation_args or []
+        if translation_owner is not None:
+            self.translation_owner = translation_owner
 
     def __init_subclass__(cls, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
         """Register a subclass."""
@@ -46,119 +55,119 @@ class ProviderUnavailableError(MusicAssistantError):
     """Error raised when trying to access mediaitem of unavailable provider."""
 
     error_code = 1
-    translation_key = "errors.provider_unavailable"
+    translation_key = "provider_unavailable"
 
 
 class MediaNotFoundError(MusicAssistantError):
     """Error raised when trying to access non existing media item."""
 
     error_code = 2
-    translation_key = "errors.media_not_found"
+    translation_key = "media_not_found"
 
 
 class InvalidDataError(MusicAssistantError):
     """Error raised when an object has invalid data."""
 
     error_code = 3
-    translation_key = "errors.invalid_data"
+    translation_key = "invalid_data"
 
 
 class AlreadyRegisteredError(MusicAssistantError):
     """Error raised when a duplicate music provider or player is registered."""
 
     error_code = 4
-    translation_key = "errors.already_registered"
+    translation_key = "already_registered"
 
 
 class SetupFailedError(MusicAssistantError):
     """Error raised when setup of a provider or player failed."""
 
     error_code = 5
-    translation_key = "errors.setup_failed"
+    translation_key = "setup_failed"
 
 
 class LoginFailed(MusicAssistantError):
     """Error raised when a login failed."""
 
     error_code = 6
-    translation_key = "errors.login_failed"
+    translation_key = "login_failed"
 
 
 class AudioError(MusicAssistantError):
     """Error raised when an issue arose when processing audio."""
 
     error_code = 7
-    translation_key = "errors.audio_error"
+    translation_key = "audio_error"
 
 
 class QueueEmpty(MusicAssistantError):
     """Error raised when trying to start queue stream while queue is empty."""
 
     error_code = 8
-    translation_key = "errors.queue_empty"
+    translation_key = "queue_empty"
 
 
 class UnsupportedFeaturedException(MusicAssistantError):
     """Error raised when a feature is not supported."""
 
     error_code = 9
-    translation_key = "errors.unsupported_feature"
+    translation_key = "unsupported_feature"
 
 
 class PlayerUnavailableError(MusicAssistantError):
     """Error raised when trying to access non-existing or unavailable player."""
 
     error_code = 10
-    translation_key = "errors.player_unavailable"
+    translation_key = "player_unavailable"
 
 
 class PlayerCommandFailed(MusicAssistantError):
     """Error raised when a command to a player failed execution."""
 
     error_code = 11
-    translation_key = "errors.player_command_failed"
+    translation_key = "player_command_failed"
 
 
 class InvalidCommand(MusicAssistantError):
     """Error raised when an unknown command is requested on the API."""
 
     error_code = 12
-    translation_key = "errors.invalid_command"
+    translation_key = "invalid_command"
 
 
 class UnplayableMediaError(MusicAssistantError):
     """Error thrown when a MediaItem cannot be played properly."""
 
     error_code = 13
-    translation_key = "errors.unplayable_media"
+    translation_key = "unplayable_media"
 
 
 class InvalidProviderURI(MusicAssistantError):
     """Error thrown when a provider URI does not match a known format."""
 
     error_code = 14
-    translation_key = "errors.invalid_provider_uri"
+    translation_key = "invalid_provider_uri"
 
 
 class InvalidProviderID(MusicAssistantError):
     """Error thrown when a provider media item identifier does not match a known format."""
 
     error_code = 15
-    translation_key = "errors.invalid_provider_id"
+    translation_key = "invalid_provider_id"
 
 
 class RetriesExhausted(MusicAssistantError):
     """Error thrown when a retries to a given provider URI have been exhausted."""
 
     error_code = 16
-    translation_key = "errors.retries_exhausted"
+    translation_key = "retries_exhausted"
 
 
 class ResourceTemporarilyUnavailable(MusicAssistantError):
     """Error thrown when a resource is temporarily unavailable."""
 
     error_code = 17
-    translation_key = "errors.resource_temporarily_unavailable"
+    translation_key = "resource_temporarily_unavailable"
 
     def __init__(self, *args: object, backoff_time: int = 0, **kwargs: Any) -> None:
         """Initialize."""
@@ -170,42 +179,42 @@ class ProviderPermissionDenied(MusicAssistantError):
     """Error thrown when a provider action is denied because of permissions."""
 
     error_code = 18
-    translation_key = "errors.provider_permission_denied"
+    translation_key = "provider_permission_denied"
 
 
 class ActionUnavailable(MusicAssistantError):
     """Error thrown when a action is denied because is is (temporary) unavailable/not possible."""
 
     error_code = 19
-    translation_key = "errors.action_unavailable"
+    translation_key = "action_unavailable"
 
 
 class AuthenticationRequired(MusicAssistantError):
     """Error raised when authentication is required but not provided."""
 
     error_code = 20
-    translation_key = "errors.authentication_required"
+    translation_key = "authentication_required"
 
 
 class AuthenticationFailed(MusicAssistantError):
     """Error raised when authentication credentials are invalid."""
 
     error_code = 21
-    translation_key = "errors.authentication_failed"
+    translation_key = "authentication_failed"
 
 
 class InsufficientPermissions(MusicAssistantError):
     """Error raised when user lacks required permissions for an action."""
 
     error_code = 22
-    translation_key = "errors.insufficient_permissions"
+    translation_key = "insufficient_permissions"
 
 
 class InvalidToken(MusicAssistantError):
     """Error raised when an access token is invalid or expired."""
 
     error_code = 23
-    translation_key = "errors.invalid_token"
+    translation_key = "invalid_token"
 
 
 class ResourceBusyError(MusicAssistantError):
@@ -219,7 +228,7 @@ class ResourceBusyError(MusicAssistantError):
     """
 
     error_code = 24
-    translation_key = "errors.resource_busy"
+    translation_key = "resource_busy"
 
 
 class RateLimited(ResourceTemporarilyUnavailable):
@@ -231,7 +240,7 @@ class RateLimited(ResourceTemporarilyUnavailable):
     """
 
     error_code = 25
-    translation_key = "errors.rate_limited"
+    translation_key = "rate_limited"
 
 
 class UnsupportedSystemError(SetupFailedError):
@@ -244,4 +253,4 @@ class UnsupportedSystemError(SetupFailedError):
     """
 
     error_code = 26
-    translation_key = "errors.unsupported_system"
+    translation_key = "unsupported_system"

--- a/music_assistant_models/media_items/media_item.py
+++ b/music_assistant_models/media_items/media_item.py
@@ -72,12 +72,8 @@ class _MediaItemBase(DataClassDictMixin):
         """Return the translation key base for this item's translation_key (None if unset)."""
         if self.translation_key is None:
             return None
-        key = self.translation_key
-        return (
-            key
-            if key.startswith(("provider.", "core.", "common."))
-            else f"media.{self._translation_group}.{key}"
-        )
+        # the group is always derived from the media type; translation_key is just the slug
+        return f"media.{self._translation_group}.{self.translation_key}"
 
     def __post_serialize__(self, d: dict[str, Any]) -> dict[str, Any]:
         """Localize name/subtitle/description when a translation resolver is set."""

--- a/tests/test_error_translations.py
+++ b/tests/test_error_translations.py
@@ -21,6 +21,8 @@ from music_assistant_models.translations import TRANSLATION_RESOLVER
 _CATALOG = {
     "errors.provider_unavailable": "De provider is niet beschikbaar.",
     "errors.media_count": "{0} items niet gevonden",
+    "errors.login_failed": "Inloggen mislukt.",
+    "provider.demo.errors.login_failed": "Demo-login mislukt.",
 }
 
 
@@ -42,35 +44,41 @@ def _resolver_active() -> Iterator[None]:
 
 
 def test_error_subclasses_expose_default_translation_key() -> None:
-    """Each standard error type carries its default translation key; the base stays None."""
+    """Each standard error type carries its default (bare) translation key; the base stays None."""
     assert MusicAssistantError.translation_key is None
-    assert ProviderUnavailableError.translation_key == "errors.provider_unavailable"
-    assert MediaNotFoundError.translation_key == "errors.media_not_found"
-    assert InvalidToken.translation_key == "errors.invalid_token"
+    assert MusicAssistantError.translation_owner is None
+    assert ProviderUnavailableError.translation_key == "provider_unavailable"
+    assert MediaNotFoundError.translation_key == "media_not_found"
+    assert InvalidToken.translation_key == "invalid_token"
     # RateLimited subclasses ResourceTemporarilyUnavailable but defines its own key
-    assert RateLimited.translation_key == "errors.rate_limited"
+    assert RateLimited.translation_key == "rate_limited"
     # UnsupportedSystemError subclasses SetupFailedError but defines its own key
-    assert UnsupportedSystemError.translation_key == "errors.unsupported_system"
+    assert UnsupportedSystemError.translation_key == "unsupported_system"
     # default key is readable on an instance too
-    assert ProviderUnavailableError("boom").translation_key == "errors.provider_unavailable"
+    assert ProviderUnavailableError("boom").translation_key == "provider_unavailable"
 
 
 def test_error_per_instance_override() -> None:
-    """A per-instance translation_key/args overrides the type default; backoff is preserved."""
+    """A per-instance translation_key/args/owner overrides the type default; backoff kept."""
     err = MediaNotFoundError(
-        "not found", translation_key="provider.demo.errors.x", translation_args=["a"]
+        "not found",
+        translation_key="custom_not_found",
+        translation_args=["a"],
+        translation_owner="provider.demo",
     )
-    assert err.translation_key == "provider.demo.errors.x"
+    assert err.translation_key == "custom_not_found"
     assert err.translation_args == ["a"]
+    assert err.translation_owner == "provider.demo"
     # custom-__init__ error forwards the translation kwargs and keeps backoff_time
     rate = RateLimited("Spotify", backoff_time=30, translation_args=["Spotify"])
-    assert rate.translation_key == "errors.rate_limited"
+    assert rate.translation_key == "rate_limited"
+    assert rate.translation_owner is None
     assert rate.backoff_time == 30
     assert rate.translation_args == ["Spotify"]
     # raised with only a backoff and no message: str() is empty, default key carries the text
     empty = ResourceTemporarilyUnavailable(backoff_time=5)
     assert str(empty) == ""
-    assert empty.translation_key == "errors.resource_temporarily_unavailable"
+    assert empty.translation_key == "resource_temporarily_unavailable"
 
 
 def test_error_result_message_localizes_details_and_strips_machinery() -> None:
@@ -95,9 +103,7 @@ def test_error_result_message_localizes_details_and_strips_machinery() -> None:
 
 def test_error_result_message_unknown_key_keeps_details() -> None:
     """When the key does not resolve, the in-code `details` (str(err)) is kept."""
-    msg = ErrorResultMessage(
-        "abc", 2, "Track 123 not found", translation_key="errors.media_not_found"
-    )
+    msg = ErrorResultMessage("abc", 2, "Track 123 not found", translation_key="media_not_found")
     with _resolver_active():
         d = msg.to_dict()
     assert d["details"] == "Track 123 not found"
@@ -106,23 +112,35 @@ def test_error_result_message_unknown_key_keeps_details() -> None:
 
 def test_error_result_message_plain_to_dict_keeps_machinery() -> None:
     """Without a resolver bound the message keeps details + machinery (round-trip safe)."""
-    msg = ErrorResultMessage(
-        "abc", 1, "Spotify is offline", translation_key="errors.provider_unavailable"
-    )
+    msg = ErrorResultMessage("abc", 1, "Spotify is offline", translation_key="provider_unavailable")
     d = msg.to_dict()
     assert d["details"] == "Spotify is offline"
-    assert d["translation_key"] == "errors.provider_unavailable"
+    assert d["translation_key"] == "provider_unavailable"
     assert d["translation_args"] == []
 
 
 def test_error_result_message_substitutes_params() -> None:
     """Positional translation_args fill {0}/{1} placeholders in the localized message."""
-    msg = ErrorResultMessage(
-        "abc", 2, "raw", translation_key="errors.media_count", translation_args=[3]
-    )
+    msg = ErrorResultMessage("abc", 2, "raw", translation_key="media_count", translation_args=[3])
     with _resolver_active():
         d = msg.to_dict()
     assert d["details"] == "3 items niet gevonden"
+
+
+def test_error_result_message_resolves_owner_before_common() -> None:
+    """A provider-owned error resolves its own message first; without an owner it hits common."""
+    owned = ErrorResultMessage(
+        "abc", 6, "raw", translation_key="login_failed", translation_owner="provider.demo"
+    )
+    with _resolver_active():
+        d = owned.to_dict()
+    assert d["details"] == "Demo-login mislukt."
+    assert "translation_owner" not in d
+    # the same bare key with no owner falls back to the shared common string
+    common = ErrorResultMessage("abc", 6, "raw", translation_key="login_failed")
+    with _resolver_active():
+        d = common.to_dict()
+    assert d["details"] == "Inloggen mislukt."
 
 
 def test_error_map_still_registers_all_subclasses() -> None:

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -45,12 +45,30 @@ def test_legacy_string_last_error_is_coerced() -> None:
 
 def test_structured_last_error_roundtrips() -> None:
     """A structured last_error survives a from_dict/to_dict round-trip."""
-    err = ProviderError(
-        error_code=21, message="auth", translation_key="errors.authentication_failed"
-    )
+    err = ProviderError(error_code=21, message="auth", translation_key="authentication_failed")
     conf = ProviderConfig.from_dict(_raw(last_error=err.to_dict()))
     assert conf.last_error == err
     assert conf.to_dict()["last_error"] == err.to_dict()
+
+
+def test_last_error_localizes_message_owner_first() -> None:
+    """A bare key resolves under errors.<slug>, owner-first then common."""
+    catalog = {
+        "errors.login_failed": "Inloggen mislukt.",
+        "provider.demo.errors.login_failed": "Demo-login mislukt.",
+    }
+    common = ProviderError(error_code=6, message="login", translation_key="login_failed")
+    with _resolver_active(catalog):
+        assert common.to_dict()["message"] == "Inloggen mislukt."
+    # a provider that owns the key resolves its own message before common
+    owned = ProviderError(
+        error_code=6,
+        message="login",
+        translation_key="login_failed",
+        translation_owner="provider.demo",
+    )
+    with _resolver_active(catalog):
+        assert owned.to_dict()["message"] == "Demo-login mislukt."
 
 
 def test_status_is_served_but_never_persisted() -> None:
@@ -66,7 +84,7 @@ def test_last_error_localized_on_serialize_with_resolver() -> None:
     err = ProviderError(
         error_code=26,
         message="raw English",
-        translation_key="errors.unsupported_system_cpu",
+        translation_key="unsupported_system_cpu",
         translation_args=["Smart Fades", 4, 2],
     )
     conf = ProviderConfig.from_dict(_raw(last_error=err.to_dict()))
@@ -82,10 +100,10 @@ def test_last_error_raw_without_resolver() -> None:
     err = ProviderError(
         error_code=26,
         message="raw English",
-        translation_key="errors.unsupported_system_cpu",
+        translation_key="unsupported_system_cpu",
         translation_args=["Smart Fades", 4, 2],
     )
     served = ProviderConfig.from_dict(_raw(last_error=err.to_dict())).to_dict()["last_error"]
     assert served["message"] == "raw English"
-    assert served["translation_key"] == "errors.unsupported_system_cpu"
+    assert served["translation_key"] == "unsupported_system_cpu"
     assert served["translation_args"] == ["Smart Fades", 4, 2]

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -21,7 +21,6 @@ from music_assistant_models.translations import TRANSLATION_RESOLVER
 _CATALOG = {
     "config_entries.log_level.label": "Logniveau",
     "config_entries.preset.label": "Preset",
-    "common.config_entries.shared_setting.label": "Gedeeld",
     "config_categories.generic": "Algemeen",
     "media.recommendations.recently_played.name": "Onlangs afgespeeld",
     "media.recommendations.recently_played.subtitle": "Ga verder waar je gebleven was",
@@ -74,19 +73,11 @@ def test_config_entry_resolves_label_and_omits_machinery() -> None:
 
 
 def test_config_entry_explicit_translation_key_is_a_bare_slug() -> None:
-    """An explicit translation_key is a bare slug under config_entries; an FQ one passes through."""
-    # relative override (e.g. a shared key for a dynamic config key) -> config_entries.<slug>
+    """An explicit translation_key is a bare slug; the model derives config_entries.<slug>."""
+    # e.g. a shared key for a dynamic config key (preset_1, preset_2, ...) -> config_entries.preset
     entry = ConfigEntry(key="preset_1", type=ConfigEntryType.STRING, translation_key="preset")
     with _resolver_active():
         assert entry.to_dict()["label"] == "Preset"
-    # a fully-qualified override is used as-is, so it can reuse a shared string elsewhere
-    shared = ConfigEntry(
-        key="x",
-        type=ConfigEntryType.STRING,
-        translation_key="common.config_entries.shared_setting",
-    )
-    with _resolver_active():
-        assert shared.to_dict()["label"] == "Gedeeld"
 
 
 def test_media_item_resolves_name_subtitle_and_strips_machinery() -> None:

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -20,6 +20,8 @@ from music_assistant_models.translations import TRANSLATION_RESOLVER
 # the strings a bound resolver would return for the keys the models look up
 _CATALOG = {
     "config_entries.log_level.label": "Logniveau",
+    "config_entries.preset.label": "Preset",
+    "common.config_entries.shared_setting.label": "Gedeeld",
     "config_categories.generic": "Algemeen",
     "media.recommendations.recently_played.name": "Onlangs afgespeeld",
     "media.recommendations.recently_played.subtitle": "Ga verder waar je gebleven was",
@@ -69,6 +71,22 @@ def test_config_entry_resolves_label_and_omits_machinery() -> None:
         localized = entry.to_dict()
     assert localized["label"] == "Logniveau"
     assert localized["category_label"] == "Algemeen"
+
+
+def test_config_entry_explicit_translation_key_is_a_bare_slug() -> None:
+    """An explicit translation_key is a bare slug under config_entries; an FQ one passes through."""
+    # relative override (e.g. a shared key for a dynamic config key) -> config_entries.<slug>
+    entry = ConfigEntry(key="preset_1", type=ConfigEntryType.STRING, translation_key="preset")
+    with _resolver_active():
+        assert entry.to_dict()["label"] == "Preset"
+    # a fully-qualified override is used as-is, so it can reuse a shared string elsewhere
+    shared = ConfigEntry(
+        key="x",
+        type=ConfigEntryType.STRING,
+        translation_key="common.config_entries.shared_setting",
+    )
+    with _resolver_active():
+        assert shared.to_dict()["label"] == "Gedeeld"
 
 
 def test_media_item_resolves_name_subtitle_and_strips_machinery() -> None:


### PR DESCRIPTION
# What does this implement/fix?

`ConfigEntry`'s `translation_key`/`category_translation_key` were treated as the *full* localization base, so an explicit override had to spell out the group (`config_entries.<key>` / `config_categories.<cat>`) — inconsistent with media items, where the model derives `media.<group>.<slug>` from a bare slug.

Now an override is the **bare key** under its group, derived by the model. So callers pass just the key (e.g. `translation_key="preset"` for a dynamic/shared config key), the same way media items and background tasks already work. A fully-qualified override (`provider.`/`core.`/`common.`) still passes through unchanged so it can reuse a shared string elsewhere. The default (no override → the entry's own key/category) is unchanged.

> Note: this changes how an explicit `translation_key` resolves, so the server side must drop the `config_entries.`/`config_categories.` prefix from its explicit overrides in the same release that bumps to this version.
