### PR TITLE
Fix media-item mixin typing; localize Podcast

### DIFF
--- a/music_assistant_models/media_items/media_item.py
+++ b/music_assistant_models/media_items/media_item.py
@@ -112,20 +112,20 @@ class _LocalizableName:
 
     Carries an optional ``translation_key`` that overrides the in-code (English) ``name`` for the
     connection locale during outbound API serialization, plus the hook that performs it. Mixed
-    into the media item types that actually have a curated, localizable name (genres, and item
-    mappings standing in for them); the everyday media types (artists, albums, tracks, …) carry
-    user/provider data names and never set a key, so they don't get this machinery. Items whose
-    title also takes positional placeholders use ``_LocalizableTitle`` instead.
+    into the media item types that actually have a curated, localizable name (genres, podcasts,
+    and item mappings standing in for them); the everyday media types (artists, albums, tracks, …)
+    carry user/provider data names and never set a key, so they don't get this machinery. Items
+    whose title also takes positional placeholders use ``_LocalizableTitle`` instead.
+
+    ``media_type`` and ``provider`` are always provided by the ``_MediaItemBase`` this mixin is
+    combined with; they're read off ``self`` below (hence the localized ``# type: ignore`` hints).
+    Declaring them here as well would make them look like dataclass fields without a default and
+    break the inherited defaults on subclasses (e.g. ItemMapping's optional ``media_type``).
     """
 
     # translation_key: optional key to localize `name` (e.g. for "Your Mixes"); resolved to the
     # connection locale at serialization, overriding the in-code `name`.
     translation_key: str | None = None
-
-    if TYPE_CHECKING:
-        # supplied by the _MediaItemBase this mixin is always combined with
-        media_type: MediaType
-        provider: str
 
     @property
     def _translation_group(self) -> str:
@@ -136,7 +136,8 @@ class _LocalizableName:
         Special subclasses override this when their media_type doesn't capture the distinction
         (e.g. recommendation folders, which share ``MediaType.FOLDER`` with browse folders).
         """
-        return self.media_type.value
+        media_type: MediaType = self.media_type  # type: ignore[attr-defined]  # from _MediaItemBase
+        return media_type.value
 
     def _translation_base(self) -> str | None:
         """Return the translation key base for this item's translation_key (None if unset)."""
@@ -161,22 +162,20 @@ class _LocalizableName:
         calls used for internal round-tripping (caching, item mappings).
         """
         base = self._translation_base()
-        # translation_params only exists on _LocalizableTitle subclasses
+        # translation_params only exists on _LocalizableTitle subclasses; provider/media_type come
+        # from the _MediaItemBase this mixin is combined with
         params = getattr(self, "translation_params", None)
+        owner: str = self.provider  # type: ignore[attr-defined]
         if base is not None:
             for field_name in ("name", "subtitle"):
                 if field_name not in d:
                     continue
-                localized = resolve_translation(
-                    f"{base}.{field_name}", owner=self.provider, params=params
-                )
+                localized = resolve_translation(f"{base}.{field_name}", owner=owner, params=params)
                 if localized is not None:
                     d[field_name] = localized
             # description lives on the nested metadata object (MediaItemMetadata), not top-level
             if isinstance(metadata := d.get("metadata"), dict):
-                localized = resolve_translation(
-                    f"{base}.description", owner=self.provider, params=params
-                )
+                localized = resolve_translation(f"{base}.description", owner=owner, params=params)
                 if localized is not None:
                     metadata["description"] = localized
         if translations_active():
@@ -420,7 +419,7 @@ class Audiobook(MediaItem):
 
 
 @dataclass(kw_only=True)
-class Podcast(MediaItem):
+class Podcast(_LocalizableName, MediaItem):
     """Model for a Podcast."""
 
     __hash__ = _MediaItemBase.__hash__

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -10,7 +10,9 @@ from music_assistant_models.enums import ConfigEntryType, ProviderType
 from music_assistant_models.media_items import (
     BrowseFolder,
     Genre,
+    ItemMapping,
     Playlist,
+    Podcast,
     ProviderMapping,
     Radio,
     RecommendationFolder,
@@ -33,6 +35,7 @@ _CATALOG = {
     "media.recommendations.recently_played.name": "Onlangs afgespeeld",
     "media.recommendations.recently_played.subtitle": "Ga verder waar je gebleven was",
     "media.folder.libraries.name": "Bibliotheken",
+    "media.podcast.unknown_podcast.name": "Onbekende podcast",
     "media.genre.jazz.name": "Jazz (NL)",
     "media.genre.jazz.description": "Jazz is een Amerikaans muziekgenre.",
     "media.playlist.infinite_mix.name": "Oneindige mix",
@@ -173,6 +176,26 @@ def test_radio_resolves_name_with_params() -> None:
     )
     with _resolver_active():
         assert radio.to_dict()["name"] == "Pandora-zender 5"
+
+
+def test_podcast_resolves_name() -> None:
+    """A Podcast localizes its name from media.podcast.<key>.name (e.g. an Unknown placeholder)."""
+    podcast = Podcast(
+        item_id="unknown",
+        provider="spotify",
+        name="Unknown Podcast",
+        translation_key="unknown_podcast",
+        provider_mappings=set(),
+    )
+    with _resolver_active():
+        assert podcast.to_dict()["name"] == "Onbekende podcast"
+
+
+def test_item_mapping_media_type_keeps_its_default() -> None:
+    """The mixin must keep ItemMapping.media_type optional (no phantom required field)."""
+    # constructs without media_type; a mixin field lacking a default would break that
+    mapping = ItemMapping(item_id="x", provider="p", name="N")
+    assert mapping.media_type.value == "unknown"
 
 
 def test_plain_media_item_has_no_translation_machinery() -> None:


### PR DESCRIPTION
## What

Follow-up to #264. Two issues that surface in downstream (server) type-checking against 1.1.138:

1. `_LocalizableName` declared `media_type` / `provider` under `if TYPE_CHECKING:` so the mixin methods could read them. mypy's dataclass plugin treats those as fields **without a default**, which made `media_type` a *required* constructor argument on `ItemMapping` (and every other mixin user) for downstream callers — even though it's optional at runtime. Read them off `self` with a localized `# type: ignore[attr-defined]` instead, preserving the inherited defaults.
2. Add `Podcast` to `_LocalizableName`. Spotify sets a `translation_key` on its "Unknown Podcast" placeholder; Podcast lost that field in the mixin split (#264), breaking that call site.

Both are caught by downstream mypy, not the models suite alone, so I also added runtime regression tests (ItemMapping without `media_type`; Podcast localizing its name). Verified the server's mypy is clean against this branch.