### PR TITLE
Fix type hint order in Audiobooks

### DIFF
--- a/music_assistant_models/media_items/media_item.py
+++ b/music_assistant_models/media_items/media_item.py
@@ -401,8 +401,9 @@ class Audiobook(MediaItem):
     __eq__ = _MediaItemBase.__eq__
 
     publisher: str | None = None
-    authors: UniqueList[str | Artist | ItemMapping] = field(default_factory=UniqueList)
-    narrators: UniqueList[str | Artist | ItemMapping] = field(default_factory=UniqueList)
+    # type hint order matters below for our get_serializable_value helper
+    authors: UniqueList[Artist | ItemMapping | str] = field(default_factory=UniqueList)
+    narrators: UniqueList[Artist | ItemMapping | str] = field(default_factory=UniqueList)
     duration: int = 0
     # resume point info
     # set to None if unknown/unsupported by provider


### PR DESCRIPTION
Otherwise our get_serializable_value helper fails. With this, the author / narrators PR seems to be ready.