### PR TITLE
Add browse_folder_type to BrowseFolder to support Audiobook collections

### DIFF
--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -183,6 +183,19 @@ class ArtistType(StrEnum):
         return cls.UNKNOWN
 
 
+class BrowseFolderType(StrEnum):
+    """Enum for BrowseFolderType."""
+
+    BROWSE = "browse"
+    AUDIOBOOK_COLLECTION = "audiobook_collection"
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def _missing_(cls, value: object) -> BrowseFolderType:  # noqa: ARG003
+        """Set default enum member if an unknown value is provided."""
+        return cls.UNKNOWN
+
+
 class ContentType(StrEnum):
     """Enum with audio content/container types supported by ffmpeg."""
 

--- a/music_assistant_models/media_items/media_item.py
+++ b/music_assistant_models/media_items/media_item.py
@@ -9,7 +9,14 @@ from typing import TYPE_CHECKING, Any, cast
 
 from mashumaro import DataClassDictMixin, field_options
 
-from music_assistant_models.enums import AlbumType, ArtistType, ExternalID, ImageType, MediaType
+from music_assistant_models.enums import (
+    AlbumType,
+    ArtistType,
+    BrowseFolderType,
+    ExternalID,
+    ImageType,
+    MediaType,
+)
 from music_assistant_models.errors import InvalidDataError
 from music_assistant_models.helpers import (
     create_sort_name,
@@ -519,6 +526,7 @@ class BrowseFolder(_LocalizableTitle, _MediaItemBase):
     # mediatype is always folder for browse folders
     # independent of the actual content mediatype(s)
     media_type: MediaType = MediaType.FOLDER
+    folder_type: BrowseFolderType = BrowseFolderType.BROWSE
 
     # path: the path (in uri style) to/for this browse folder
     path: str = ""


### PR DESCRIPTION
Allows me to distinguish a special Collection Folder from a normal folder in the frontend.
Frontend PR: https://github.com/music-assistant/frontend/pull/1941
Backend PR: https://github.com/music-assistant/server/pull/4372