### PR TITLE
Add CrossfadeMode and PlayerQueueConfig for per-queue settings

### DIFF
--- a/music_assistant_models/config_entries.py
+++ b/music_assistant_models/config_entries.py
@@ -497,6 +497,13 @@ class PlayerConfig(Config):
 
 
 @dataclass
+class PlayerQueueConfig(Config):
+    """PlayerQueue Configuration."""
+
+    queue_id: str
+
+
+@dataclass
 class CoreConfig(Config):
     """CoreController Configuration."""
 

--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -366,6 +366,18 @@ class RepeatMode(StrEnum):
         return cls.UNKNOWN
 
 
+class CrossfadeMode(StrEnum):
+    """Enum with crossfade modes for a queue."""
+
+    SMART_CROSSFADE = "smart_crossfade"  # Use smart crossfade with beat matching and EQ filters
+    STANDARD_CROSSFADE = "standard_crossfade"  # Use standard crossfade only
+    DISABLED = "disabled"  # No crossfade
+
+
+# alias for backwards compatibility
+SmartFadesMode = CrossfadeMode
+
+
 class PlaybackState(StrEnum):
     """Enum for the (playback)state of a player."""
 

--- a/music_assistant_models/player_queue.py
+++ b/music_assistant_models/player_queue.py
@@ -9,7 +9,7 @@ from typing import Any
 from mashumaro import DataClassDictMixin, field_options, pass_through
 
 from .constants import EXTRA_ATTRIBUTES_TYPES
-from .enums import PlaybackState, RepeatMode
+from .enums import CrossfadeMode, PlaybackState, RepeatMode
 from .media_items import ItemMapping, MediaItemType, media_from_dict
 from .queue_item import QueueItem
 
@@ -34,7 +34,11 @@ class PlayerQueue(DataClassDictMixin):
     items: int
     shuffle_enabled: bool = False
     repeat_mode: RepeatMode = RepeatMode.OFF
+    crossfade_mode: CrossfadeMode = CrossfadeMode.DISABLED
     dont_stop_the_music_enabled: bool = False
+    # smart_fades_available: helper for clients to know if the smart_crossfade option can be
+    # selected; derived at runtime by the server (not persisted, recomputed on load)
+    smart_fades_available: bool = False
 
     # current_index: index that is active (e.g. being played) by the player
     current_index: int | None = None
@@ -118,6 +122,8 @@ class PlayerQueue(DataClassDictMixin):
         d.pop("current_item", None)
         d.pop("next_item", None)
         d.pop("index_in_buffer", None)
+        # smart_fades_available is derived at runtime, never persisted
+        d.pop("smart_fades_available", None)
         # enqueued_media_items needs to survive a restart
         # otherwise 'dont stop the music' will not work
         d["enqueued_media_items"] = [x.to_dict() for x in self.enqueued_media_items]


### PR DESCRIPTION
Model support for moving queue-scoped playback settings off the player and onto the queue, so crossfade can become a per-play toggle (like repeat/shuffle) and queue settings get their own config object.

- \`CrossfadeMode\` enum (\`disabled\` / \`standard_crossfade\` / \`smart_crossfade\`); \`SmartFadesMode\` kept as a back-compat alias
- \`PlayerQueue.crossfade_mode\` (serialized, persisted to cache and copied on queue transfer) plus a derived \`smart_fades_available\` helper for clients
- \`PlayerQueueConfig\` config object for per-queue "set and forget" settings (crossfade duration, volume normalization)