### PR TITLE
Add content_type to genre class

### DIFF
--- a/music_assistant_models/media_items/media_item.py
+++ b/music_assistant_models/media_items/media_item.py
@@ -245,7 +245,23 @@ class Genre(_LocalizableName, MediaItem):
     __eq__ = _MediaItemBase.__eq__
 
     media_type: MediaType = MediaType.GENRE
+    # content_type namespaces the genre's taxonomy: None = music/general (back-compat),
+    # MediaType.PODCAST / MediaType.AUDIOBOOK for the disjoint spoken-word taxonomies.
+    content_type: MediaType | None = None
     genre_aliases: set[str] | None = None
+
+    @property
+    def _translation_group(self) -> str:
+        """
+        Namespace spoken-word genres separately so the same name can exist per taxonomy.
+
+        Music genres (content_type None) keep the bare ``genre`` group (``media.genre.<key>``);
+        podcast/audiobook genres get ``podcast_genre`` / ``audiobook_genre`` so e.g. "History"
+        can exist in both without a translation-key collision.
+        """
+        if self.content_type is not None:
+            return f"{self.content_type.value}_genre"
+        return "genre"
 
     def __post_init__(self) -> None:
         """Call after init."""

--- a/tests/test_genre_content_type.py
+++ b/tests/test_genre_content_type.py
@@ -1,0 +1,34 @@
+"""Tests for the Genre.content_type field (taxonomy namespacing) serialization."""
+
+from music_assistant_models.enums import MediaType
+from music_assistant_models.media_items import Genre
+
+
+def test_content_type_defaults_to_none() -> None:
+    """A genre with no content_type defaults to None (music/general)."""
+    genre = Genre(item_id="rock", provider="library", name="Rock", provider_mappings=set())
+    assert genre.content_type is None
+    assert genre.to_dict().get("content_type") is None
+
+
+def test_content_type_survives_roundtrip() -> None:
+    """content_type is preserved through to_dict/from_dict for each taxonomy."""
+    for content_type in (None, MediaType.PODCAST, MediaType.AUDIOBOOK):
+        genre = Genre(
+            item_id="x",
+            provider="library",
+            name="X",
+            content_type=content_type,
+            provider_mappings=set(),
+        )
+        restored = Genre.from_dict(genre.to_dict())
+        assert restored.content_type == content_type
+
+
+def test_missing_content_type_key_deserializes_as_none() -> None:
+    """Back-compat: payloads predating the field (no content_type key) load as music (None)."""
+    genre = Genre(item_id="rock", provider="library", name="Rock", provider_mappings=set())
+    data = genre.to_dict()
+    data.pop("content_type", None)
+    restored = Genre.from_dict(data)
+    assert restored.content_type is None

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from music_assistant_models.background_task import BackgroundTask
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption
-from music_assistant_models.enums import ConfigEntryType, ProviderType
+from music_assistant_models.enums import ConfigEntryType, MediaType, ProviderType
 from music_assistant_models.media_items import (
     BrowseFolder,
     Genre,
@@ -38,6 +38,9 @@ _CATALOG = {
     "media.podcast.unknown_podcast.name": "Onbekende podcast",
     "media.genre.jazz.name": "Jazz (NL)",
     "media.genre.jazz.description": "Jazz is een Amerikaans muziekgenre.",
+    "media.genre.comedy.name": "Komedie (muziek)",
+    "media.podcast_genre.comedy.name": "Komedie (podcast)",
+    "media.audiobook_genre.history.name": "Geschiedenis (audioboek)",
     "media.playlist.infinite_mix.name": "Oneindige mix",
     "media.playlist.flow.name": "Stroom: {0}",
     "media.radio.pandora_station.name": "Pandora-zender {0}",
@@ -135,6 +138,41 @@ def test_genre_resolves_nested_metadata_description() -> None:
     assert localized["name"] == "Jazz (NL)"
     assert localized["metadata"]["description"] == "Jazz is een Amerikaans muziekgenre."
     assert "translation_key" not in localized
+
+
+def test_genre_content_type_uses_distinct_translation_namespace() -> None:
+    """content_type namespaces a genre's translation group so names don't collide per taxonomy."""
+    # same name + slug across taxonomies: each resolves its own group, no collision
+    music = Genre(
+        item_id="comedy",
+        provider="library",
+        name="Comedy",
+        translation_key="comedy",
+        provider_mappings=set(),
+    )
+    podcast = Genre(
+        item_id="comedy",
+        provider="library",
+        name="Comedy",
+        translation_key="comedy",
+        content_type=MediaType.PODCAST,
+        provider_mappings=set(),
+    )
+    audiobook = Genre(
+        item_id="history",
+        provider="library",
+        name="History",
+        translation_key="history",
+        content_type=MediaType.AUDIOBOOK,
+        provider_mappings=set(),
+    )
+    with _resolver_active():
+        # music genre (content_type None) keeps the bare media.genre.* group
+        assert music.to_dict()["name"] == "Komedie (muziek)"
+        # identical slug under podcast resolves the distinct media.podcast_genre.* key
+        assert podcast.to_dict()["name"] == "Komedie (podcast)"
+        # audiobook gets its own media.audiobook_genre.* namespace
+        assert audiobook.to_dict()["name"] == "Geschiedenis (audioboek)"
 
 
 def test_playlist_resolves_static_name_and_with_params() -> None:


### PR DESCRIPTION
`content_type` will be used to namespace the genre translation taxonomies, allowing us to have different default genre sets for spoken word MediaTypes (audiobooks/podcasts) vs music.

This PR is purely additive and fully backwards compatible as nothing constructs a non-None `content_type` yet.