### PR TITLE
Add sleep timer and related event

### DIFF
--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -542,6 +542,7 @@ class EventType(StrEnum):
     PLAYER_CONFIG_UPDATED = "player_config_updated"
     PLAYER_DSP_CONFIG_UPDATED = "player_dsp_config_updated"
     PLAYER_OPTIONS_UPDATED = "player_options_updated"
+    PLAYER_SLEEP_TIMER_UPDATED = "player_sleep_timer_updated"
     DSP_PRESETS_UPDATED = "dsp_presets_updated"
     QUEUE_ADDED = "queue_added"
     QUEUE_UPDATED = "queue_updated"

--- a/music_assistant_models/player.py
+++ b/music_assistant_models/player.py
@@ -417,7 +417,7 @@ class Player(DataClassDictMixin):
     # needs_setup: if True, the player needs to be set up before it can be used
     needs_setup: bool = False
 
-    # sleep_timer_expires_at: unix timestamp at which the active sleep timer will
+    # sleep_timer_expires_at: unix (utc) timestamp at which the active sleep timer will
     # stop playback, or None if no sleep timer is currently set for this player
     sleep_timer_expires_at: float | None = None
 

--- a/music_assistant_models/player.py
+++ b/music_assistant_models/player.py
@@ -417,6 +417,10 @@ class Player(DataClassDictMixin):
     # needs_setup: if True, the player needs to be set up before it can be used
     needs_setup: bool = False
 
+    # sleep_timer_expires_at: unix timestamp at which the active sleep timer will
+    # stop playback, or None if no sleep timer is currently set for this player
+    sleep_timer_expires_at: float | None = None
+
     #############################################################################
     # helper methods and properties                                             #
     #############################################################################


### PR DESCRIPTION
Add sleep timer to Player, along with an event for when it changes (set, cleared, or fired).

This is to support https://github.com/music-assistant/server/pull/4432 which will be updated to use these.