### PR TITLE
Add PLAYLIST_METADATA to ProviderFeature enum

### DIFF
--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -655,6 +655,7 @@ class ProviderFeature(StrEnum):
     ARTIST_METADATA = "artist_metadata"
     ALBUM_METADATA = "album_metadata"
     TRACK_METADATA = "track_metadata"
+    PLAYLIST_METADATA = "playlist_metadata"
     LYRICS = "lyrics"  # lyrics support - can also be provided by a music provider
 
     #


### PR DESCRIPTION
# What does this implement/fix?

Adds `PLAYLIST_METADATA` to the `ProviderFeature` enum, enabling metadata providers to declare support for generating playlist metadata (artwork, future: genres, descriptions).

This follows the same pattern as existing features (`ARTIST_METADATA`, `ALBUM_METADATA`, `TRACK_METADATA`) and enables the standard MetadataProvider pattern for playlists.

**Related issue (if applicable):** N/A

## Types of changes

- [x] Enhancement to an existing feature — `enhancement`

## Checklist

- [x] The code change is tested and works locally.
- [x] For changes to shared models, the companion PR in `music-assistant/server` is linked below.

**Companion PRs:**
- music-assistant/server: Core infrastructure PR (draft, pending)
- music-assistant/server: playlist_metadata provider implementation (PR #3786)