### PR TITLE
Rename queue radio_source to sources (keep deprecated key)

### DIFF
--- a/music_assistant_models/player_queue.py
+++ b/music_assistant_models/player_queue.py
@@ -60,9 +60,8 @@ class PlayerQueue(DataClassDictMixin):
     next_item: QueueItem | None = None
     # sources: the parent items the queue is playing from — regular media items and/or dynamic
     # playlists (radio playlists, provider stations). When `is_dynamic` the queue dynamically fills
-    # from these. Renamed from the deprecated `radio_source`, still mirrored on the wire for older
-    # clients.
-    sources: list[MediaItemType] = field(default_factory=list)
+    # from these.
+    sources: list[ItemMapping] = field(default_factory=list)
 
     flow_mode: bool = False
     resume_pos: int = 0
@@ -129,7 +128,7 @@ class PlayerQueue(DataClassDictMixin):
         """Mirror the deprecated `dont_stop_the_music_enabled` / `radio_source` keys."""
         d["dont_stop_the_music_enabled"] = d["autoplay_enabled"]
         # temporary back-compat: older clients still read the deprecated `radio_source`
-        d["radio_source"] = d.get("sources", [])
+        d["radio_source"] = d.get("sources", []) if self.is_dynamic else []
         return d
 
     @property

--- a/music_assistant_models/player_queue.py
+++ b/music_assistant_models/player_queue.py
@@ -59,8 +59,8 @@ class PlayerQueue(DataClassDictMixin):
     current_item: QueueItem | None = None
     next_item: QueueItem | None = None
     # sources: the parent items the queue is playing from — regular media items and/or dynamic
-    # playlists (radio playlists, provider stations). When `is_dynamic` the queue dynamically fills
-    # from these.
+    # playlists (radio playlists, provider stations). 
+    # When `is_dynamic` the queue dynamically fills from these.
     sources: list[ItemMapping] = field(default_factory=list)
 
     flow_mode: bool = False

--- a/music_assistant_models/player_queue.py
+++ b/music_assistant_models/player_queue.py
@@ -59,7 +59,7 @@ class PlayerQueue(DataClassDictMixin):
     current_item: QueueItem | None = None
     next_item: QueueItem | None = None
     # sources: the parent items the queue is playing from — regular media items and/or dynamic
-    # playlists (radio playlists, provider stations). 
+    # playlists (radio playlists, provider stations).
     # When `is_dynamic` the queue dynamically fills from these.
     sources: list[ItemMapping] = field(default_factory=list)
 

--- a/music_assistant_models/player_queue.py
+++ b/music_assistant_models/player_queue.py
@@ -58,11 +58,16 @@ class PlayerQueue(DataClassDictMixin):
     state: PlaybackState = PlaybackState.IDLE
     current_item: QueueItem | None = None
     next_item: QueueItem | None = None
-    radio_source: list[MediaItemType] = field(default_factory=list)
+    # sources: the parent items the queue is playing from — regular media items and/or dynamic
+    # playlists (radio playlists, provider stations). When `is_dynamic` the queue dynamically fills
+    # from these. Renamed from the deprecated `radio_source`, still mirrored on the wire for older
+    # clients.
+    sources: list[MediaItemType] = field(default_factory=list)
 
     flow_mode: bool = False
     resume_pos: int = 0
-    # True if exactly one playlist in the queue is dynamic; set by the server.
+    # True when the queue is in dynamic mode (one or more dynamic sources); set by the server.
+    # Implies autoplay and smart shuffle are active.
     is_dynamic: bool = False
 
     # extra_attributes: additional attributes for this player_queue to store/forward
@@ -113,14 +118,18 @@ class PlayerQueue(DataClassDictMixin):
 
     @classmethod
     def __pre_deserialize__(cls, d: dict[str, Any]) -> dict[str, Any]:
-        """Accept the legacy `dont_stop_the_music_enabled` key from older clients/caches."""
+        """Accept the legacy `dont_stop_the_music_enabled` / `radio_source` keys."""
         if "autoplay_enabled" not in d and "dont_stop_the_music_enabled" in d:
             d["autoplay_enabled"] = d["dont_stop_the_music_enabled"]
+        if "sources" not in d and "radio_source" in d:
+            d["sources"] = d["radio_source"]
         return d
 
     def __post_serialize__(self, d: dict[str, Any]) -> dict[str, Any]:
-        """Mirror `autoplay_enabled` to the legacy key for backwards compatibility."""
+        """Mirror the deprecated `dont_stop_the_music_enabled` / `radio_source` keys."""
         d["dont_stop_the_music_enabled"] = d["autoplay_enabled"]
+        # temporary back-compat: older clients still read the deprecated `radio_source`
+        d["radio_source"] = d.get("sources", [])
         return d
 
     @property
@@ -156,9 +165,9 @@ class PlayerQueue(DataClassDictMixin):
             for x in data.get("enqueued_media_items", [])
             if isinstance(x, dict) and not isinstance(item := media_from_dict(x), ItemMapping)
         ]
-        self.radio_source = [
+        self.sources = [
             item
-            for x in data.get("radio_source", [])
+            for x in data.get("sources", data.get("radio_source", []))
             if isinstance(x, dict) and not isinstance(item := media_from_dict(x), ItemMapping)
         ]
         self.userid = data.get("userid")

--- a/music_assistant_models/player_queue.py
+++ b/music_assistant_models/player_queue.py
@@ -167,7 +167,7 @@ class PlayerQueue(DataClassDictMixin):
         self.sources = [
             item
             for x in data.get("sources", data.get("radio_source", []))
-            if isinstance(x, dict) and not isinstance(item := media_from_dict(x), ItemMapping)
+            if isinstance(x, dict) and isinstance(item := media_from_dict(x), ItemMapping)
         ]
         self.userid = data.get("userid")
         return self

--- a/tests/test_player_queue.py
+++ b/tests/test_player_queue.py
@@ -1,0 +1,28 @@
+"""Tests for the PlayerQueue model (deprecated-key back-compat serialization)."""
+
+from music_assistant_models.player_queue import PlayerQueue
+
+
+def _queue() -> PlayerQueue:
+    return PlayerQueue(queue_id="q1", active=True, display_name="Q1", available=True, items=0)
+
+
+def test_sources_mirrors_deprecated_radio_source() -> None:
+    """to_dict mirrors sources to the deprecated radio_source key for older clients."""
+    d = _queue().to_dict()
+    assert "sources" in d
+    assert d["radio_source"] == d["sources"]
+
+
+def test_legacy_radio_source_maps_to_sources() -> None:
+    """from_dict accepts the legacy radio_source key (no sources) as sources."""
+    legacy = _queue().to_dict()
+    legacy.pop("sources", None)
+    restored = PlayerQueue.from_dict(legacy)
+    assert restored.sources == []
+
+
+def test_autoplay_dont_stop_backcompat_preserved() -> None:
+    """The existing autoplay <-> dont_stop_the_music back-compat still holds."""
+    d = _queue().to_dict()
+    assert d["dont_stop_the_music_enabled"] == d["autoplay_enabled"]


### PR DESCRIPTION
Renames `PlayerQueue.radio_source` → `sources` — the parent items the queue plays from (regular media items and/or dynamic playlists such as radio playlists or provider stations). `is_dynamic` (generalised to "queue is in dynamic mode") is the separate flag.

The deprecated `radio_source` key is still emitted on serialize and accepted on deserialize (via the existing `__post_serialize__`/`__pre_deserialize__` back-compat hooks), so older clients and caches keep working during the transition.

Prep for the server-side radio → dynamic-playlist / autoplay overhaul (music-assistant/server); the server PR will bump the pin and consume `sources`.