### PR TITLE
Fix missing proxy_id on remotely accessible images

### DIFF
--- a/music_assistant_models/media_items/metadata.py
+++ b/music_assistant_models/media_items/metadata.py
@@ -71,8 +71,9 @@ class MediaItemImage(DataClassDictMixin):
 
     def __post_serialize__(self, d: dict[str, Any]) -> dict[str, Any]:
         """Inject `proxy_id` when a resolver is set on the current context."""
-        if self.remotely_accessible:
-            return d
+        # A proxy_id is filled regardless of `remotely_accessible`: even when a
+        # client can fetch the image directly, it still needs the proxy to obtain
+        # a resized/reformatted thumbnail (`?size=...&fmt=...`).
         # only inject when proxy_id was not already provided so that values
         # round-tripped via from_dict (or set explicitly by the caller) survive
         if d.get("proxy_id") is not None:

--- a/tests/test_media_item_image.py
+++ b/tests/test_media_item_image.py
@@ -32,8 +32,8 @@ def test_image_with_resolver_injects_proxy_id() -> None:
     assert d["proxy_id"] == hashlib.sha256(b"filesystem//local/cover.jpg").hexdigest()
 
 
-def test_remotely_accessible_image_skips_injection() -> None:
-    """Public images that clients can fetch directly must not get a proxy_id."""
+def test_remotely_accessible_image_still_injects_proxy_id() -> None:
+    """Public images also get a proxy_id so clients can request proxied thumbnails."""
     image = MediaItemImage(
         type=ImageType.THUMB,
         path="https://cdn.example.com/a.jpg",
@@ -45,7 +45,7 @@ def test_remotely_accessible_image_skips_injection() -> None:
         d = image.to_dict()
     finally:
         IMAGE_PROXY_ID_RESOLVER.reset(token)
-    assert d["proxy_id"] is None
+    assert d["proxy_id"] == hashlib.sha256(b"spotify/https://cdn.example.com/a.jpg").hexdigest()
 
 
 def test_proxy_id_round_trips_through_from_dict() -> None:


### PR DESCRIPTION
## Problem
`MediaItemImage` skipped filling `proxy_id` for images flagged `remotely_accessible`. But the imageproxy is also the resize/thumbnail endpoint (`?size=...&fmt=...`), so a client that wants a proxied thumbnail of a remote image had no id to build the URL with.

## Changes
- Always populate `proxy_id` when a resolver is set, regardless of `remotely_accessible`.
- Kept existing guards: a pre-set/round-tripped `proxy_id` is never overwritten, and with no resolver it stays `None`.
- Updated the matching test to assert injection now happens for remotely accessible images.
