### PR TITLE
Add album_artist and version to PlayerMedia

### DIFF
--- a/music_assistant_models/player.py
+++ b/music_assistant_models/player.py
@@ -107,8 +107,10 @@ class PlayerMedia(DataClassDictMixin):
     uri: str  # uri or other identifier of the loaded media - mandatory!
     media_type: MediaType = MediaType.UNKNOWN
     title: str | None = None  # optional
+    version: str | None = None  # optional - track version/edit info (e.g. "Remastered")
     artist: str | None = None  # optional
     album: str | None = None  # optional
+    album_artist: str | None = None  # optional
     image_url: str | None = None  # optional
     palette: MediaItemPalette | None = None  # optional
     duration: int | None = None  # optional


### PR DESCRIPTION
## Problem
The Home Assistant integration currently derives now-playing metadata from the queue's `current_item`, then reads back the queue for two fields that `PlayerMedia` doesn't expose: the album artist and the track version suffix. To let the integration read all display metadata from `player.current_media` (live state) instead of re-deriving it from the queue, `PlayerMedia` needs these two fields.

## Changes
- Add `album_artist: str | None` to `PlayerMedia`
- Add `version: str | None` to `PlayerMedia` (track version/edit info, e.g. "Remastered")

Both are optional and default to `None`, so this is backward compatible with existing payloads.