### PR TITLE
Remove unused version field from PlayerMedia

### DIFF
--- a/music_assistant_models/player.py
+++ b/music_assistant_models/player.py
@@ -107,7 +107,6 @@ class PlayerMedia(DataClassDictMixin):
     uri: str  # uri or other identifier of the loaded media - mandatory!
     media_type: MediaType = MediaType.UNKNOWN
     title: str | None = None  # optional
-    version: str | None = None  # optional - track version/edit info (e.g. "Remastered")
     artist: str | None = None  # optional
     album: str | None = None  # optional
     album_artist: str | None = None  # optional


### PR DESCRIPTION
## What
Removes the `version` field from `PlayerMedia`, added in #286.

## Why
It turned out to be redundant. `Player.__final_current_media` (server-side) already appends the track version to `current_media.title` (`"Name (Version)"`), so consumers — including the Home Assistant integration — get the version without a separate field. Only `album_artist` (also from #286) was actually needed; that one stays.

Removing it now before anything starts depending on it. `album_artist` is unaffected.