### PR TITLE
Add derived-transport info to OutputProtocol

### DIFF
--- a/music_assistant_models/player.py
+++ b/music_assistant_models/player.py
@@ -24,6 +24,7 @@ class OutputProtocol(DataClassDictMixin):
     This provides a unified view of all ways to play audio to a device:
     - Native output (if player supports PLAY_MEDIA)
     - Protocol outputs (AirPlay, Chromecast, DLNA, etc.)
+    - Derived transports riding on another output (e.g. Sendspin over AirPlay)
     """
 
     output_protocol_id: str  # Unique ID: "native" or protocol player_id
@@ -33,6 +34,7 @@ class OutputProtocol(DataClassDictMixin):
     is_native: bool = False  # True if this is the player's native output
     priority: int = 100  # Lower = more preferred (native = 0 if supported)
     available: bool = True  # Whether this output protocol is currently available
+    derived_from: str | None = None  # output_protocol_id of the base output, if derived
 
 
 @dataclass


### PR DESCRIPTION
Some output protocols are derived transports that ride on another protocol (e.g. a Sendspin bridge over an AirPlay player). The server already tracks this relationship via `Player.underlying_player_id`, but it was never exposed on the wire — so clients (HA integration, mobile, frontend badges) couldn't tell a derived transport apart from a direct output.

This adds an optional `derived_from` field to `OutputProtocol` holding the `output_protocol_id` of the base output a derived transport rides on. Clients can use it to render annotations like "Sendspin (over AirPlay)".

## Changes
- Add `derived_from: str | None = None` to `OutputProtocol` (the base output's `output_protocol_id`, `None` for direct outputs).
- Document derived transports in the `OutputProtocol` docstring.

Backwards compatible: the field is optional with a `None` default, so existing payloads deserialize unchanged. Once released, the server will populate it from the persisted `underlying_player_id`.
