### PR TITLE
Add scope based authorization primitives and service user role

### DIFF
--- a/music_assistant_models/auth.py
+++ b/music_assistant_models/auth.py
@@ -11,11 +11,18 @@ from mashumaro.mixins.orjson import DataClassORJSONMixin
 
 
 class UserRole(StrEnum):
-    """User role enum."""
+    """
+    The role id's of the builtin (default) user roles.
+
+    A role is identified by its (string) id, of which these are the builtin defaults.
+    User.role is deliberately a plain string and not limited to these values,
+    to allow for custom roles in the future.
+    """
 
     ADMIN = "admin"
     USER = "user"
     GUEST = "guest"
+    SERVICE = "service"
 
 
 class AuthProviderType(StrEnum):
@@ -24,6 +31,42 @@ class AuthProviderType(StrEnum):
     BUILTIN = "builtin"
     HOME_ASSISTANT = "homeassistant"
 
+    @classmethod
+    def _missing_(cls, value: object) -> AuthProviderType:  # noqa: ARG003
+        """Return BUILTIN if an unknown value is provided."""
+        return cls.BUILTIN
+
+
+class Scope(StrEnum):
+    """Scope enum for fine grained access to (parts of) the API."""
+
+    ALL = "*"
+    LIBRARY_READ = "library.read"
+    LIBRARY_WRITE = "library.write"
+    LIBRARY_MANAGE = "library.manage"
+    PLAYERS_READ = "players.read"
+    PLAYERS_CONTROL = "players.control"
+    QUEUES_READ = "queues.read"
+    QUEUES_CONTROL = "queues.control"
+    PROVIDERS_READ = "providers.read"
+    CONFIG_PLAYERS_READ = "config.players.read"
+    CONFIG_PLAYERS_WRITE = "config.players.write"
+    CONFIG_PROVIDERS_READ = "config.providers.read"
+    CONFIG_PROVIDERS_WRITE = "config.providers.write"
+    CONFIG_CORE_READ = "config.core.read"
+    CONFIG_CORE_WRITE = "config.core.write"
+    USERS_MANAGE = "users.manage"
+    USERS_IMPERSONATE = "users.impersonate"
+    USERS_INVITE = "users.invite"
+    SYSTEM_READ = "system.read"
+    SYSTEM_MANAGE = "system.manage"
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def _missing_(cls, value: object) -> Scope:  # noqa: ARG003
+        """Return UNKNOWN (which grants no access) if an unknown value is provided."""
+        return cls.UNKNOWN
+
 
 @dataclass
 class User(DataClassORJSONMixin):
@@ -31,7 +74,8 @@ class User(DataClassORJSONMixin):
 
     user_id: str
     username: str
-    role: UserRole
+    # the id of the role assigned to the user (see UserRole for the builtin roles)
+    role: str
     enabled: bool = True
     created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
     display_name: str | None = None

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,42 @@
+"""Tests for the authentication models."""
+
+import pytest
+
+from music_assistant_models.auth import (
+    AuthProviderType,
+    Scope,
+    User,
+    UserRole,
+)
+
+
+def test_user_role_validation() -> None:
+    """Test that an unknown (builtin) user role raises on validation."""
+    with pytest.raises(ValueError, match="some_future_role"):
+        UserRole("some_future_role")
+    assert UserRole("admin") == UserRole.ADMIN
+
+
+def test_auth_provider_type_missing() -> None:
+    """Test that an unknown auth provider type falls back to BUILTIN."""
+    assert AuthProviderType("some_future_provider") == AuthProviderType.BUILTIN
+    assert AuthProviderType("homeassistant") == AuthProviderType.HOME_ASSISTANT
+
+
+def test_scope_missing() -> None:
+    """Test that an unknown scope falls back to UNKNOWN (which grants no access)."""
+    assert Scope("some.future.scope") == Scope.UNKNOWN
+    assert Scope("library.read") == Scope.LIBRARY_READ
+
+
+def test_user_with_unknown_role_deserializes() -> None:
+    """Test that a User with an unknown role id deserializes with the role id preserved."""
+    user = User.from_dict(
+        {
+            "user_id": "abc123",
+            "username": "testuser",
+            "role": "some_future_role",
+        }
+    )
+    # the role id is preserved as-is, to allow for custom roles in the future
+    assert user.role == "some_future_role"


### PR DESCRIPTION
## What does this implement/fix?

The server is moving from static role checks (admin/user/guest) to fine grained, scope based authorization on each API command (see companion PR in music-assistant/server). This adds the shared vocabulary; the role -> scope policy itself lives in the server, where custom roles will be resolved in the future.

- `Scope` enum: fine grained access scopes in `resource.action` dot notation, with an `UNKNOWN` fallback member so unknown scopes never grant access
- New builtin `service` role id: slightly elevated rights over a regular user, used for the Home Assistant system user
- `User.role` is now a plain string role id instead of an enum value, preparing for custom (user defined) roles later; `UserRole` remains as the ids of the builtin roles
- `_missing_` fallback on `AuthProviderType` (-> `BUILTIN`) so the enum can be extended without breaking older clients

Companion PR: music-assistant/server (scope based authorization + centralized impersonation)