### PR TITLE
Add AudioMetadata model to expose BPM and musical key on tracks

### DIFF
--- a/music_assistant_models/media_items/__init__.py
+++ b/music_assistant_models/media_items/__init__.py
@@ -32,6 +32,7 @@ from .media_item import (
     Track,
 )
 from .metadata import (
+    AudioMetadata,
     MediaItemChapter,
     MediaItemCollection,
     MediaItemImage,
@@ -45,6 +46,7 @@ __all__ = [
     "Album",
     "Artist",
     "AudioFormat",
+    "AudioMetadata",
     "AudioSource",
     "Audiobook",
     "BrowseFolder",

--- a/music_assistant_models/media_items/media_item.py
+++ b/music_assistant_models/media_items/media_item.py
@@ -21,7 +21,7 @@ from music_assistant_models.helpers import (
 from music_assistant_models.translations import resolve_translation, translations_active
 from music_assistant_models.unique_list import UniqueList
 
-from .metadata import MediaItemImage, MediaItemMetadata
+from .metadata import AudioMetadata, MediaItemImage, MediaItemMetadata
 from .provider_mapping import ProviderMapping
 
 
@@ -345,6 +345,8 @@ class Track(MediaItem):
     album: Album | ItemMapping | None = None  # required for album tracks
     disc_number: int = 0  # required for album tracks
     track_number: int = 0  # required for album tracks
+    # only populated when a FULL track is requested (get_track), not on track listings
+    audio_metadata: AudioMetadata | None = None
 
     @property
     def image(self) -> MediaItemImage | None:

--- a/music_assistant_models/media_items/metadata.py
+++ b/music_assistant_models/media_items/metadata.py
@@ -138,6 +138,14 @@ class MediaItemCollection(DataClassDictMixin):
 
 
 @dataclass(kw_only=True)
+class AudioMetadata(DataClassDictMixin):
+    """Model for audio-analysis-derived metadata of a track."""
+
+    bpm: float | None = None  # beats per minute
+    musical_key: str | None = None  # pitch class plus mode, e.g. "F# minor"
+
+
+@dataclass(kw_only=True)
 class MediaItemMetadata(DataClassDictMixin):
     """Model for a MediaItem's metadata."""
 


### PR DESCRIPTION
The Music Assistant server wants to expose audio-analysis-derived metadata (BPM and musical key) on full Track objects to the frontend.

- Add `AudioMetadata` dataclass (`bpm: float | None`, `musical_key: str | None`) in `media_items/metadata.py`
- Add optional `audio_metadata: AudioMetadata | None` field to `Track`, only populated when a full track is requested (get_track)
- Export `AudioMetadata` from `music_assistant_models.media_items`