### PR TITLE
Add TrackType enum and track_type field to Track model

### DIFF
--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -169,6 +169,26 @@ class AlbumType(StrEnum):
         return cls.UNKNOWN
 
 
+class TrackType(StrEnum):
+    """Enum for Track type."""
+
+    STUDIO = "studio"
+    LIVE = "live"
+    KARAOKE = "karaoke"
+    DEMO = "demo"
+    REHEARSAL = "rehearsal"
+    INSTRUMENTAL = "instrumental"
+    ACAPELLA = "acapella"
+    COVER = "cover"
+    REMIX = "remix"
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def _missing_(cls, value: object) -> TrackType:  # noqa: ARG003
+        """Set default enum member if an unknown value is provided."""
+        return cls.UNKNOWN
+
+
 class ArtistType(StrEnum):
     """Enum for Artist type."""
 

--- a/music_assistant_models/media_items/media_item.py
+++ b/music_assistant_models/media_items/media_item.py
@@ -9,7 +9,14 @@ from typing import TYPE_CHECKING, Any, cast
 
 from mashumaro import DataClassDictMixin, field_options
 
-from music_assistant_models.enums import AlbumType, ArtistType, ExternalID, ImageType, MediaType
+from music_assistant_models.enums import (
+    AlbumType,
+    ArtistType,
+    ExternalID,
+    ImageType,
+    MediaType,
+    TrackType,
+)
 from music_assistant_models.errors import InvalidDataError
 from music_assistant_models.helpers import (
     create_sort_name,
@@ -345,6 +352,7 @@ class Track(MediaItem):
     album: Album | ItemMapping | None = None  # required for album tracks
     disc_number: int = 0  # required for album tracks
     track_number: int = 0  # required for album tracks
+    track_type: TrackType = TrackType.UNKNOWN
     # only populated when a FULL track is requested (get_track), not on track listings
     audio_metadata: AudioMetadata | None = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,8 @@ test = [
 ]
 
 [tool.codespell]
+# "acapella" is a common alternative spelling of "a cappella" used by MusicBrainz
+ignore-words-list = "acapella,"
 skip = "*.js"
 
 [tool.setuptools]


### PR DESCRIPTION
## What does this implement/fix?

Adds a `TrackType` enum and `track_type` field to the `Track` model to distinguish between different types of recordings (e.g., live vs studio, karaoke, demo, etc.).

This is analogous to the existing `album_type` field on `Album` and enables:
- Better track metadata representation
- MusicBrainz disambiguation field support
- Future Smart Playlist filtering by track type (similar to existing album_type filtering)

### TrackType values:
- `STUDIO` - Studio recording
- `LIVE` - Live performance
- `KARAOKE` - Karaoke version
- `DEMO` - Demo recording
- `REHEARSAL` - Rehearsal recording
- `INSTRUMENTAL` - Instrumental version
- `ACAPELLA` - A cappella version
- `COVER` - Cover version
- `REMIX` - Remix
- `UNKNOWN` - Default/unknown type

### Future enhancement
This field should eventually be exposed in Smart Playlist filters, similar to how `album_type` filtering currently works.

## Related PRs
- Server implementation: music-assistant/server (will be created as draft once this is merged)