### PR TITLE
Add PROVIDER_EVENT event type for provider-emitted events

### DIFF
--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -553,6 +553,10 @@ class EventType(StrEnum):
     MEDIA_ITEM_UPDATED = "media_item_updated"
     MEDIA_ITEM_DELETED = "media_item_deleted"
     PROVIDERS_UPDATED = "providers_updated"
+    # generic event emitted by a provider instance;
+    # object_id = provider instance_id (optionally suffixed with /sub_scope),
+    # data = provider-defined payload
+    PROVIDER_EVENT = "provider_event"
     SYNC_TASKS_UPDATED = "sync_tasks_updated"
     TASKS_UPDATED = "tasks_updated"
     MUSIC_SYNC_COMPLETED = "music_sync_completed"

--- a/music_assistant_models/event.py
+++ b/music_assistant_models/event.py
@@ -14,7 +14,7 @@ class MassEvent(DataClassORJSONMixin):
     """Representation of an Event emitted in/by Music Assistant."""
 
     event: EventType
-    object_id: str | None = None  # player_id, queue_id or uri
+    object_id: str | None = None  # player_id, queue_id, uri or provider instance_id
     data: Any = field(
         default=None,
         metadata={"serialize": lambda v: get_serializable_value(v)},


### PR DESCRIPTION
Providers (especially plugin providers) currently have no way to push state updates to connected clients, forcing frontends to poll. This adds a generic event type so providers can push custom events; routing/delivery follows in a server PR.

Changes:
- Add `EventType.PROVIDER_EVENT` ("provider_event")
- Convention: `object_id` = provider instance_id (optionally with a `/sub_scope` suffix), `data` = provider-defined payload
- Extend the `object_id` comment on `MassEvent` to include provider instance_id