### PR TITLE
Add SoundEffect media item support

### DIFF
--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -20,7 +20,6 @@ class MediaTypeMeta(EnumType):
             MediaType.RADIO,
             MediaType.AUDIOBOOK,
             MediaType.PODCAST,
-            MediaType.SOUND_EFFECT,
             MediaType.GENRE,
         ]
 
@@ -588,7 +587,6 @@ class ProviderFeature(StrEnum):
     LIBRARY_RADIOS = "library_radios"
     LIBRARY_AUDIOBOOKS = "library_audiobooks"
     LIBRARY_PODCASTS = "library_podcasts"
-    LIBRARY_SOUND_EFFECTS = "library_sound_effects"
 
     # additional library features
     AUTHOR_AUDIOBOOKS = "author_audiobooks"
@@ -614,7 +612,6 @@ class ProviderFeature(StrEnum):
     LIBRARY_RADIOS_EDIT = "library_radios_edit"
     LIBRARY_AUDIOBOOKS_EDIT = "library_audiobooks_edit"
     LIBRARY_PODCASTS_EDIT = "library_podcasts_edit"
-    LIBRARY_SOUND_EFFECTS_EDIT = "library_sound_effects_edit"
 
     # favorites editing per mediatype
     FAVORITE_ARTISTS_EDIT = "favorite_artists_edit"
@@ -624,7 +621,6 @@ class ProviderFeature(StrEnum):
     FAVORITE_RADIOS_EDIT = "favorite_radios_edit"
     FAVORITE_AUDIOBOOKS_EDIT = "favorite_audiobooks_edit"
     FAVORITE_PODCASTS_EDIT = "favorite_podcasts_edit"
-    FAVORITE_SOUND_EFFECTS_EDIT = "favorite_sound_effects_edit"
 
     # if we can grab 'similar tracks' from the music provider or plugin
     # used to generate dynamic playlists

--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -20,6 +20,7 @@ class MediaTypeMeta(EnumType):
             MediaType.RADIO,
             MediaType.AUDIOBOOK,
             MediaType.PODCAST,
+            MediaType.SOUND_EFFECT,
             MediaType.GENRE,
         ]
 
@@ -587,6 +588,7 @@ class ProviderFeature(StrEnum):
     LIBRARY_RADIOS = "library_radios"
     LIBRARY_AUDIOBOOKS = "library_audiobooks"
     LIBRARY_PODCASTS = "library_podcasts"
+    LIBRARY_SOUND_EFFECTS = "library_sound_effects"
 
     # additional library features
     AUTHOR_AUDIOBOOKS = "author_audiobooks"
@@ -612,6 +614,7 @@ class ProviderFeature(StrEnum):
     LIBRARY_RADIOS_EDIT = "library_radios_edit"
     LIBRARY_AUDIOBOOKS_EDIT = "library_audiobooks_edit"
     LIBRARY_PODCASTS_EDIT = "library_podcasts_edit"
+    LIBRARY_SOUND_EFFECTS_EDIT = "library_sound_effects_edit"
 
     # favorites editing per mediatype
     FAVORITE_ARTISTS_EDIT = "favorite_artists_edit"
@@ -621,6 +624,7 @@ class ProviderFeature(StrEnum):
     FAVORITE_RADIOS_EDIT = "favorite_radios_edit"
     FAVORITE_AUDIOBOOKS_EDIT = "favorite_audiobooks_edit"
     FAVORITE_PODCASTS_EDIT = "favorite_podcasts_edit"
+    FAVORITE_SOUND_EFFECTS_EDIT = "favorite_sound_effects_edit"
 
     # if we can grab 'similar tracks' from the music provider or plugin
     # used to generate dynamic playlists

--- a/music_assistant_models/media_items/__init__.py
+++ b/music_assistant_models/media_items/__init__.py
@@ -29,6 +29,7 @@ from .media_item import (
     PodcastEpisode,
     Radio,
     RecommendationFolder,
+    SoundEffect,
     Track,
 )
 from .metadata import (
@@ -72,6 +73,7 @@ __all__ = [
     "ProviderMapping",
     "Radio",
     "RecommendationFolder",
+    "SoundEffect",
     "Track",
     "UniqueList",
 ]
@@ -89,6 +91,7 @@ class SearchResults(DataClassDictMixin):
     radio: Sequence[Radio | ItemMapping] = field(default_factory=list)
     audiobooks: Sequence[Audiobook | ItemMapping] = field(default_factory=list)
     podcasts: Sequence[Podcast | ItemMapping] = field(default_factory=list)
+    sound_effects: Sequence[SoundEffect | ItemMapping] = field(default_factory=list)
 
 
 def media_from_dict(media_item: dict[str, Any]) -> MediaItemType | ItemMapping:
@@ -113,6 +116,8 @@ def media_from_dict(media_item: dict[str, Any]) -> MediaItemType | ItemMapping:
         return Podcast.from_dict(media_item)
     if media_item["media_type"] == "podcast_episode":
         return PodcastEpisode.from_dict(media_item)
+    if media_item["media_type"] == "sound_effect":
+        return SoundEffect.from_dict(media_item)
     if media_item["media_type"] == "audio_source":
         return AudioSource.from_dict(media_item)
     raise InvalidDataError("Unknown media type")

--- a/music_assistant_models/media_items/media_item.py
+++ b/music_assistant_models/media_items/media_item.py
@@ -617,7 +617,8 @@ MediaItemType = (
     | Audiobook
     | Podcast
     | PodcastEpisode
+    | SoundEffect
     | Genre
     | AudioSource
 )
-PlayableMediaItemType = Track | Radio | Audiobook | PodcastEpisode | AudioSource
+PlayableMediaItemType = Track | Radio | Audiobook | PodcastEpisode | SoundEffect | AudioSource

--- a/tests/test_sound_effect.py
+++ b/tests/test_sound_effect.py
@@ -1,0 +1,68 @@
+"""Tests for the SoundEffect MediaItem and related types."""
+
+from music_assistant_models.enums import MediaType
+from music_assistant_models.media_items import (
+    ItemMapping,
+    SoundEffect,
+    media_from_dict,
+)
+from music_assistant_models.media_items.provider_mapping import ProviderMapping
+
+
+def _make_sound_effect() -> SoundEffect:
+    return SoundEffect(
+        item_id="rain-loop",
+        provider="soundlib",
+        name="Rain Loop",
+        provider_mappings={
+            ProviderMapping(
+                item_id="rain-loop",
+                provider_domain="soundlib",
+                provider_instance="soundlib",
+            )
+        },
+        duration=30,
+    )
+
+
+def test_media_type_sound_effect_roundtrips() -> None:
+    """MediaType.SOUND_EFFECT is reachable and round-trips through StrEnum."""
+    assert MediaType("sound_effect") is MediaType.SOUND_EFFECT
+    assert MediaType.SOUND_EFFECT.value == "sound_effect"
+
+
+def test_sound_effect_defaults() -> None:
+    """SoundEffect has sane defaults aligned with the model contract."""
+    item = SoundEffect(
+        item_id="x",
+        provider="y",
+        name="z",
+        provider_mappings=set(),
+    )
+    assert item.media_type == MediaType.SOUND_EFFECT
+    assert item.duration == 0
+    assert item.uri == "y://sound_effect/x"
+
+
+def test_sound_effect_serialize_roundtrip() -> None:
+    """SoundEffect survives a to_dict -> from_dict round-trip."""
+    original = _make_sound_effect()
+    data = original.to_dict()
+    restored = SoundEffect.from_dict(data)
+    # MediaItem.__eq__ only checks the URI, so compare the serialized form to
+    # verify the full payload (duration, provider mappings, ...)
+    assert restored.to_dict() == data
+
+
+def test_media_from_dict_returns_sound_effect() -> None:
+    """media_from_dict deserializes sound_effect payloads to SoundEffect."""
+    result = media_from_dict(_make_sound_effect().to_dict())
+    assert isinstance(result, SoundEffect)
+    assert result.media_type == MediaType.SOUND_EFFECT
+
+
+def test_item_mapping_for_sound_effect() -> None:
+    """A SoundEffect can be reduced to an ItemMapping like other media items."""
+    mapping = ItemMapping.from_item(_make_sound_effect())
+    assert mapping.media_type == MediaType.SOUND_EFFECT
+    assert mapping.item_id == "rain-loop"


### PR DESCRIPTION
The `SoundEffect` media item and `MediaType.SOUND_EFFECT` already existed but were not fully wired up, so sound effects could not be used as a playable media type. This completes the core support as groundwork for the audio overlays feature in the server repo (queue audio overlay feature, reshaping music-assistant/server#3844).

Sound effects are fetched live (and cached) from providers rather than synced into the library, so no library/favorite provider features are added — those can be added later if needed.

- Add `SoundEffect` to the `MediaItemType` and `PlayableMediaItemType` unions
- Export `SoundEffect` from the `media_items` package
- Add `sound_effects` to `SearchResults` and handle `sound_effect` in `media_from_dict`
- Add tests for the `SoundEffect` model