### PR TITLE
Add sound effects provider feature

### DIFF
--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -666,6 +666,8 @@ class ProviderFeature(StrEnum):
     # PLUGIN FEATURES
     #
     AUDIO_SOURCE = "audio_source"
+    # provider can enumerate sound effect items (live, not library-backed)
+    SOUND_EFFECTS = "sound_effects"
     AUDIO_OVERLAY = "audio_overlay"  # plugin can mix an audio overlay into queue playback
 
     #

--- a/tests/test_sound_effect.py
+++ b/tests/test_sound_effect.py
@@ -1,6 +1,6 @@
 """Tests for the SoundEffect MediaItem and related types."""
 
-from music_assistant_models.enums import MediaType
+from music_assistant_models.enums import MediaType, ProviderFeature
 from music_assistant_models.media_items import (
     ItemMapping,
     SoundEffect,
@@ -29,6 +29,12 @@ def test_media_type_sound_effect_roundtrips() -> None:
     """MediaType.SOUND_EFFECT is reachable and round-trips through StrEnum."""
     assert MediaType("sound_effect") is MediaType.SOUND_EFFECT
     assert MediaType.SOUND_EFFECT.value == "sound_effect"
+
+
+def test_provider_feature_sound_effects_roundtrips() -> None:
+    """ProviderFeature.SOUND_EFFECTS is reachable and round-trips through StrEnum."""
+    assert ProviderFeature("sound_effects") is ProviderFeature.SOUND_EFFECTS
+    assert ProviderFeature.SOUND_EFFECTS.value == "sound_effects"
 
 
 def test_sound_effect_defaults() -> None:


### PR DESCRIPTION
- Add `ProviderFeature.SOUND_EFFECTS` so providers can declare they offer sound effect items (fetched live from the provider, not library-backed)
- Used by the upcoming audio overlay feature in the server