### PR TITLE
Make sound effect names translatable

### DIFF
--- a/music_assistant_models/media_items/media_item.py
+++ b/music_assistant_models/media_items/media_item.py
@@ -470,7 +470,7 @@ class PodcastEpisode(MediaItem):
 
 
 @dataclass(kw_only=True)
-class SoundEffect(MediaItem):
+class SoundEffect(_LocalizableName, MediaItem):
     """Model for a Sound Effect."""
 
     __hash__ = _MediaItemBase.__hash__

--- a/tests/test_sound_effect.py
+++ b/tests/test_sound_effect.py
@@ -72,3 +72,30 @@ def test_item_mapping_for_sound_effect() -> None:
     mapping = ItemMapping.from_item(_make_sound_effect())
     assert mapping.media_type == MediaType.SOUND_EFFECT
     assert mapping.item_id == "rain-loop"
+
+
+def test_translation_key_roundtrips() -> None:
+    """A translation_key survives a to_dict -> from_dict round-trip."""
+    original = _make_sound_effect()
+    original.translation_key = "white_noise"
+    restored = SoundEffect.from_dict(original.to_dict())
+    assert restored.translation_key == "white_noise"
+
+
+def test_translation_key_is_opt_in() -> None:
+    """translation_key defaults to None and older payloads without the key deserialize."""
+    item = _make_sound_effect()
+    assert item.translation_key is None
+    legacy = item.to_dict()
+    legacy.pop("translation_key", None)
+    restored = SoundEffect.from_dict(legacy)
+    assert restored.translation_key is None
+
+
+def test_item_mapping_preserves_translation_key() -> None:
+    """ItemMapping.from_item keeps translation_key and media_type of a SoundEffect."""
+    item = _make_sound_effect()
+    item.translation_key = "white_noise"
+    mapping = ItemMapping.from_item(item)
+    assert mapping.media_type == MediaType.SOUND_EFFECT
+    assert mapping.translation_key == "white_noise"

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -16,6 +16,7 @@ from music_assistant_models.media_items import (
     ProviderMapping,
     Radio,
     RecommendationFolder,
+    SoundEffect,
     Track,
 )
 from music_assistant_models.player import (
@@ -39,6 +40,7 @@ _CATALOG = {
     "media.recommendations.recently_played.subtitle": "Ga verder waar je gebleven was",
     "media.folder.libraries.name": "Bibliotheken",
     "media.podcast.unknown_podcast.name": "Onbekende podcast",
+    "media.sound_effect.white_noise.name": "Witte ruis",
     "media.genre.jazz.name": "Jazz (NL)",
     "media.genre.jazz.description": "Jazz is een Amerikaans muziekgenre.",
     "media.genre.comedy.name": "Komedie (muziek)",
@@ -255,6 +257,19 @@ def test_podcast_resolves_name() -> None:
     )
     with _resolver_active():
         assert podcast.to_dict()["name"] == "Onbekende podcast"
+
+
+def test_sound_effect_resolves_name() -> None:
+    """A SoundEffect localizes its name from media.sound_effect.<key>.name."""
+    sound_effect = SoundEffect(
+        item_id="white-noise",
+        provider="ambient_sounds",
+        name="White noise",
+        translation_key="white_noise",
+        provider_mappings=set(),
+    )
+    with _resolver_active():
+        assert sound_effect.to_dict()["name"] == "Witte ruis"
 
 
 def test_item_mapping_media_type_keeps_its_default() -> None:


### PR DESCRIPTION
- Add the localizable-name mixin to `SoundEffect` so its name can be translated via an optional `translation_key` (like Podcast/Genre)
- Needed for server providers that ship built-in sound effect presets (e.g. "White noise", "Ocean waves") whose names should localize like the builtin provider's playlists
- Add serialization and translation tests; `translation_key` stays opt-in so existing payloads are unaffected