### PR TITLE
Add artist entity type and life span metadata fields

### DIFF
--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -190,8 +190,8 @@ class ArtistType(StrEnum):
     UNKNOWN = "unknown"
 
 
-class ArtistCategory(StrEnum):
-    """Enum for Artist category (MusicBrainz artist type)."""
+class ArtistEntityType(StrEnum):
+    """Enum for Artist entity type (mirrors MusicBrainz artist type)."""
 
     PERSON = "person"  # individual person
     GROUP = "group"  # music group
@@ -202,7 +202,7 @@ class ArtistCategory(StrEnum):
     UNKNOWN = "unknown"
 
     @classmethod
-    def _missing_(cls, value: object) -> ArtistCategory:  # noqa: ARG003
+    def _missing_(cls, value: object) -> ArtistEntityType:  # noqa: ARG003
         """Set default enum member if an unknown value is provided."""
         return cls.UNKNOWN
 

--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -177,8 +177,21 @@ class ArtistType(StrEnum):
     NARRATOR = "narrator"  # narrator of an audiobook
     UNKNOWN = "unknown"
 
+
+class ArtistCategory(StrEnum):
+    """Enum for Artist category (MusicBrainz artist type)."""
+
+    PERSON = "person"  # individual person
+    GROUP = "group"  # music group
+    BAND = "band"  # band
+    ORCHESTRA = "orchestra"  # orchestra
+    CHOIR = "choir"  # choir
+    CHARACTER = "character"  # fictional character
+    OTHER = "other"  # other
+    UNKNOWN = "unknown"
+
     @classmethod
-    def _missing_(cls, value: object) -> ArtistType:  # noqa: ARG003
+    def _missing_(cls, value: object) -> ArtistCategory:  # noqa: ARG003
         """Set default enum member if an unknown value is provided."""
         return cls.UNKNOWN
 

--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -195,7 +195,6 @@ class ArtistCategory(StrEnum):
 
     PERSON = "person"  # individual person
     GROUP = "group"  # music group
-    BAND = "band"  # band
     ORCHESTRA = "orchestra"  # orchestra
     CHOIR = "choir"  # choir
     CHARACTER = "character"  # fictional character

--- a/music_assistant_models/media_items/media_item.py
+++ b/music_assistant_models/media_items/media_item.py
@@ -11,7 +11,7 @@ from mashumaro import DataClassDictMixin, field_options
 
 from music_assistant_models.enums import (
     AlbumType,
-    ArtistCategory,
+    ArtistEntityType,
     ArtistType,
     ExternalID,
     ImageType,
@@ -319,7 +319,7 @@ class Artist(MediaItem):
 
     media_type: MediaType = MediaType.ARTIST
     artist_type: ArtistType = ArtistType.SINGER
-    artist_category: ArtistCategory = ArtistCategory.UNKNOWN
+    artist_entity_type: ArtistEntityType = ArtistEntityType.UNKNOWN
 
 
 @dataclass(kw_only=True)

--- a/music_assistant_models/media_items/media_item.py
+++ b/music_assistant_models/media_items/media_item.py
@@ -9,7 +9,14 @@ from typing import TYPE_CHECKING, Any, cast
 
 from mashumaro import DataClassDictMixin, field_options
 
-from music_assistant_models.enums import AlbumType, ArtistType, ExternalID, ImageType, MediaType
+from music_assistant_models.enums import (
+    AlbumType,
+    ArtistCategory,
+    ArtistType,
+    ExternalID,
+    ImageType,
+    MediaType,
+)
 from music_assistant_models.errors import InvalidDataError
 from music_assistant_models.helpers import (
     create_sort_name,
@@ -311,6 +318,7 @@ class Artist(MediaItem):
 
     media_type: MediaType = MediaType.ARTIST
     artist_type: ArtistType = ArtistType.SINGER
+    artist_category: ArtistCategory = ArtistCategory.UNKNOWN
 
 
 @dataclass(kw_only=True)

--- a/music_assistant_models/media_items/media_item.py
+++ b/music_assistant_models/media_items/media_item.py
@@ -11,7 +11,6 @@ from mashumaro import DataClassDictMixin, field_options
 
 from music_assistant_models.enums import (
     AlbumType,
-    ArtistEntityType,
     ArtistType,
     ExternalID,
     ImageType,
@@ -319,7 +318,6 @@ class Artist(MediaItem):
 
     media_type: MediaType = MediaType.ARTIST
     artist_type: ArtistType = ArtistType.SINGER
-    artist_entity_type: ArtistEntityType = ArtistEntityType.UNKNOWN
 
 
 @dataclass(kw_only=True)

--- a/music_assistant_models/media_items/metadata.py
+++ b/music_assistant_models/media_items/metadata.py
@@ -145,6 +145,15 @@ class AudioMetadata(DataClassDictMixin):
     musical_key: str | None = None  # pitch class plus mode, e.g. "F# minor"
 
 
+@dataclass(frozen=True, kw_only=True)
+class LifeSpan(DataClassDictMixin):
+    """Life span dates for an artist (person or group)."""
+
+    begin: str | None = None  # ISO date (YYYY-MM-DD) or partial (YYYY-MM or YYYY)
+    end: str | None = None  # ISO date (YYYY-MM-DD) or partial (YYYY-MM or YYYY)
+    ended: bool = False  # whether the artist is deceased or the group has disbanded
+
+
 @dataclass(kw_only=True)
 class MediaItemMetadata(DataClassDictMixin):
     """Model for a MediaItem's metadata."""
@@ -152,6 +161,8 @@ class MediaItemMetadata(DataClassDictMixin):
     description: str | None = None
     # ISO 639-1 language code for `description`
     description_language: str | None = None
+    # Artist-specific metadata (applicable to Artist media type only)
+    life_span: LifeSpan | None = None  # birth/death for persons, founded/disbanded for groups
     review: str | None = None
     explicit: bool | None = None
     # NOTE: images is a list of available images, sorted by preference

--- a/music_assistant_models/media_items/metadata.py
+++ b/music_assistant_models/media_items/metadata.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from mashumaro import DataClassDictMixin
 
-from music_assistant_models.enums import ImageType, LinkType
+from music_assistant_models.enums import ArtistEntityType, ImageType, LinkType
 from music_assistant_models.helpers import merge_lists
 from music_assistant_models.unique_list import UniqueList
 
@@ -163,6 +163,7 @@ class MediaItemMetadata(DataClassDictMixin):
     description_language: str | None = None
     # Artist-specific metadata (applicable to Artist media type only)
     life_span: LifeSpan | None = None  # birth/death for persons, founded/disbanded for groups
+    artist_entity_type: ArtistEntityType | None = None  # MusicBrainz artist entity type
     review: str | None = None
     explicit: bool | None = None
     # NOTE: images is a list of available images, sorted by preference


### PR DESCRIPTION
Adds artist-specific metadata fields to enable providers to store artist entity type and birth/death dates (for persons) or founded/disbanded dates (for groups).

## Changes

- Added `ArtistEntityType` enum (PERSON, GROUP, ORCHESTRA, CHOIR, CHARACTER, OTHER, UNKNOWN)
- Added `Artist.artist_entity_type` field to distinguish person vs group artists
- Added `LifeSpan` dataclass with `begin`, `end`, and `ended` fields
- Added `life_span` field to `MediaItemMetadata`

## Benefits

- Metadata providers (MusicBrainz, Last.fm, etc.) can store artist entity type and dates in metadata instead of requiring repeated API calls
- Enables efficient birthday/memorial/founding/disbanding recommendations
- Allows frontend to display artist birth/death dates on artist detail pages (can be implemented in a future PR)
- Dates support full ISO format (YYYY-MM-DD) or partial dates (YYYY-MM or YYYY)

## Design Decision

Uses `Artist.artist_entity_type` instead of `metadata.artist_type` to avoid confusion with the existing `Artist.artist_type` field:
- `artist_type` = role/function (SINGER for music, AUTHOR/NARRATOR for audiobooks)
- `artist_entity_type` = MusicBrainz artist entity type (PERSON vs GROUP vs ORCHESTRA, etc.)

An artist can be both `artist_type=SINGER` and `artist_entity_type=PERSON` without confusion.

## Related

This prepares the groundwork for music-assistant/server#4687 (MusicBrainz recommendations) which currently fetches artist data via API for every scan. With these fields, the data can be stored in metadata.