### PR TITLE
Add RecommendationFolderType enum for folder display behavior

### DIFF
--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -169,6 +169,18 @@ class AlbumType(StrEnum):
         return cls.UNKNOWN
 
 
+class RecommendationFolderType(StrEnum):
+    """Enum for RecommendationFolder type."""
+
+    DEFAULT = "default"
+    TIMELINE = "timeline"
+
+    @classmethod
+    def _missing_(cls, value: object) -> RecommendationFolderType:  # noqa: ARG003
+        """Set default enum member if an unknown value is provided."""
+        return cls.DEFAULT
+
+
 class ArtistType(StrEnum):
     """Enum for Artist type."""
 

--- a/music_assistant_models/media_items/media_item.py
+++ b/music_assistant_models/media_items/media_item.py
@@ -9,7 +9,14 @@ from typing import TYPE_CHECKING, Any, cast
 
 from mashumaro import DataClassDictMixin, field_options
 
-from music_assistant_models.enums import AlbumType, ArtistType, ExternalID, ImageType, MediaType
+from music_assistant_models.enums import (
+    AlbumType,
+    ArtistType,
+    ExternalID,
+    ImageType,
+    MediaType,
+    RecommendationFolderType,
+)
 from music_assistant_models.errors import InvalidDataError
 from music_assistant_models.helpers import (
     create_sort_name,
@@ -598,6 +605,7 @@ class RecommendationFolder(BrowseFolder):
         metadata=field_options(deserialize=_deserialize_recommendation_items),
     )
     subtitle: str | None = None  # optional subtitle for the recommendation
+    type: RecommendationFolderType = RecommendationFolderType.DEFAULT
 
     @property
     def _translation_group(self) -> str:


### PR DESCRIPTION
This PR adds a `type` field to `RecommendationFolder` with an enum to distinguish different folder display behaviors:

**New enum: `RecommendationFolderType`**
- `DEFAULT` - Regular recommendation folder (default value)
- `TIMELINE` - Timeline-style visualization for chronological events

**Benefits:**
- Providers can define how folders should be displayed
- Reduces frontend-specific logic for detecting special folder types
- Type-safe and easily extensible for future folder types

**Use case:** 
MusicBrainz recommendations can set `type=TIMELINE` for artist birthday/memorial folders, allowing the frontend to render them in a timeline view instead of requiring complex heuristics to detect these special cases.

**Related PRs:**
- Server: music-assistant/server#4687
- Frontend: music-assistant/frontend#2042

Both PRs will be updated to use this new field once merged.