### PR TITLE
Add audio processing chain models

### DIFF
--- a/music_assistant_models/audio_processing.py
+++ b/music_assistant_models/audio_processing.py
@@ -1,0 +1,269 @@
+"""Models for runtime audio processing details."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+from mashumaro import DataClassDictMixin
+
+from .dsp import DSPFilter, DSPState
+from .enums import CrossfadeMode, VolumeNormalizationMode
+from .media_items import AudioFormat, ItemMapping
+
+
+class AudioProcessingState(StrEnum):
+    """State of an audio processing snapshot."""
+
+    PENDING = "pending"
+    READY = "ready"
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def _missing_(cls, _: object) -> AudioProcessingState:
+        """Set default enum member if an unknown value is provided."""
+        return cls.UNKNOWN
+
+
+class AudioQuality(StrEnum):
+    """Effective audio quality classification."""
+
+    LOW = "low"
+    STANDARD = "standard"
+    LOSSLESS = "lossless"
+    HI_RES = "hi_res"
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def _missing_(cls, _: object) -> AudioQuality:
+        """Set default enum member if an unknown value is provided."""
+        return cls.UNKNOWN
+
+
+class AudioNormalizationMeasurementSource(StrEnum):
+    """Source of the loudness measurement used for normalization."""
+
+    TRACK = "track"
+    ALBUM = "album"
+    LIVE = "live"
+    FALLBACK = "fallback"
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def _missing_(cls, _: object) -> AudioNormalizationMeasurementSource:
+        """Set default enum member if an unknown value is provided."""
+        return cls.UNKNOWN
+
+
+class AudioCrossfadeState(StrEnum):
+    """Runtime state of a crossfade."""
+
+    PENDING = "pending"
+    APPLIED = "applied"
+    BYPASSED = "bypassed"
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def _missing_(cls, _: object) -> AudioCrossfadeState:
+        """Set default enum member if an unknown value is provided."""
+        return cls.UNKNOWN
+
+
+class AudioChannelMode(StrEnum):
+    """Effective output channel routing mode."""
+
+    STEREO = "stereo"
+    MONO = "mono"
+    LEFT = "left"
+    RIGHT = "right"
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def _missing_(cls, _: object) -> AudioChannelMode:
+        """Set default enum member if an unknown value is provided."""
+        return cls.UNKNOWN
+
+
+class AudioResamplingMethod(StrEnum):
+    """Method used to resample an output path."""
+
+    SOXR = "soxr"
+    SWR = "swr"
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def _missing_(cls, _: object) -> AudioResamplingMethod:
+        """Set default enum member if an unknown value is provided."""
+        return cls.UNKNOWN
+
+
+class AudioDitheringMethod(StrEnum):
+    """Method used to dither an output path."""
+
+    TRIANGULAR_HP = "triangular_hp"
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def _missing_(cls, _: object) -> AudioDitheringMethod:
+        """Set default enum member if an unknown value is provided."""
+        return cls.UNKNOWN
+
+
+@dataclass(kw_only=True)
+class AudioFidelity(DataClassDictMixin):
+    """Effective fidelity at an input or final output."""
+
+    quality: AudioQuality = AudioQuality.UNKNOWN
+    bit_perfect: bool | None = None
+
+
+@dataclass(kw_only=True)
+class AudioFidelitySummary(DataClassDictMixin):
+    """Minimum and maximum quality across all output paths."""
+
+    min_output_quality: AudioQuality = AudioQuality.UNKNOWN
+    max_output_quality: AudioQuality = AudioQuality.UNKNOWN
+
+
+@dataclass(kw_only=True)
+class AudioInputDetails(DataClassDictMixin):
+    """Source and server-received formats for an audio input."""
+
+    source_format: AudioFormat | None = None
+    server_input_format: AudioFormat | None = None
+    fidelity: AudioFidelity = field(default_factory=AudioFidelity)
+
+
+@dataclass(kw_only=True)
+class AudioNormalizationDetails(DataClassDictMixin):
+    """Effective volume normalization details.
+
+    ``reason_code`` is a machine-readable identifier, not presentation text.
+    """
+
+    mode: VolumeNormalizationMode = VolumeNormalizationMode.UNKNOWN
+    measurement_source: AudioNormalizationMeasurementSource = (
+        AudioNormalizationMeasurementSource.UNKNOWN
+    )
+    target_lufs: float | None = None
+    measured_lufs: float | None = None
+    applied_gain_db: float | None = None
+    target_true_peak_dbtp: float | None = None
+    target_loudness_range_lu: float | None = None
+    reason_code: str | None = None
+
+
+@dataclass(kw_only=True)
+class AudioTempoDetails(DataClassDictMixin):
+    """Active playback-speed processing details."""
+
+    playback_speed: float = 1.0
+
+
+@dataclass(kw_only=True)
+class AudioCrossfadeDetails(DataClassDictMixin):
+    """Effective crossfade details and runtime result.
+
+    ``reason_code`` is a machine-readable identifier, not presentation text.
+    """
+
+    mode: CrossfadeMode = CrossfadeMode.UNKNOWN
+    state: AudioCrossfadeState = AudioCrossfadeState.UNKNOWN
+    from_queue_item_id: str | None = None
+    to_queue_item_id: str | None = None
+    planned_duration: float | None = None
+    actual_duration: float | None = None
+    reason_code: str | None = None
+
+
+@dataclass(kw_only=True)
+class AudioOverlayDetails(DataClassDictMixin):
+    """Effective audio overlay source and volume."""
+
+    source: ItemMapping | None = None
+    volume_percent: int = 100
+
+
+@dataclass(kw_only=True)
+class AudioQueueProcessing(DataClassDictMixin):
+    """Shared queue processing before output fan-out."""
+
+    input_format: AudioFormat | None = None
+    output_format: AudioFormat | None = None
+    normalization: AudioNormalizationDetails | None = None
+    tempo: AudioTempoDetails | None = None
+    crossfade: AudioCrossfadeDetails | None = None
+    overlay: AudioOverlayDetails | None = None
+
+
+@dataclass(kw_only=True)
+class AudioDSPDetails(DataClassDictMixin):
+    """Effective user DSP applied to an output path."""
+
+    state: DSPState = DSPState.UNKNOWN
+    input_gain: float = 0.0
+    filters: list[DSPFilter] = field(default_factory=list)
+    output_gain: float = 0.0
+
+
+@dataclass(kw_only=True)
+class AudioChannelDetails(DataClassDictMixin):
+    """Effective channel routing or conversion details."""
+
+    mode: AudioChannelMode = AudioChannelMode.UNKNOWN
+
+
+@dataclass(kw_only=True)
+class AudioLimiterDetails(DataClassDictMixin):
+    """Output limiter state and threshold in dBFS."""
+
+    enabled: bool = False
+    threshold_dbfs: float | None = None
+
+
+@dataclass(kw_only=True)
+class AudioResamplingDetails(DataClassDictMixin):
+    """Effective output resampling details."""
+
+    method: AudioResamplingMethod = AudioResamplingMethod.UNKNOWN
+
+
+@dataclass(kw_only=True)
+class AudioDitheringDetails(DataClassDictMixin):
+    """Effective output dithering details."""
+
+    method: AudioDitheringMethod = AudioDitheringMethod.UNKNOWN
+
+
+@dataclass(kw_only=True)
+class AudioOutputPath(DataClassDictMixin):
+    """Processing shared by a deterministic group of output players.
+
+    ``output_format`` is the furthest downstream format known to Music Assistant.
+    ``handoff_format`` is set only when an earlier provider handoff differs.
+    """
+
+    player_ids: list[str] = field(default_factory=list)
+    input_format: AudioFormat | None = None
+    dsp: AudioDSPDetails = field(default_factory=AudioDSPDetails)
+    channels: AudioChannelDetails | None = None
+    limiter: AudioLimiterDetails = field(default_factory=AudioLimiterDetails)
+    resampling: AudioResamplingDetails | None = None
+    dithering: AudioDitheringDetails | None = None
+    output_format: AudioFormat | None = None
+    handoff_format: AudioFormat | None = None
+    fidelity: AudioFidelity = field(default_factory=AudioFidelity)
+
+
+@dataclass(kw_only=True)
+class AudioProcessingChain(DataClassDictMixin):
+    """Full runtime audio processing snapshot for a queue."""
+
+    queue_id: str = ""
+    queue_item_id: str | None = None
+    revision: int = 0
+    state: AudioProcessingState = AudioProcessingState.UNKNOWN
+    input: AudioInputDetails | None = None
+    queue_processing: AudioQueueProcessing | None = None
+    outputs: list[AudioOutputPath] = field(default_factory=list)
+    fidelity: AudioFidelitySummary | None = None

--- a/music_assistant_models/dsp.py
+++ b/music_assistant_models/dsp.py
@@ -190,6 +190,12 @@ class DSPState(StrEnum):
     ENABLED = "enabled"
     DISABLED = "disabled"
     DISABLED_BY_UNSUPPORTED_GROUP = "disabled_by_unsupported_group"
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def _missing_(cls, _: object) -> DSPState:
+        """Set default enum member if an unknown value is provided."""
+        return cls.UNKNOWN
 
 
 @dataclass(kw_only=True)

--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -384,6 +384,12 @@ class CrossfadeMode(StrEnum):
     SMART_CROSSFADE = "smart_crossfade"  # Use smart crossfade with beat matching and EQ filters
     STANDARD_CROSSFADE = "standard_crossfade"  # Use standard crossfade only
     DISABLED = "disabled"  # No crossfade
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def _missing_(cls, value: object) -> CrossfadeMode:  # noqa: ARG003
+        """Set default enum member if an unknown value is provided."""
+        return cls.UNKNOWN
 
 
 # alias for backwards compatibility
@@ -556,6 +562,7 @@ class EventType(StrEnum):
     PLAYER_OPTIONS_UPDATED = "player_options_updated"
     PLAYER_SLEEP_TIMER_UPDATED = "player_sleep_timer_updated"
     DSP_PRESETS_UPDATED = "dsp_presets_updated"
+    AUDIO_PROCESSING_UPDATED = "audio_processing_updated"
     QUEUE_ADDED = "queue_added"
     QUEUE_UPDATED = "queue_updated"
     QUEUE_ITEMS_UPDATED = "queue_items_updated"

--- a/tests/test_audio_processing.py
+++ b/tests/test_audio_processing.py
@@ -1,0 +1,252 @@
+"""Tests for audio processing models."""
+
+import orjson
+
+from music_assistant_models.audio_processing import (
+    AudioChannelDetails,
+    AudioChannelMode,
+    AudioCrossfadeDetails,
+    AudioCrossfadeState,
+    AudioDitheringDetails,
+    AudioDitheringMethod,
+    AudioDSPDetails,
+    AudioFidelity,
+    AudioFidelitySummary,
+    AudioInputDetails,
+    AudioLimiterDetails,
+    AudioNormalizationDetails,
+    AudioNormalizationMeasurementSource,
+    AudioOutputPath,
+    AudioOverlayDetails,
+    AudioProcessingChain,
+    AudioProcessingState,
+    AudioQuality,
+    AudioQueueProcessing,
+    AudioResamplingDetails,
+    AudioResamplingMethod,
+    AudioTempoDetails,
+)
+from music_assistant_models.dsp import DSPState, ToneControlFilter
+from music_assistant_models.enums import (
+    ContentType,
+    CrossfadeMode,
+    EventType,
+    MediaType,
+    VolumeNormalizationMode,
+)
+from music_assistant_models.event import MassEvent
+from music_assistant_models.helpers import get_serializable_value
+from music_assistant_models.media_items import AudioFormat, ItemMapping
+
+
+def test_audio_processing_defaults() -> None:
+    """All audio processing models have safe defaults."""
+    chain = AudioProcessingChain()
+
+    assert chain.to_dict() == {
+        "queue_id": "",
+        "queue_item_id": None,
+        "revision": 0,
+        "state": "unknown",
+        "input": None,
+        "queue_processing": None,
+        "outputs": [],
+        "fidelity": None,
+    }
+    assert AudioProcessingChain.from_dict({}) == chain
+    assert AudioInputDetails().fidelity == AudioFidelity()
+    assert AudioQueueProcessing().tempo is None
+    assert AudioOutputPath().dsp == AudioDSPDetails()
+    assert AudioOutputPath().limiter == AudioLimiterDetails()
+    assert AudioOutputPath().fidelity == AudioFidelity()
+
+
+def test_audio_processing_roundtrip() -> None:
+    """A populated snapshot survives serialization and deserialization."""
+    chain = _full_chain()
+    serialized = chain.to_dict()
+    normalization = serialized["queue_processing"]["normalization"]
+    crossfade = serialized["queue_processing"]["crossfade"]
+
+    assert get_serializable_value(chain) == serialized
+    assert AudioProcessingChain.from_dict(serialized) == chain
+    assert normalization["target_true_peak_dbtp"] == -2.0
+    assert "target_true_peak_dbfs" not in normalization
+    assert "reason_code" in normalization
+    assert "reason" not in normalization
+    assert "reason_code" in crossfade
+    assert "reason" not in crossfade
+
+
+def test_audio_processing_event_serialization() -> None:
+    """The snapshot serializes as event data."""
+    event = MassEvent(
+        event=EventType.AUDIO_PROCESSING_UPDATED,
+        object_id="queue-1",
+        data=_full_chain(),
+    )
+
+    serialized = orjson.loads(event.to_json())
+
+    assert serialized["event"] == "audio_processing_updated"
+    assert serialized["object_id"] == "queue-1"
+    assert serialized["data"]["queue_id"] == "queue-1"
+    assert serialized["data"]["outputs"][0]["player_ids"] == ["player-1", "player-2"]
+
+
+def test_unknown_audio_processing_enums_fall_back() -> None:
+    """Unknown enum values deserialize without rejecting the snapshot."""
+    payload = _full_chain().to_dict()
+    payload["state"] = "future"
+    payload["input"]["fidelity"]["quality"] = "future"
+    payload["queue_processing"]["normalization"]["measurement_source"] = "future"
+    payload["queue_processing"]["crossfade"]["mode"] = "future"
+    payload["queue_processing"]["crossfade"]["state"] = "future"
+    payload["outputs"][0]["dsp"]["state"] = "future"
+    payload["outputs"][0]["channels"]["mode"] = "future"
+    payload["outputs"][0]["resampling"]["method"] = "future"
+    payload["outputs"][0]["dithering"]["method"] = "future"
+    payload["fidelity"]["min_output_quality"] = "future"
+
+    restored = AudioProcessingChain.from_dict(payload)
+
+    assert restored.state is AudioProcessingState.UNKNOWN
+    assert restored.input is not None
+    assert restored.input.fidelity.quality is AudioQuality.UNKNOWN
+    assert restored.queue_processing is not None
+    assert restored.queue_processing.normalization is not None
+    assert (
+        restored.queue_processing.normalization.measurement_source
+        is AudioNormalizationMeasurementSource.UNKNOWN
+    )
+    assert restored.queue_processing.crossfade is not None
+    assert restored.queue_processing.crossfade.mode is CrossfadeMode.UNKNOWN
+    assert restored.queue_processing.crossfade.state is AudioCrossfadeState.UNKNOWN
+    assert restored.outputs[0].dsp.state is DSPState.UNKNOWN
+    assert restored.outputs[0].channels is not None
+    assert restored.outputs[0].channels.mode is AudioChannelMode.UNKNOWN
+    assert restored.outputs[0].resampling is not None
+    assert restored.outputs[0].resampling.method is AudioResamplingMethod.UNKNOWN
+    assert restored.outputs[0].dithering is not None
+    assert restored.outputs[0].dithering.method is AudioDitheringMethod.UNKNOWN
+    assert restored.fidelity is not None
+    assert restored.fidelity.min_output_quality is AudioQuality.UNKNOWN
+
+
+def test_unknown_fields_are_ignored() -> None:
+    """Additive unknown fields do not prevent deserialization."""
+    payload = _full_chain().to_dict()
+    payload["future"] = True
+    payload["input"]["future"] = True
+    payload["queue_processing"]["future"] = True
+    payload["queue_processing"]["normalization"]["future"] = True
+    payload["outputs"][0]["future"] = True
+    payload["outputs"][0]["dsp"]["future"] = True
+    payload["outputs"][0]["fidelity"]["future"] = True
+    payload["fidelity"]["future"] = True
+
+    restored = AudioProcessingChain.from_dict(payload)
+
+    assert restored == _full_chain()
+
+
+def _full_chain() -> AudioProcessingChain:
+    source_format = AudioFormat(
+        content_type=ContentType.FLAC,
+        codec_type=ContentType.FLAC,
+        sample_rate=96000,
+        bit_depth=24,
+        channels=2,
+        bit_rate=3200,
+    )
+    input_format = AudioFormat(
+        content_type=ContentType.PCM_S24LE,
+        codec_type=ContentType.PCM_S24LE,
+        sample_rate=96000,
+        bit_depth=24,
+        channels=2,
+    )
+    processing_format = AudioFormat(
+        content_type=ContentType.PCM_F32LE,
+        codec_type=ContentType.PCM_F32LE,
+        sample_rate=96000,
+        bit_depth=32,
+        channels=2,
+    )
+    output_format = AudioFormat(
+        content_type=ContentType.FLAC,
+        codec_type=ContentType.FLAC,
+        sample_rate=48000,
+        bit_depth=24,
+        channels=1,
+        bit_rate=1200,
+    )
+    overlay_source = ItemMapping(
+        media_type=MediaType.SOUND_EFFECT,
+        item_id="rain",
+        provider="builtin",
+        name="Rain",
+    )
+    return AudioProcessingChain(
+        queue_id="queue-1",
+        queue_item_id="item-1",
+        revision=3,
+        state=AudioProcessingState.READY,
+        input=AudioInputDetails(
+            source_format=source_format,
+            server_input_format=input_format,
+            fidelity=AudioFidelity(quality=AudioQuality.HI_RES, bit_perfect=True),
+        ),
+        queue_processing=AudioQueueProcessing(
+            input_format=input_format,
+            output_format=processing_format,
+            normalization=AudioNormalizationDetails(
+                mode=VolumeNormalizationMode.DYNAMIC,
+                measurement_source=AudioNormalizationMeasurementSource.LIVE,
+                target_lufs=-14.0,
+                measured_lufs=-17.2,
+                target_true_peak_dbtp=-2.0,
+                target_loudness_range_lu=10.0,
+            ),
+            tempo=AudioTempoDetails(playback_speed=1.25),
+            crossfade=AudioCrossfadeDetails(
+                mode=CrossfadeMode.SMART_CROSSFADE,
+                state=AudioCrossfadeState.APPLIED,
+                from_queue_item_id="item-0",
+                to_queue_item_id="item-1",
+                planned_duration=8.0,
+                actual_duration=7.8,
+            ),
+            overlay=AudioOverlayDetails(source=overlay_source, volume_percent=40),
+        ),
+        outputs=[
+            AudioOutputPath(
+                player_ids=["player-1", "player-2"],
+                input_format=processing_format,
+                dsp=AudioDSPDetails(
+                    state=DSPState.ENABLED,
+                    input_gain=-1.0,
+                    filters=[
+                        ToneControlFilter(
+                            enabled=True,
+                            bass_level=1.5,
+                            mid_level=0.0,
+                            treble_level=-0.5,
+                        )
+                    ],
+                    output_gain=-0.5,
+                ),
+                channels=AudioChannelDetails(mode=AudioChannelMode.LEFT),
+                limiter=AudioLimiterDetails(enabled=True, threshold_dbfs=-2.0),
+                resampling=AudioResamplingDetails(method=AudioResamplingMethod.SOXR),
+                dithering=AudioDitheringDetails(method=AudioDitheringMethod.TRIANGULAR_HP),
+                output_format=output_format,
+                handoff_format=processing_format,
+                fidelity=AudioFidelity(quality=AudioQuality.LOSSLESS, bit_perfect=False),
+            )
+        ],
+        fidelity=AudioFidelitySummary(
+            min_output_quality=AudioQuality.LOSSLESS,
+            max_output_quality=AudioQuality.LOSSLESS,
+        ),
+    )


### PR DESCRIPTION
Audio processing details currently reach clients through unrelated fields and cannot describe shared processing or grouped output paths consistently.

- Add typed input, queue-processing, output-path, and fidelity models
- Add forward-compatible processing states and update event
- Cover serialization, unknown values, and additive schema changes