### PR TITLE
Simplify audio processing models

### DIFF
--- a/music_assistant_models/audio_processing.py
+++ b/music_assistant_models/audio_processing.py
@@ -1,4 +1,4 @@
-"""Models for runtime audio processing details."""
+"""Models for effective audio processing details."""
 
 from __future__ import annotations
 
@@ -7,32 +7,19 @@ from enum import StrEnum
 
 from mashumaro import DataClassDictMixin
 
-from .dsp import DSPFilter, DSPState
+from .dsp import AudioChannel, DSPFilter, DSPState
 from .enums import CrossfadeMode, VolumeNormalizationMode
-from .media_items import AudioFormat, ItemMapping
-
-
-class AudioProcessingState(StrEnum):
-    """State of an audio processing snapshot."""
-
-    PENDING = "pending"
-    READY = "ready"
-    UNKNOWN = "unknown"
-
-    @classmethod
-    def _missing_(cls, _: object) -> AudioProcessingState:
-        """Set default enum member if an unknown value is provided."""
-        return cls.UNKNOWN
+from .media_items import AudioFormat
 
 
 class AudioQuality(StrEnum):
-    """Effective audio quality classification."""
+    """Quality classification for an audio stream."""
 
+    UNKNOWN = "unknown"
     LOW = "low"
     STANDARD = "standard"
     LOSSLESS = "lossless"
     HI_RES = "hi_res"
-    UNKNOWN = "unknown"
 
     @classmethod
     def _missing_(cls, _: object) -> AudioQuality:
@@ -41,13 +28,13 @@ class AudioQuality(StrEnum):
 
 
 class AudioNormalizationMeasurementSource(StrEnum):
-    """Source of the loudness measurement used for normalization."""
+    """Source used for a normalization loudness measurement."""
 
+    UNKNOWN = "unknown"
     TRACK = "track"
     ALBUM = "album"
     LIVE = "live"
     FALLBACK = "fallback"
-    UNKNOWN = "unknown"
 
     @classmethod
     def _missing_(cls, _: object) -> AudioNormalizationMeasurementSource:
@@ -55,215 +42,75 @@ class AudioNormalizationMeasurementSource(StrEnum):
         return cls.UNKNOWN
 
 
-class AudioCrossfadeState(StrEnum):
-    """Runtime state of a crossfade."""
-
-    PENDING = "pending"
-    APPLIED = "applied"
-    BYPASSED = "bypassed"
-    UNKNOWN = "unknown"
-
-    @classmethod
-    def _missing_(cls, _: object) -> AudioCrossfadeState:
-        """Set default enum member if an unknown value is provided."""
-        return cls.UNKNOWN
-
-
-class AudioChannelMode(StrEnum):
-    """Effective output channel routing mode."""
-
-    STEREO = "stereo"
-    MONO = "mono"
-    LEFT = "left"
-    RIGHT = "right"
-    UNKNOWN = "unknown"
-
-    @classmethod
-    def _missing_(cls, _: object) -> AudioChannelMode:
-        """Set default enum member if an unknown value is provided."""
-        return cls.UNKNOWN
-
-
-class AudioResamplingMethod(StrEnum):
-    """Method used to resample an output path."""
-
-    SOXR = "soxr"
-    SWR = "swr"
-    UNKNOWN = "unknown"
-
-    @classmethod
-    def _missing_(cls, _: object) -> AudioResamplingMethod:
-        """Set default enum member if an unknown value is provided."""
-        return cls.UNKNOWN
-
-
-class AudioDitheringMethod(StrEnum):
-    """Method used to dither an output path."""
-
-    TRIANGULAR_HP = "triangular_hp"
-    UNKNOWN = "unknown"
-
-    @classmethod
-    def _missing_(cls, _: object) -> AudioDitheringMethod:
-        """Set default enum member if an unknown value is provided."""
-        return cls.UNKNOWN
-
-
 @dataclass(kw_only=True)
 class AudioFidelity(DataClassDictMixin):
-    """Effective fidelity at an input or final output."""
+    """Fidelity of an input or output audio stream."""
 
     quality: AudioQuality = AudioQuality.UNKNOWN
+    # None when bit-perfect status cannot be determined.
     bit_perfect: bool | None = None
 
 
 @dataclass(kw_only=True)
-class AudioFidelitySummary(DataClassDictMixin):
-    """Minimum and maximum quality across all output paths."""
-
-    min_output_quality: AudioQuality = AudioQuality.UNKNOWN
-    max_output_quality: AudioQuality = AudioQuality.UNKNOWN
-
-
-@dataclass(kw_only=True)
-class AudioInputDetails(DataClassDictMixin):
-    """Source and server-received formats for an audio input."""
-
-    source_format: AudioFormat | None = None
-    server_input_format: AudioFormat | None = None
-    fidelity: AudioFidelity = field(default_factory=AudioFidelity)
-
-
-@dataclass(kw_only=True)
 class AudioNormalizationDetails(DataClassDictMixin):
-    """Effective volume normalization details.
-
-    ``reason_code`` is a machine-readable identifier, not presentation text.
-    """
+    """Effective volume normalization applied to queue audio."""
 
     mode: VolumeNormalizationMode = VolumeNormalizationMode.UNKNOWN
     measurement_source: AudioNormalizationMeasurementSource = (
         AudioNormalizationMeasurementSource.UNKNOWN
     )
+    # Target loudness in LUFS.
     target_lufs: float | None = None
+    # Measured source loudness in LUFS.
     measured_lufs: float | None = None
+    # Gain applied during normalization in dB.
     applied_gain_db: float | None = None
-    target_true_peak_dbtp: float | None = None
-    target_loudness_range_lu: float | None = None
-    reason_code: str | None = None
-
-
-@dataclass(kw_only=True)
-class AudioTempoDetails(DataClassDictMixin):
-    """Active playback-speed processing details."""
-
-    playback_speed: float = 1.0
-
-
-@dataclass(kw_only=True)
-class AudioCrossfadeDetails(DataClassDictMixin):
-    """Effective crossfade details and runtime result.
-
-    ``reason_code`` is a machine-readable identifier, not presentation text.
-    """
-
-    mode: CrossfadeMode = CrossfadeMode.UNKNOWN
-    state: AudioCrossfadeState = AudioCrossfadeState.UNKNOWN
-    from_queue_item_id: str | None = None
-    to_queue_item_id: str | None = None
-    planned_duration: float | None = None
-    actual_duration: float | None = None
-    reason_code: str | None = None
-
-
-@dataclass(kw_only=True)
-class AudioOverlayDetails(DataClassDictMixin):
-    """Effective audio overlay source and volume."""
-
-    source: ItemMapping | None = None
-    volume_percent: int = 100
 
 
 @dataclass(kw_only=True)
 class AudioQueueProcessing(DataClassDictMixin):
-    """Shared queue processing before output fan-out."""
+    """Effective processing shared before output fan-out."""
 
-    input_format: AudioFormat | None = None
-    output_format: AudioFormat | None = None
+    # Internal PCM format shared by queue processing, including F32 headroom.
+    pcm_format: AudioFormat | None = None
     normalization: AudioNormalizationDetails | None = None
-    tempo: AudioTempoDetails | None = None
-    crossfade: AudioCrossfadeDetails | None = None
-    overlay: AudioOverlayDetails | None = None
+    playback_speed: float = 1.0
+    # DISABLED means no crossfade is active.
+    crossfade_mode: CrossfadeMode = CrossfadeMode.DISABLED
+    overlay_active: bool = False
 
 
 @dataclass(kw_only=True)
 class AudioDSPDetails(DataClassDictMixin):
-    """Effective user DSP applied to an output path."""
+    """Effective DSP applied to an output."""
 
     state: DSPState = DSPState.UNKNOWN
+    # Input gain in dB.
     input_gain: float = 0.0
     filters: list[DSPFilter] = field(default_factory=list)
+    # Output gain in dB.
     output_gain: float = 0.0
+    output_limiter: bool = False
 
 
 @dataclass(kw_only=True)
-class AudioChannelDetails(DataClassDictMixin):
-    """Effective channel routing or conversion details."""
-
-    mode: AudioChannelMode = AudioChannelMode.UNKNOWN
-
-
-@dataclass(kw_only=True)
-class AudioLimiterDetails(DataClassDictMixin):
-    """Output limiter state and threshold in dBFS."""
-
-    enabled: bool = False
-    threshold_dbfs: float | None = None
-
-
-@dataclass(kw_only=True)
-class AudioResamplingDetails(DataClassDictMixin):
-    """Effective output resampling details."""
-
-    method: AudioResamplingMethod = AudioResamplingMethod.UNKNOWN
-
-
-@dataclass(kw_only=True)
-class AudioDitheringDetails(DataClassDictMixin):
-    """Effective output dithering details."""
-
-    method: AudioDitheringMethod = AudioDitheringMethod.UNKNOWN
-
-
-@dataclass(kw_only=True)
-class AudioOutputPath(DataClassDictMixin):
-    """Processing shared by a deterministic group of output players.
-
-    ``output_format`` is the furthest downstream format known to Music Assistant.
-    ``handoff_format`` is set only when an earlier provider handoff differs.
-    """
+class AudioOutputDetails(DataClassDictMixin):
+    """Effective processing for a group of output players."""
 
     player_ids: list[str] = field(default_factory=list)
-    input_format: AudioFormat | None = None
     dsp: AudioDSPDetails = field(default_factory=AudioDSPDetails)
-    channels: AudioChannelDetails | None = None
-    limiter: AudioLimiterDetails = field(default_factory=AudioLimiterDetails)
-    resampling: AudioResamplingDetails | None = None
-    dithering: AudioDitheringDetails | None = None
+    # Set only for explicit left/right routing; formats show mono/stereo conversion.
+    source_channel: AudioChannel | None = None
+    # Furthest downstream format known to Music Assistant.
     output_format: AudioFormat | None = None
-    handoff_format: AudioFormat | None = None
     fidelity: AudioFidelity = field(default_factory=AudioFidelity)
 
 
 @dataclass(kw_only=True)
 class AudioProcessingChain(DataClassDictMixin):
-    """Full runtime audio processing snapshot for a queue."""
+    """Effective audio processing for a stream."""
 
-    queue_id: str = ""
-    queue_item_id: str | None = None
-    revision: int = 0
-    state: AudioProcessingState = AudioProcessingState.UNKNOWN
-    input: AudioInputDetails | None = None
+    # Input provider and audio format come from the containing StreamDetails.
+    input_fidelity: AudioFidelity = field(default_factory=AudioFidelity)
     queue_processing: AudioQueueProcessing | None = None
-    outputs: list[AudioOutputPath] = field(default_factory=list)
-    fidelity: AudioFidelitySummary | None = None
+    outputs: list[AudioOutputDetails] = field(default_factory=list)

--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -562,7 +562,6 @@ class EventType(StrEnum):
     PLAYER_OPTIONS_UPDATED = "player_options_updated"
     PLAYER_SLEEP_TIMER_UPDATED = "player_sleep_timer_updated"
     DSP_PRESETS_UPDATED = "dsp_presets_updated"
-    AUDIO_PROCESSING_UPDATED = "audio_processing_updated"
     QUEUE_ADDED = "queue_added"
     QUEUE_UPDATED = "queue_updated"
     QUEUE_ITEMS_UPDATED = "queue_items_updated"

--- a/music_assistant_models/streamdetails.py
+++ b/music_assistant_models/streamdetails.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from mashumaro import DataClassDictMixin, field_options, pass_through
 
+from .audio_processing import AudioProcessingChain
 from .dsp import DSPDetails
 from .enums import MediaType, StreamType, VolumeNormalizationMode
 from .media_items import AudioFormat
@@ -92,6 +93,9 @@ class StreamDetails(DataClassDictMixin):
     # stream metadata: radio/live streams can optionally set/use this field
     # to set the metadata of the playing media during the stream
     stream_metadata: StreamMetadata | None = None
+
+    # Complete audio processing chain; None until resolved by the server.
+    audio_processing: AudioProcessingChain | None = None
 
     #############################################################################
     # the fields below will only be used server-side and not sent to the client #

--- a/tests/test_audio_processing.py
+++ b/tests/test_audio_processing.py
@@ -1,42 +1,24 @@
 """Tests for audio processing models."""
 
-import orjson
-
 from music_assistant_models.audio_processing import (
-    AudioChannelDetails,
-    AudioChannelMode,
-    AudioCrossfadeDetails,
-    AudioCrossfadeState,
-    AudioDitheringDetails,
-    AudioDitheringMethod,
     AudioDSPDetails,
     AudioFidelity,
-    AudioFidelitySummary,
-    AudioInputDetails,
-    AudioLimiterDetails,
     AudioNormalizationDetails,
     AudioNormalizationMeasurementSource,
-    AudioOutputPath,
-    AudioOverlayDetails,
+    AudioOutputDetails,
     AudioProcessingChain,
-    AudioProcessingState,
     AudioQuality,
     AudioQueueProcessing,
-    AudioResamplingDetails,
-    AudioResamplingMethod,
-    AudioTempoDetails,
 )
-from music_assistant_models.dsp import DSPState, ToneControlFilter
+from music_assistant_models.dsp import AudioChannel, DSPState, ToneControlFilter
 from music_assistant_models.enums import (
     ContentType,
     CrossfadeMode,
-    EventType,
-    MediaType,
     VolumeNormalizationMode,
 )
-from music_assistant_models.event import MassEvent
 from music_assistant_models.helpers import get_serializable_value
-from music_assistant_models.media_items import AudioFormat, ItemMapping
+from music_assistant_models.media_items import AudioFormat
+from music_assistant_models.streamdetails import StreamDetails
 
 
 def test_audio_processing_defaults() -> None:
@@ -44,128 +26,158 @@ def test_audio_processing_defaults() -> None:
     chain = AudioProcessingChain()
 
     assert chain.to_dict() == {
-        "queue_id": "",
-        "queue_item_id": None,
-        "revision": 0,
-        "state": "unknown",
-        "input": None,
+        "input_fidelity": {"quality": "unknown", "bit_perfect": None},
         "queue_processing": None,
         "outputs": [],
-        "fidelity": None,
     }
     assert AudioProcessingChain.from_dict({}) == chain
-    assert AudioInputDetails().fidelity == AudioFidelity()
-    assert AudioQueueProcessing().tempo is None
-    assert AudioOutputPath().dsp == AudioDSPDetails()
-    assert AudioOutputPath().limiter == AudioLimiterDetails()
-    assert AudioOutputPath().fidelity == AudioFidelity()
+    assert AudioNormalizationDetails().to_dict() == {
+        "mode": "unknown",
+        "measurement_source": "unknown",
+        "target_lufs": None,
+        "measured_lufs": None,
+        "applied_gain_db": None,
+    }
+    assert AudioQueueProcessing().to_dict() == {
+        "pcm_format": None,
+        "normalization": None,
+        "playback_speed": 1.0,
+        "crossfade_mode": "disabled",
+        "overlay_active": False,
+    }
+    assert AudioOutputDetails().to_dict() == {
+        "player_ids": [],
+        "dsp": {
+            "state": "unknown",
+            "input_gain": 0.0,
+            "filters": [],
+            "output_gain": 0.0,
+            "output_limiter": False,
+        },
+        "source_channel": None,
+        "output_format": None,
+        "fidelity": {"quality": "unknown", "bit_perfect": None},
+    }
+    assert [quality.value for quality in AudioQuality] == [
+        "unknown",
+        "low",
+        "standard",
+        "lossless",
+        "hi_res",
+    ]
+    assert [source.value for source in AudioNormalizationMeasurementSource] == [
+        "unknown",
+        "track",
+        "album",
+        "live",
+        "fallback",
+    ]
 
 
 def test_audio_processing_roundtrip() -> None:
-    """A populated snapshot survives serialization and deserialization."""
+    """A populated chain retains its compact wire shape."""
     chain = _full_chain()
     serialized = chain.to_dict()
-    normalization = serialized["queue_processing"]["normalization"]
-    crossfade = serialized["queue_processing"]["crossfade"]
+    queue_processing = serialized["queue_processing"]
+    output = serialized["outputs"][0]
 
+    assert set(serialized) == {"input_fidelity", "queue_processing", "outputs"}
+    assert set(queue_processing) == {
+        "pcm_format",
+        "normalization",
+        "playback_speed",
+        "crossfade_mode",
+        "overlay_active",
+    }
+    assert set(queue_processing["normalization"]) == {
+        "mode",
+        "measurement_source",
+        "target_lufs",
+        "measured_lufs",
+        "applied_gain_db",
+    }
+    assert set(output) == {
+        "player_ids",
+        "dsp",
+        "source_channel",
+        "output_format",
+        "fidelity",
+    }
+    assert set(output["dsp"]) == {
+        "state",
+        "input_gain",
+        "filters",
+        "output_gain",
+        "output_limiter",
+    }
     assert get_serializable_value(chain) == serialized
     assert AudioProcessingChain.from_dict(serialized) == chain
-    assert normalization["target_true_peak_dbtp"] == -2.0
-    assert "target_true_peak_dbfs" not in normalization
-    assert "reason_code" in normalization
-    assert "reason" not in normalization
-    assert "reason_code" in crossfade
-    assert "reason" not in crossfade
 
 
-def test_audio_processing_event_serialization() -> None:
-    """The snapshot serializes as event data."""
-    event = MassEvent(
-        event=EventType.AUDIO_PROCESSING_UPDATED,
-        object_id="queue-1",
-        data=_full_chain(),
-    )
+def test_streamdetails_audio_processing_defaults_to_none() -> None:
+    """Stream details omit a chain until one is available."""
+    streamdetails = _streamdetails()
+    serialized = streamdetails.to_dict()
 
-    serialized = orjson.loads(event.to_json())
+    assert streamdetails.audio_processing is None
+    assert serialized["audio_processing"] is None
+    assert StreamDetails.from_dict(serialized) == streamdetails
 
-    assert serialized["event"] == "audio_processing_updated"
-    assert serialized["object_id"] == "queue-1"
-    assert serialized["data"]["queue_id"] == "queue-1"
-    assert serialized["data"]["outputs"][0]["player_ids"] == ["player-1", "player-2"]
+
+def test_streamdetails_audio_processing_roundtrip() -> None:
+    """Stream details round-trip a complete nested chain."""
+    streamdetails = _streamdetails(audio_processing=_full_chain())
+    serialized = streamdetails.to_dict()
+
+    assert streamdetails.audio_processing is not None
+    assert serialized["audio_processing"] == streamdetails.audio_processing.to_dict()
+    assert StreamDetails.from_dict(serialized) == streamdetails
 
 
 def test_unknown_audio_processing_enums_fall_back() -> None:
-    """Unknown enum values deserialize without rejecting the snapshot."""
+    """Unknown enum values deserialize to forward-compatible fallbacks."""
     payload = _full_chain().to_dict()
-    payload["state"] = "future"
-    payload["input"]["fidelity"]["quality"] = "future"
+    payload["input_fidelity"]["quality"] = "future"
+    payload["queue_processing"]["normalization"]["mode"] = "future"
     payload["queue_processing"]["normalization"]["measurement_source"] = "future"
-    payload["queue_processing"]["crossfade"]["mode"] = "future"
-    payload["queue_processing"]["crossfade"]["state"] = "future"
+    payload["queue_processing"]["crossfade_mode"] = "future"
     payload["outputs"][0]["dsp"]["state"] = "future"
-    payload["outputs"][0]["channels"]["mode"] = "future"
-    payload["outputs"][0]["resampling"]["method"] = "future"
-    payload["outputs"][0]["dithering"]["method"] = "future"
-    payload["fidelity"]["min_output_quality"] = "future"
+    payload["outputs"][0]["fidelity"]["quality"] = "future"
 
     restored = AudioProcessingChain.from_dict(payload)
 
-    assert restored.state is AudioProcessingState.UNKNOWN
-    assert restored.input is not None
-    assert restored.input.fidelity.quality is AudioQuality.UNKNOWN
+    assert restored.input_fidelity.quality is AudioQuality.UNKNOWN
     assert restored.queue_processing is not None
     assert restored.queue_processing.normalization is not None
+    assert restored.queue_processing.normalization.mode is VolumeNormalizationMode.UNKNOWN
     assert (
         restored.queue_processing.normalization.measurement_source
         is AudioNormalizationMeasurementSource.UNKNOWN
     )
-    assert restored.queue_processing.crossfade is not None
-    assert restored.queue_processing.crossfade.mode is CrossfadeMode.UNKNOWN
-    assert restored.queue_processing.crossfade.state is AudioCrossfadeState.UNKNOWN
+    assert restored.queue_processing.crossfade_mode is CrossfadeMode.UNKNOWN
     assert restored.outputs[0].dsp.state is DSPState.UNKNOWN
-    assert restored.outputs[0].channels is not None
-    assert restored.outputs[0].channels.mode is AudioChannelMode.UNKNOWN
-    assert restored.outputs[0].resampling is not None
-    assert restored.outputs[0].resampling.method is AudioResamplingMethod.UNKNOWN
-    assert restored.outputs[0].dithering is not None
-    assert restored.outputs[0].dithering.method is AudioDitheringMethod.UNKNOWN
-    assert restored.fidelity is not None
-    assert restored.fidelity.min_output_quality is AudioQuality.UNKNOWN
+    assert restored.outputs[0].fidelity.quality is AudioQuality.UNKNOWN
 
 
 def test_unknown_fields_are_ignored() -> None:
     """Additive unknown fields do not prevent deserialization."""
-    payload = _full_chain().to_dict()
+    streamdetails = _streamdetails(audio_processing=_full_chain())
+    payload = streamdetails.to_dict()
     payload["future"] = True
-    payload["input"]["future"] = True
-    payload["queue_processing"]["future"] = True
-    payload["queue_processing"]["normalization"]["future"] = True
-    payload["outputs"][0]["future"] = True
-    payload["outputs"][0]["dsp"]["future"] = True
-    payload["outputs"][0]["fidelity"]["future"] = True
-    payload["fidelity"]["future"] = True
+    payload["audio_processing"]["future"] = True
+    payload["audio_processing"]["input_fidelity"]["future"] = True
+    payload["audio_processing"]["queue_processing"]["future"] = True
+    payload["audio_processing"]["queue_processing"]["normalization"]["future"] = True
+    payload["audio_processing"]["outputs"][0]["future"] = True
+    payload["audio_processing"]["outputs"][0]["dsp"]["future"] = True
+    payload["audio_processing"]["outputs"][0]["fidelity"]["future"] = True
 
-    restored = AudioProcessingChain.from_dict(payload)
+    restored = StreamDetails.from_dict(payload)
 
-    assert restored == _full_chain()
+    assert restored == streamdetails
 
 
 def _full_chain() -> AudioProcessingChain:
-    source_format = AudioFormat(
-        content_type=ContentType.FLAC,
-        codec_type=ContentType.FLAC,
-        sample_rate=96000,
-        bit_depth=24,
-        channels=2,
-        bit_rate=3200,
-    )
-    input_format = AudioFormat(
-        content_type=ContentType.PCM_S24LE,
-        codec_type=ContentType.PCM_S24LE,
-        sample_rate=96000,
-        bit_depth=24,
-        channels=2,
-    )
     processing_format = AudioFormat(
         content_type=ContentType.PCM_F32LE,
         codec_type=ContentType.PCM_F32LE,
@@ -181,48 +193,24 @@ def _full_chain() -> AudioProcessingChain:
         channels=1,
         bit_rate=1200,
     )
-    overlay_source = ItemMapping(
-        media_type=MediaType.SOUND_EFFECT,
-        item_id="rain",
-        provider="builtin",
-        name="Rain",
-    )
     return AudioProcessingChain(
-        queue_id="queue-1",
-        queue_item_id="item-1",
-        revision=3,
-        state=AudioProcessingState.READY,
-        input=AudioInputDetails(
-            source_format=source_format,
-            server_input_format=input_format,
-            fidelity=AudioFidelity(quality=AudioQuality.HI_RES, bit_perfect=True),
-        ),
+        input_fidelity=AudioFidelity(quality=AudioQuality.HI_RES, bit_perfect=True),
         queue_processing=AudioQueueProcessing(
-            input_format=input_format,
-            output_format=processing_format,
+            pcm_format=processing_format,
             normalization=AudioNormalizationDetails(
                 mode=VolumeNormalizationMode.DYNAMIC,
                 measurement_source=AudioNormalizationMeasurementSource.LIVE,
                 target_lufs=-14.0,
                 measured_lufs=-17.2,
-                target_true_peak_dbtp=-2.0,
-                target_loudness_range_lu=10.0,
+                applied_gain_db=3.2,
             ),
-            tempo=AudioTempoDetails(playback_speed=1.25),
-            crossfade=AudioCrossfadeDetails(
-                mode=CrossfadeMode.SMART_CROSSFADE,
-                state=AudioCrossfadeState.APPLIED,
-                from_queue_item_id="item-0",
-                to_queue_item_id="item-1",
-                planned_duration=8.0,
-                actual_duration=7.8,
-            ),
-            overlay=AudioOverlayDetails(source=overlay_source, volume_percent=40),
+            playback_speed=1.25,
+            crossfade_mode=CrossfadeMode.SMART_CROSSFADE,
+            overlay_active=True,
         ),
         outputs=[
-            AudioOutputPath(
+            AudioOutputDetails(
                 player_ids=["player-1", "player-2"],
-                input_format=processing_format,
                 dsp=AudioDSPDetails(
                     state=DSPState.ENABLED,
                     input_gain=-1.0,
@@ -235,18 +223,29 @@ def _full_chain() -> AudioProcessingChain:
                         )
                     ],
                     output_gain=-0.5,
+                    output_limiter=True,
                 ),
-                channels=AudioChannelDetails(mode=AudioChannelMode.LEFT),
-                limiter=AudioLimiterDetails(enabled=True, threshold_dbfs=-2.0),
-                resampling=AudioResamplingDetails(method=AudioResamplingMethod.SOXR),
-                dithering=AudioDitheringDetails(method=AudioDitheringMethod.TRIANGULAR_HP),
+                source_channel=AudioChannel.FL,
                 output_format=output_format,
-                handoff_format=processing_format,
                 fidelity=AudioFidelity(quality=AudioQuality.LOSSLESS, bit_perfect=False),
             )
         ],
-        fidelity=AudioFidelitySummary(
-            min_output_quality=AudioQuality.LOSSLESS,
-            max_output_quality=AudioQuality.LOSSLESS,
+    )
+
+
+def _streamdetails(
+    audio_processing: AudioProcessingChain | None = None,
+) -> StreamDetails:
+    return StreamDetails(
+        provider="provider",
+        item_id="item",
+        audio_format=AudioFormat(
+            content_type=ContentType.FLAC,
+            codec_type=ContentType.FLAC,
+            sample_rate=96000,
+            bit_depth=24,
+            channels=2,
+            bit_rate=3200,
         ),
+        audio_processing=audio_processing,
     )


### PR DESCRIPTION
The initial audio processing contract contains more runtime and implementation detail than clients need.

- Embed the processing chain directly on stream details
- Keep only effective queue processing, DSP, formats, and fidelity
- Remove redundant state, transition, resampling, dithering, and summary models