### PR TITLE
Add Gain and Balance DSP filter types

### DIFF
--- a/music_assistant_models/dsp.py
+++ b/music_assistant_models/dsp.py
@@ -31,6 +31,8 @@ class DSPFilterType(StrEnum):
 
     PARAMETRIC_EQ = "parametric_eq"
     TONE_CONTROL = "tone_control"
+    GAIN = "gain"
+    BALANCE = "balance"
 
 
 @dataclass
@@ -135,8 +137,37 @@ class ToneControlFilter(DSPFilterBase):
             raise ValueError("Treble level must be in the range -60.0 to 60.0 dB")
 
 
+@dataclass
+class GainFilter(DSPFilterBase):
+    """Model for a Gain filter."""
+
+    type: Literal[DSPFilterType.GAIN] = DSPFilterType.GAIN
+    # Gain in dB, can be negative or positive
+    gain: float = 0.0
+
+    def validate(self) -> None:
+        """Validate the Gain filter."""
+        if not -15.0 <= self.gain <= 15.0:
+            raise ValueError("Gain must be in the range -15.0 to 15.0 dB")
+
+
+@dataclass
+class BalanceFilter(DSPFilterBase):
+    """Model for a stereo Balance filter."""
+
+    type: Literal[DSPFilterType.BALANCE] = DSPFilterType.BALANCE
+    # Balance position from -100 (full left) to +100 (full right), 0 is centered.
+    # The channel opposite to the direction is attenuated.
+    balance: float = 0.0
+
+    def validate(self) -> None:
+        """Validate the Balance filter."""
+        if not -100.0 <= self.balance <= 100.0:
+            raise ValueError("Balance must be in the range -100.0 to 100.0")
+
+
 # Type alias for all possible DSP filters
-DSPFilter = ParametricEQFilter | ToneControlFilter
+DSPFilter = ParametricEQFilter | ToneControlFilter | GainFilter | BalanceFilter
 
 
 @dataclass

--- a/music_assistant_models/dsp.py
+++ b/music_assistant_models/dsp.py
@@ -147,8 +147,8 @@ class GainFilter(DSPFilterBase):
 
     def validate(self) -> None:
         """Validate the Gain filter."""
-        if not -15.0 <= self.gain <= 15.0:
-            raise ValueError("Gain must be in the range -15.0 to 15.0 dB")
+        if not -60.0 <= self.gain <= 60.0:
+            raise ValueError("Gain must be in the range -60.0 to 60.0 dB")
 
 
 @dataclass

--- a/tests/test_dsp.py
+++ b/tests/test_dsp.py
@@ -1,0 +1,54 @@
+"""Tests for DSP models."""
+
+import pytest
+
+from music_assistant_models.dsp import (
+    BalanceFilter,
+    DSPConfig,
+    GainFilter,
+)
+
+
+def test_dsp_config_gain_balance_roundtrip() -> None:
+    """A DSPConfig with Gain and Balance filters round-trips to the correct classes."""
+    config = DSPConfig(
+        enabled=True,
+        filters=[
+            GainFilter(enabled=True, gain=-3.5),
+            BalanceFilter(enabled=False, balance=25.0),
+        ],
+    )
+    serialized = config.to_dict()
+
+    assert serialized["filters"][0]["type"] == "gain"
+    assert serialized["filters"][1]["type"] == "balance"
+
+    restored = DSPConfig.from_dict(serialized)
+
+    assert restored == config
+    assert isinstance(restored.filters[0], GainFilter)
+    assert isinstance(restored.filters[1], BalanceFilter)
+
+
+def test_gain_filter_validate() -> None:
+    """Gain validates within +-15 dB and rejects values outside."""
+    GainFilter(enabled=True).validate()
+    GainFilter(enabled=True, gain=-15.0).validate()
+    GainFilter(enabled=True, gain=15.0).validate()
+
+    with pytest.raises(ValueError, match="Gain"):
+        GainFilter(enabled=True, gain=-15.1).validate()
+    with pytest.raises(ValueError, match="Gain"):
+        GainFilter(enabled=True, gain=15.1).validate()
+
+
+def test_balance_filter_validate() -> None:
+    """Balance validates within +-100 and rejects values outside."""
+    BalanceFilter(enabled=True).validate()
+    BalanceFilter(enabled=True, balance=-100.0).validate()
+    BalanceFilter(enabled=True, balance=100.0).validate()
+
+    with pytest.raises(ValueError, match="Balance"):
+        BalanceFilter(enabled=True, balance=-100.1).validate()
+    with pytest.raises(ValueError, match="Balance"):
+        BalanceFilter(enabled=True, balance=100.1).validate()

--- a/tests/test_dsp.py
+++ b/tests/test_dsp.py
@@ -31,15 +31,15 @@ def test_dsp_config_gain_balance_roundtrip() -> None:
 
 
 def test_gain_filter_validate() -> None:
-    """Gain validates within +-15 dB and rejects values outside."""
+    """Gain validates within +-60 dB and rejects values outside."""
     GainFilter(enabled=True).validate()
-    GainFilter(enabled=True, gain=-15.0).validate()
-    GainFilter(enabled=True, gain=15.0).validate()
+    GainFilter(enabled=True, gain=-60.0).validate()
+    GainFilter(enabled=True, gain=60.0).validate()
 
     with pytest.raises(ValueError, match="Gain"):
-        GainFilter(enabled=True, gain=-15.1).validate()
+        GainFilter(enabled=True, gain=-60.1).validate()
     with pytest.raises(ValueError, match="Gain"):
-        GainFilter(enabled=True, gain=15.1).validate()
+        GainFilter(enabled=True, gain=60.1).validate()
 
 
 def test_balance_filter_validate() -> None:


### PR DESCRIPTION
Adds two new DSP filter types as the first pass of expanding the DSP filter set which is a backlog item. Both are deliberately minimal so the server and frontend changes that follow can ship together as small single slider additions.

GainFilter will apply an in chain gain between other filters and will be limited to plus or minus 15 dB to match the user facing range of the existing input and output gain controls. BalanceFilter will carry a stereo balance position from -100 for full left to +100 for full right, where the implementation attenuates the channel opposite to the slider direction and leaves the other untouched, so it can never introduce clipping. The attenuation itself is applied by the server, the model only carries the position.

Both types join the DSPFilter union and deserialize through the existing type discriminator. Note that configs saved with these new filter types will not load on older server versions, which is the normal caveat when downgrading.

Server and frontend PRs will follow once this is released.