### PR TITLE
Remember DSP preset identity

### DIFF
--- a/music_assistant_models/audio_processing.py
+++ b/music_assistant_models/audio_processing.py
@@ -91,6 +91,7 @@ class AudioDSPDetails(DataClassDictMixin):
     # Output gain in dB.
     output_gain: float = 0.0
     output_limiter: bool = False
+    # ID of the selected preset; cleared when the user changes DSP settings manually.
     preset_id: str | None = None
 
 

--- a/music_assistant_models/audio_processing.py
+++ b/music_assistant_models/audio_processing.py
@@ -91,6 +91,7 @@ class AudioDSPDetails(DataClassDictMixin):
     # Output gain in dB.
     output_gain: float = 0.0
     output_limiter: bool = False
+    preset_id: str | None = None
 
 
 @dataclass(kw_only=True)

--- a/music_assistant_models/dsp.py
+++ b/music_assistant_models/dsp.py
@@ -151,6 +151,7 @@ class DSPConfig(DataClassDictMixin):
     input_gain: float = 0.0
     # Output gain in dB, will be applied after all other DSP filters
     output_gain: float = 0.0
+    # ID of the selected preset; cleared when the user changes DSP settings manually.
     preset_id: str | None = None
 
     def validate(self) -> None:

--- a/music_assistant_models/dsp.py
+++ b/music_assistant_models/dsp.py
@@ -151,6 +151,7 @@ class DSPConfig(DataClassDictMixin):
     input_gain: float = 0.0
     # Output gain in dB, will be applied after all other DSP filters
     output_gain: float = 0.0
+    preset_id: str | None = None
 
     def validate(self) -> None:
         """Validate the DSP configuration."""

--- a/tests/test_audio_processing.py
+++ b/tests/test_audio_processing.py
@@ -45,6 +45,14 @@ def test_audio_processing_defaults() -> None:
         "crossfade_mode": "disabled",
         "overlay_active": False,
     }
+    assert AudioDSPDetails().to_dict() == {
+        "state": "unknown",
+        "input_gain": 0.0,
+        "filters": [],
+        "output_gain": 0.0,
+        "output_limiter": False,
+        "preset_id": None,
+    }
     assert AudioOutputDetails().to_dict() == {
         "player_ids": [],
         "dsp": {
@@ -53,6 +61,7 @@ def test_audio_processing_defaults() -> None:
             "filters": [],
             "output_gain": 0.0,
             "output_limiter": False,
+            "preset_id": None,
         },
         "source_channel": None,
         "output_format": None,
@@ -109,9 +118,32 @@ def test_audio_processing_roundtrip() -> None:
         "filters",
         "output_gain",
         "output_limiter",
+        "preset_id",
     }
+    assert output["dsp"]["preset_id"] == "preset-1"
     assert get_serializable_value(chain) == serialized
     assert AudioProcessingChain.from_dict(serialized) == chain
+
+
+def test_audio_dsp_details_legacy_payload() -> None:
+    """Audio DSP details accept payloads without a preset ID."""
+    payload = {
+        "state": "enabled",
+        "input_gain": -1.0,
+        "filters": [],
+        "output_gain": -0.5,
+        "output_limiter": True,
+    }
+
+    details = AudioDSPDetails.from_dict(payload)
+
+    assert details.preset_id is None
+    assert details == AudioDSPDetails(
+        state=DSPState.ENABLED,
+        input_gain=-1.0,
+        output_gain=-0.5,
+        output_limiter=True,
+    )
 
 
 def test_streamdetails_audio_processing_defaults_to_none() -> None:
@@ -131,6 +163,7 @@ def test_streamdetails_audio_processing_roundtrip() -> None:
 
     assert streamdetails.audio_processing is not None
     assert serialized["audio_processing"] == streamdetails.audio_processing.to_dict()
+    assert serialized["audio_processing"]["outputs"][0]["dsp"]["preset_id"] == "preset-1"
     assert StreamDetails.from_dict(serialized) == streamdetails
 
 
@@ -224,6 +257,7 @@ def _full_chain() -> AudioProcessingChain:
                     ],
                     output_gain=-0.5,
                     output_limiter=True,
+                    preset_id="preset-1",
                 ),
                 source_channel=AudioChannel.FL,
                 output_format=output_format,

--- a/tests/test_dsp.py
+++ b/tests/test_dsp.py
@@ -1,0 +1,40 @@
+"""Tests for DSP models."""
+
+from music_assistant_models.dsp import DSPConfig
+
+
+def test_dsp_config_defaults() -> None:
+    """DSP config serializes the default preset identity."""
+    config = DSPConfig()
+
+    assert config.to_dict() == {
+        "enabled": False,
+        "filters": [],
+        "input_gain": 0.0,
+        "output_gain": 0.0,
+        "preset_id": None,
+    }
+
+
+def test_dsp_config_legacy_payload() -> None:
+    """DSP config accepts payloads without a preset ID."""
+    payload = {
+        "enabled": True,
+        "filters": [],
+        "input_gain": -1.0,
+        "output_gain": 2.0,
+    }
+
+    config = DSPConfig.from_dict(payload)
+
+    assert config.preset_id is None
+    assert config == DSPConfig(enabled=True, input_gain=-1.0, output_gain=2.0)
+
+
+def test_dsp_config_preset_id_roundtrip() -> None:
+    """DSP config retains a non-null preset ID."""
+    config = DSPConfig(preset_id="preset-1")
+    payload = config.to_dict()
+
+    assert payload["preset_id"] == "preset-1"
+    assert DSPConfig.from_dict(payload) == config


### PR DESCRIPTION
Remember the selected DSP preset across model serialization.

- Add optional `preset_id` fields to DSP configuration and effective audio details
- Keep payloads without the field compatible
- Cover direct and nested serialization