### PR TITLE
Target the server stable branch for .post releases in the release workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -27,8 +27,10 @@ jobs:
       - name: Check for new commits
         id: check_commits
         run: |
-          # Get the latest PUBLISHED release (exclude drafts)
-          LATEST_RELEASE=$(gh release list --exclude-drafts --limit 1 --json createdAt,tagName --jq '.[0]' 2>/dev/null || echo "")
+          # Get the latest PUBLISHED release (exclude drafts). Only consider plain X.Y.Z
+          # releases so stable patch builds (e.g. 1.1.129.post1) are ignored when
+          # computing the next main-line version.
+          LATEST_RELEASE=$(gh release list --exclude-drafts --limit 30 --json createdAt,tagName --jq 'map(select(.tagName | test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))) | .[0] // empty' 2>/dev/null || echo "")
 
           if [ -z "$LATEST_RELEASE" ]; then
             echo "No previous releases found"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,11 +183,22 @@ jobs:
     needs: prepare-downstream-prs
     runs-on: ubuntu-latest
     steps:
+      - name: Determine server target branch
+        id: target
+        run: |
+          # Stable patch builds (PEP 440 .post releases) bump the server `stable`
+          # branch; regular releases bump the default (dev) branch.
+          if [[ "${{ inputs.version }}" == *.post* ]]; then
+            echo "branch=stable" >> $GITHUB_OUTPUT
+          else
+            echo "branch=dev" >> $GITHUB_OUTPUT
+          fi
 
       - name: Checkout server repository
         uses: actions/checkout@v7
         with:
           repository: music-assistant/server
+          ref: ${{ steps.target.outputs.branch }}
           token: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
           path: .
 
@@ -213,6 +224,7 @@ jobs:
           branch: "auto-update-models-${{ inputs.version }}"
           delete-branch: true
           title: "⬆️ Update music-assistant-models to ${{ inputs.version }}"
+          base: ${{ steps.target.outputs.branch }}
           body: |
             Update music-assistant-models to version [${{ inputs.version }}](https://github.com/music-assistant/models/releases/tag/${{ inputs.version }})
 
@@ -225,6 +237,9 @@ jobs:
     name: Client repo PR
     needs: prepare-downstream-prs
     runs-on: ubuntu-latest
+    # the client tracks dev; stable patch builds (.post releases) must not
+    # downgrade its models pin
+    if: ${{ !contains(inputs.version, '.post') }}
     steps:
       - name: Checkout client repository
         uses: actions/checkout@v7


### PR DESCRIPTION
The release workflow always opened the downstream models-bump PRs against the server and client default branches. A stable maintenance release (PEP 440 `.post` version, e.g. `1.1.129.post1`) would therefore open a PR that *downgrades* the models pin on the server `dev` branch, and same for the client.

Mirrors how the frontend release workflow already handles this:

- Add a "Determine server target branch" step: `.post` releases target the server `stable` branch, regular releases target `dev` (checkout `ref` + PR `base`)
- Skip the client repo PR entirely for `.post` releases (the client tracks dev)