### PR TITLE
Fix serialize and extend MediaCollection

### DIFF
--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -36,6 +36,7 @@ class MediaType(StrEnum, metaclass=MediaTypeMeta):
     PODCAST = "podcast"
     PODCAST_EPISODE = "podcast_episode"
     FOLDER = "folder"
+    COLLECTION = "collection"
     ANNOUNCEMENT = "announcement"
     FLOW_STREAM = "flow_stream"
     # deprecated: replaced by AUDIO_SOURCE, kept for one release for backwards compatibility

--- a/music_assistant_models/media_items/__init__.py
+++ b/music_assistant_models/media_items/__init__.py
@@ -149,6 +149,8 @@ def media_from_dict(media_item: dict[str, Any]) -> MediaItemType | ItemMapping:
         return SoundEffect.from_dict(media_item)
     if media_item["media_type"] == "audio_source":
         return AudioSource.from_dict(media_item)
+    if media_item["media_type"] == "collection":
+        return MediaCollection.from_dict(media_item)
     raise InvalidDataError("Unknown media type")
 
 

--- a/music_assistant_models/media_items/media_item.py
+++ b/music_assistant_models/media_items/media_item.py
@@ -26,6 +26,7 @@ from music_assistant_models.helpers import (
     is_valid_uuid,
     remove_diacritics,
 )
+from music_assistant_models.media_items import media_from_dict
 from music_assistant_models.translations import resolve_translation, translations_active
 from music_assistant_models.unique_list import UniqueList
 
@@ -490,12 +491,8 @@ class CollectionItemSerializationStrategy(SerializationStrategy):
 
     def deserialize(self, value: list[dict[str, Any]]) -> UniqueListItems[MediaItemType]:
         """Deserialize."""
-        if len(value) == 0:
-            return UniqueListItems([])
-        item_media_type = MediaType(value[0].get("media_type", "unknown"))
-        if item_media_type == MediaType.AUDIOBOOK:
-            return UniqueListItems([Audiobook.from_dict(x) for x in value])
-        raise TypeError(f"MediaType {item_media_type} is not supported in collections.")
+        # cast, as we do not expect an ItemMapping
+        return cast("UniqueList[MediaItemType]", UniqueList([media_from_dict(x) for x in value]))
 
 
 @dataclass(kw_only=True)

--- a/music_assistant_models/media_items/media_item.py
+++ b/music_assistant_models/media_items/media_item.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from mashumaro import DataClassDictMixin, field_options
+from mashumaro.types import SerializationStrategy
 
 from music_assistant_models.enums import (
     AlbumType,
@@ -477,6 +478,24 @@ class PodcastEpisode(MediaItem):
 
 
 M = TypeVar("M", bound="MediaItemType")
+UniqueListItems = UniqueList  # to define the SerializationStrategy or only for this UniqueList
+
+
+class CollectionItemSerializationStrategy(SerializationStrategy):
+    """Serialization strategy for items in a collection."""
+
+    def serialize(self, value: UniqueListItems[MediaItemType]) -> list[dict[str, Any]]:
+        """Serialize."""
+        return [x.to_dict() for x in value]
+
+    def deserialize(self, value: list[dict[str, Any]]) -> UniqueListItems[MediaItemType]:
+        """Deserialize."""
+        if len(value) == 0:
+            return UniqueListItems([])
+        item_media_type = MediaType(value[0].get("media_type", "unknown"))
+        if item_media_type == MediaType.AUDIOBOOK:
+            return UniqueListItems([Audiobook.from_dict(x) for x in value])
+        raise TypeError(f"MediaType {item_media_type} is not supported in collections.")
 
 
 @dataclass(kw_only=True)
@@ -486,10 +505,14 @@ class MediaCollection[M](MediaItem):
     __hash__ = _MediaItemBase.__hash__
     __eq__ = _MediaItemBase.__eq__
 
-    items: UniqueList[M] = field(
-        default_factory=UniqueList, metadata={"serialize": lambda v: [x.to_dict() for x in v]}
-    )
+    items: UniqueListItems[M] = field(default_factory=UniqueListItems)
     media_type: MediaType = MediaType.COLLECTION
+
+    class Config:
+        """Config."""
+
+        serialization_strategy = {UniqueListItems: CollectionItemSerializationStrategy()}
+        # ruff: noqa: RUF012
 
 
 @dataclass(kw_only=True)

--- a/music_assistant_models/media_items/media_item.py
+++ b/music_assistant_models/media_items/media_item.py
@@ -486,7 +486,9 @@ class MediaCollection[M](MediaItem):
     __hash__ = _MediaItemBase.__hash__
     __eq__ = _MediaItemBase.__eq__
 
-    items: UniqueList[M] = field(default_factory=UniqueList)
+    items: UniqueList[M] = field(
+        default_factory=UniqueList, metadata={"serialize": lambda v: [x.to_dict() for x in v]}
+    )
 
 
 @dataclass(kw_only=True)

--- a/music_assistant_models/media_items/media_item.py
+++ b/music_assistant_models/media_items/media_item.py
@@ -490,12 +490,10 @@ class CollectionItemSerializationStrategy(SerializationStrategy):
 
     def deserialize(self, value: list[dict[str, Any]]) -> UniqueListItems[MediaItemType]:
         """Deserialize."""
-        if len(value) == 0:
-            return UniqueListItems([])
-        item_media_type = MediaType(value[0].get("media_type", "unknown"))
-        if item_media_type == MediaType.AUDIOBOOK:
-            return UniqueListItems([Audiobook.from_dict(x) for x in value])
-        raise TypeError(f"MediaType {item_media_type} is not supported in collections.")
+        from . import media_from_dict
+
+        # ruff: noqa: PLC0415
+        return cast("UniqueList[MediaItemType]", UniqueList(media_from_dict(x) for x in value))
 
 
 @dataclass(kw_only=True)

--- a/music_assistant_models/media_items/media_item.py
+++ b/music_assistant_models/media_items/media_item.py
@@ -490,7 +490,6 @@ class MediaCollection[M](MediaItem):
         default_factory=UniqueList, metadata={"serialize": lambda v: [x.to_dict() for x in v]}
     )
     media_type: MediaType = MediaType.COLLECTION
-    is_playable = False
 
 
 @dataclass(kw_only=True)

--- a/music_assistant_models/media_items/media_item.py
+++ b/music_assistant_models/media_items/media_item.py
@@ -489,6 +489,8 @@ class MediaCollection[M](MediaItem):
     items: UniqueList[M] = field(
         default_factory=UniqueList, metadata={"serialize": lambda v: [x.to_dict() for x in v]}
     )
+    media_type: MediaType = MediaType.COLLECTION
+    is_playable = False
 
 
 @dataclass(kw_only=True)

--- a/music_assistant_models/media_items/media_item.py
+++ b/music_assistant_models/media_items/media_item.py
@@ -26,7 +26,6 @@ from music_assistant_models.helpers import (
     is_valid_uuid,
     remove_diacritics,
 )
-from music_assistant_models.media_items import media_from_dict
 from music_assistant_models.translations import resolve_translation, translations_active
 from music_assistant_models.unique_list import UniqueList
 
@@ -491,8 +490,12 @@ class CollectionItemSerializationStrategy(SerializationStrategy):
 
     def deserialize(self, value: list[dict[str, Any]]) -> UniqueListItems[MediaItemType]:
         """Deserialize."""
-        # cast, as we do not expect an ItemMapping
-        return cast("UniqueList[MediaItemType]", UniqueList([media_from_dict(x) for x in value]))
+        if len(value) == 0:
+            return UniqueListItems([])
+        item_media_type = MediaType(value[0].get("media_type", "unknown"))
+        if item_media_type == MediaType.AUDIOBOOK:
+            return UniqueListItems([Audiobook.from_dict(x) for x in value])
+        raise TypeError(f"MediaType {item_media_type} is not supported in collections.")
 
 
 @dataclass(kw_only=True)

--- a/music_assistant_models/media_items/media_item.py
+++ b/music_assistant_models/media_items/media_item.py
@@ -647,5 +647,6 @@ MediaItemType = (
     | SoundEffect
     | Genre
     | AudioSource
+    | MediaCollection
 )
 PlayableMediaItemType = Track | Radio | Audiobook | PodcastEpisode | SoundEffect | AudioSource

--- a/tests/test_media_collection.py
+++ b/tests/test_media_collection.py
@@ -1,0 +1,73 @@
+"""Tests for MediaCollection."""
+
+import orjson
+
+from music_assistant_models.enums import MediaType
+from music_assistant_models.helpers import get_serializable_value
+from music_assistant_models.media_items import Audiobook, MediaCollection, media_from_dict
+from music_assistant_models.media_items.media_item import ItemMapping
+from music_assistant_models.unique_list import UniqueList
+
+
+def _make_media_collection_audiobook() -> MediaCollection:
+    return MediaCollection(
+        item_id="audiobook_collection",
+        provider="library",
+        name="Audiobook Collection",
+        provider_mappings=set(),
+        items=UniqueList(
+            [
+                Audiobook(item_id="a1", provider="library", name="book 1", provider_mappings=set()),
+                Audiobook(item_id="a2", provider="library", name="book 2", provider_mappings=set()),
+            ]
+        ),
+    )
+
+
+def test_media_type_media_collection_roundtrips() -> None:
+    """MediaType.COLLECTION is reachable and round-trips through StrEnum."""
+    assert MediaType("collection") is MediaType.COLLECTION
+    assert MediaType.COLLECTION.value == "collection"
+
+
+def test_media_collection_defaults() -> None:
+    """MediaCollection has sane defaults aligned with the model contract."""
+    item = MediaCollection(
+        item_id="x",
+        provider="y",
+        name="z",
+        provider_mappings=set(),
+    )
+    assert item.media_type == MediaType.COLLECTION
+    assert item.uri == "y://collection/x"
+    assert item.items == []
+
+
+def test_media_collection_serialize_roundtrip() -> None:
+    """MediaCollection survives a to_dict -> from_dict round-trip."""
+    original = _make_media_collection_audiobook()
+    data = original.to_dict()
+    restored = MediaCollection.from_dict(data)
+    assert restored.to_dict() == data
+
+
+def test_media_from_dict_returns_media_collection_audiobook() -> None:
+    """media_from_dict deserializes media_collection payloads to MediaCollection."""
+    result = media_from_dict(_make_media_collection_audiobook().to_dict())
+    assert isinstance(result, MediaCollection)
+    assert result.media_type == MediaType.COLLECTION
+    assert isinstance(result.items[0], Audiobook)
+
+
+def test_item_mapping_for_media_collection() -> None:
+    """A MediaCollection can be reduced to an ItemMapping like other media items."""
+    mapping = ItemMapping.from_item(_make_media_collection_audiobook())
+    assert mapping.media_type == MediaType.COLLECTION
+    assert mapping.item_id == "audiobook_collection"
+
+
+def test_serialization_to_and_from_json() -> None:
+    """Verify serialization strategy of MediaCollection."""
+    original = _make_media_collection_audiobook()
+    json_string = orjson.dumps(get_serializable_value(original))
+    assert original == MediaCollection.from_dict(orjson.loads(json_string))


### PR DESCRIPTION
I started to work on the frontend, and noticed this. This fixes the serialization over the websocket, i.e.

```SuccessResultMessage(..., result=[MediaCollection(items=...)])```, but I don't know why I need this. When I tested via the api, i.e. not web socket, it worked fine.