### PR TITLE
Remove legacy DSP stream details

### DIFF
--- a/music_assistant_models/dsp.py
+++ b/music_assistant_models/dsp.py
@@ -8,8 +8,6 @@ from typing import Literal
 
 from mashumaro import DataClassDictMixin
 
-from .media_items.audio_format import AudioFormat
-
 # ruff: noqa: S105
 
 
@@ -218,7 +216,7 @@ class DSPConfigPreset(DataClassDictMixin):
 
 
 class DSPState(StrEnum):
-    """Enum of all DSP states of DSPDetails."""
+    """Enum of all DSP processing states."""
 
     ENABLED = "enabled"
     DISABLED = "disabled"
@@ -229,22 +227,3 @@ class DSPState(StrEnum):
     def _missing_(cls, _: object) -> DSPState:
         """Set default enum member if an unknown value is provided."""
         return cls.UNKNOWN
-
-
-@dataclass(kw_only=True)
-class DSPDetails(DataClassDictMixin):
-    """Model for information about a DSP applied to a stream.
-
-    This describes the DSP configuration as applied,
-    even when the DSP state is disabled. For example,
-    output_limiter can remain true while the DSP is disabled.
-    All filters in the list are guaranteed to be enabled.
-    output_format is the format that will be sent to the output device (if known).
-    """
-
-    state: DSPState = DSPState.DISABLED
-    input_gain: float = 0.0
-    filters: list[DSPFilter] = field(default_factory=list)
-    output_gain: float = 0.0
-    output_limiter: bool = True
-    output_format: AudioFormat | None = None

--- a/music_assistant_models/streamdetails.py
+++ b/music_assistant_models/streamdetails.py
@@ -10,7 +10,6 @@ from typing import Any
 from mashumaro import DataClassDictMixin, field_options, pass_through
 
 from .audio_processing import AudioProcessingChain
-from .dsp import DSPDetails
 from .enums import MediaType, StreamType, VolumeNormalizationMode
 from .media_items import AudioFormat
 
@@ -204,10 +203,6 @@ class StreamDetails(DataClassDictMixin):
     volume_normalization_mode: VolumeNormalizationMode | None = None
     volume_normalization_gain_correct: float | None = None
     target_loudness: float | None = None
-
-    # This contains the DSPDetails of all players in the group.
-    # In case of single player playback, dict will contain only one entry.
-    dsp: dict[str, DSPDetails] | None = None
 
     # the fields below are managed by the queue/stream controller and may not be set by providers
     fade_in: bool = field(

--- a/tests/test_streamdetails.py
+++ b/tests/test_streamdetails.py
@@ -55,3 +55,26 @@ def test_decoded_audio_format_is_not_serialized() -> None:
     )
     sd = _make_streamdetails(decoded_audio_format=decoded)
     assert "decoded_audio_format" not in sd.to_dict()
+
+
+def test_legacy_dsp_is_not_serialized() -> None:
+    """Legacy DSP details are not included in stream details."""
+    assert "dsp" not in _make_streamdetails().to_dict()
+
+
+def test_legacy_dsp_payload_is_ignored() -> None:
+    """Legacy DSP details do not affect deserialization."""
+    streamdetails = _make_streamdetails()
+    payload = streamdetails.to_dict()
+    payload["dsp"] = {
+        "player-id": {
+            "state": "enabled",
+            "input_gain": 0.0,
+            "filters": [],
+            "output_gain": 0.0,
+            "output_limiter": True,
+            "output_format": None,
+        }
+    }
+
+    assert StreamDetails.from_dict(payload) == streamdetails


### PR DESCRIPTION
Removes the legacy top-level DSP data now superseded by `StreamDetails.audio_processing`.

- Remove `StreamDetails.dsp` and the unused `DSPDetails` model
- Preserve shared DSP configuration, filter, and state models
- Keep old payloads deserializable by ignoring the retired field