### PR TITLE
Add Limiter and Compressor DSP filters

### DIFF
--- a/music_assistant_models/dsp.py
+++ b/music_assistant_models/dsp.py
@@ -35,7 +35,7 @@ class DSPFilterType(StrEnum):
     HIGH_LOW_PASS = "high_low_pass"
     STEREO_WIDTH = "stereo_width"
     CROSSFEED = "crossfeed"
-    LIMITER = "limiter"
+    SAFETY_LIMITER = "safety_limiter"
     COMPRESSOR = "compressor"
 
 
@@ -270,16 +270,16 @@ class CrossfeedFilter(DSPFilterBase):
 
 
 @dataclass
-class LimiterFilter(DSPFilterBase):
-    """Model for a Limiter filter."""
+class SafetyLimiterFilter(DSPFilterBase):
+    """Model for a Safety Limiter filter."""
 
-    type: Literal[DSPFilterType.LIMITER] = DSPFilterType.LIMITER
+    type: Literal[DSPFilterType.SAFETY_LIMITER] = DSPFilterType.SAFETY_LIMITER
     # Output ceiling in dB (0 = full scale); the signal is held below this level.
     # Default matches the server's global output limiter ceiling.
     ceiling: float = -2.0
 
     def validate(self) -> None:
-        """Validate the Limiter filter."""
+        """Validate the Safety Limiter filter."""
         if not -24.0 <= self.ceiling <= 0.0:
             raise ValueError("Ceiling must be in the range -24.0 to 0.0 dB")
 
@@ -328,7 +328,7 @@ DSPFilter = (
     | HighLowPassFilter
     | StereoWidthFilter
     | CrossfeedFilter
-    | LimiterFilter
+    | SafetyLimiterFilter
     | CompressorFilter
 )
 

--- a/music_assistant_models/dsp.py
+++ b/music_assistant_models/dsp.py
@@ -35,6 +35,8 @@ class DSPFilterType(StrEnum):
     HIGH_LOW_PASS = "high_low_pass"
     STEREO_WIDTH = "stereo_width"
     CROSSFEED = "crossfeed"
+    LIMITER = "limiter"
+    COMPRESSOR = "compressor"
 
 
 @dataclass
@@ -267,6 +269,55 @@ class CrossfeedFilter(DSPFilterBase):
             raise ValueError("Soundstage must be in the range 0.0 to 1.0")
 
 
+@dataclass
+class LimiterFilter(DSPFilterBase):
+    """Model for a Limiter filter."""
+
+    type: Literal[DSPFilterType.LIMITER] = DSPFilterType.LIMITER
+    # Output ceiling in dB (0 = full scale); the signal is held below this level.
+    # Default matches the server's global output limiter ceiling.
+    ceiling: float = -2.0
+
+    def validate(self) -> None:
+        """Validate the Limiter filter."""
+        if not -24.0 <= self.ceiling <= 0.0:
+            raise ValueError("Ceiling must be in the range -24.0 to 0.0 dB")
+
+
+@dataclass
+class CompressorFilter(DSPFilterBase):
+    """Model for a dynamic range Compressor filter."""
+
+    type: Literal[DSPFilterType.COMPRESSOR] = DSPFilterType.COMPRESSOR
+    # Level above which compression starts, in dB
+    threshold: float = -18.0
+    # Compression ratio (input:output above the threshold)
+    ratio: float = 2.0
+    # Attack time in milliseconds
+    attack: float = 20.0
+    # Release time in milliseconds
+    release: float = 250.0
+    # Knee width in dB (0 = hard knee); default matches ffmpeg's acompressor knee (~9 dB)
+    knee: float = 9.0
+    # Make-up gain in dB, applied after compression
+    makeup: float = 0.0
+
+    def validate(self) -> None:
+        """Validate the Compressor filter."""
+        if not -60.0 <= self.threshold <= 0.0:
+            raise ValueError("Threshold must be in the range -60.0 to 0.0 dB")
+        if not 1.0 <= self.ratio <= 20.0:
+            raise ValueError("Ratio must be in the range 1.0 to 20.0")
+        if not 0.01 <= self.attack <= 2000.0:
+            raise ValueError("Attack must be in the range 0.01 to 2000.0 ms")
+        if not 0.01 <= self.release <= 9000.0:
+            raise ValueError("Release must be in the range 0.01 to 9000.0 ms")
+        if not 0.0 <= self.knee <= 18.0:
+            raise ValueError("Knee must be in the range 0.0 to 18.0 dB")
+        if not 0.0 <= self.makeup <= 36.0:
+            raise ValueError("Make-up gain must be in the range 0.0 to 36.0 dB")
+
+
 # Type alias for all possible DSP filters
 DSPFilter = (
     ParametricEQFilter
@@ -277,6 +328,8 @@ DSPFilter = (
     | HighLowPassFilter
     | StereoWidthFilter
     | CrossfeedFilter
+    | LimiterFilter
+    | CompressorFilter
 )
 
 

--- a/tests/test_dsp.py
+++ b/tests/test_dsp.py
@@ -13,7 +13,7 @@ from music_assistant_models.dsp import (
     HighLowPassFilter,
     HighLowPassMode,
     HighLowPassSlope,
-    LimiterFilter,
+    SafetyLimiterFilter,
     StereoWidthFilter,
 )
 
@@ -140,24 +140,24 @@ def test_dsp_config_convolution_roundtrip() -> None:
     assert isinstance(restored.filters[0], ConvolutionFilter)
 
 
-def test_dsp_config_limiter_compressor_roundtrip() -> None:
-    """A DSPConfig with Limiter and Compressor filters round-trips to the correct classes."""
+def test_dsp_config_safety_limiter_compressor_roundtrip() -> None:
+    """A DSPConfig with Safety Limiter and Compressor filters round-trips to the correct classes."""
     config = DSPConfig(
         enabled=True,
         filters=[
-            LimiterFilter(enabled=True, ceiling=-3.0),
+            SafetyLimiterFilter(enabled=True, ceiling=-3.0),
             CompressorFilter(enabled=False, threshold=-20.0, ratio=4.0),
         ],
     )
     serialized = config.to_dict()
 
-    assert serialized["filters"][0]["type"] == "limiter"
+    assert serialized["filters"][0]["type"] == "safety_limiter"
     assert serialized["filters"][1]["type"] == "compressor"
 
     restored = DSPConfig.from_dict(serialized)
 
     assert restored == config
-    assert isinstance(restored.filters[0], LimiterFilter)
+    assert isinstance(restored.filters[0], SafetyLimiterFilter)
     assert isinstance(restored.filters[1], CompressorFilter)
 
 
@@ -316,26 +316,26 @@ def test_crossfeed_filter_validate() -> None:
         CrossfeedFilter(enabled=True, soundstage=1.1).validate()
 
 
-def test_limiter_filter_defaults() -> None:
-    """Limiter constructs with its documented defaults and validates."""
-    limiter = LimiterFilter(enabled=True)
+def test_safety_limiter_filter_defaults() -> None:
+    """Safety Limiter constructs with its documented defaults and validates."""
+    safety_limiter = SafetyLimiterFilter(enabled=True)
 
-    assert limiter.type == "limiter"
-    assert limiter.ceiling == -2.0
+    assert safety_limiter.type == "safety_limiter"
+    assert safety_limiter.ceiling == -2.0
 
-    limiter.validate()
+    safety_limiter.validate()
 
 
-def test_limiter_filter_validate() -> None:
+def test_safety_limiter_filter_validate() -> None:
     """Ceiling validates within -24..0 dB and rejects values outside."""
-    LimiterFilter(enabled=True, ceiling=-2.0).validate()
-    LimiterFilter(enabled=True, ceiling=-24.0).validate()
-    LimiterFilter(enabled=True, ceiling=0.0).validate()
+    SafetyLimiterFilter(enabled=True, ceiling=-2.0).validate()
+    SafetyLimiterFilter(enabled=True, ceiling=-24.0).validate()
+    SafetyLimiterFilter(enabled=True, ceiling=0.0).validate()
 
     with pytest.raises(ValueError, match="Ceiling"):
-        LimiterFilter(enabled=True, ceiling=-24.1).validate()
+        SafetyLimiterFilter(enabled=True, ceiling=-24.1).validate()
     with pytest.raises(ValueError, match="Ceiling"):
-        LimiterFilter(enabled=True, ceiling=0.1).validate()
+        SafetyLimiterFilter(enabled=True, ceiling=0.1).validate()
 
 
 def test_compressor_filter_defaults() -> None:

--- a/tests/test_dsp.py
+++ b/tests/test_dsp.py
@@ -4,6 +4,7 @@ import pytest
 
 from music_assistant_models.dsp import (
     BalanceFilter,
+    CompressorFilter,
     ConvolutionFilter,
     CrossfeedFilter,
     DSPConfig,
@@ -12,6 +13,7 @@ from music_assistant_models.dsp import (
     HighLowPassFilter,
     HighLowPassMode,
     HighLowPassSlope,
+    LimiterFilter,
     StereoWidthFilter,
 )
 
@@ -136,6 +138,27 @@ def test_dsp_config_convolution_roundtrip() -> None:
 
     assert restored == config
     assert isinstance(restored.filters[0], ConvolutionFilter)
+
+
+def test_dsp_config_limiter_compressor_roundtrip() -> None:
+    """A DSPConfig with Limiter and Compressor filters round-trips to the correct classes."""
+    config = DSPConfig(
+        enabled=True,
+        filters=[
+            LimiterFilter(enabled=True, ceiling=-3.0),
+            CompressorFilter(enabled=False, threshold=-20.0, ratio=4.0),
+        ],
+    )
+    serialized = config.to_dict()
+
+    assert serialized["filters"][0]["type"] == "limiter"
+    assert serialized["filters"][1]["type"] == "compressor"
+
+    restored = DSPConfig.from_dict(serialized)
+
+    assert restored == config
+    assert isinstance(restored.filters[0], LimiterFilter)
+    assert isinstance(restored.filters[1], CompressorFilter)
 
 
 def test_dsp_config_stereo_width_crossfeed_roundtrip() -> None:
@@ -291,3 +314,102 @@ def test_crossfeed_filter_validate() -> None:
         CrossfeedFilter(enabled=True, soundstage=-0.1).validate()
     with pytest.raises(ValueError, match="Soundstage"):
         CrossfeedFilter(enabled=True, soundstage=1.1).validate()
+
+
+def test_limiter_filter_defaults() -> None:
+    """Limiter constructs with its documented defaults and validates."""
+    limiter = LimiterFilter(enabled=True)
+
+    assert limiter.type == "limiter"
+    assert limiter.ceiling == -2.0
+
+    limiter.validate()
+
+
+def test_limiter_filter_validate() -> None:
+    """Ceiling validates within -24..0 dB and rejects values outside."""
+    LimiterFilter(enabled=True, ceiling=-2.0).validate()
+    LimiterFilter(enabled=True, ceiling=-24.0).validate()
+    LimiterFilter(enabled=True, ceiling=0.0).validate()
+
+    with pytest.raises(ValueError, match="Ceiling"):
+        LimiterFilter(enabled=True, ceiling=-24.1).validate()
+    with pytest.raises(ValueError, match="Ceiling"):
+        LimiterFilter(enabled=True, ceiling=0.1).validate()
+
+
+def test_compressor_filter_defaults() -> None:
+    """Compressor constructs with its documented defaults and validates."""
+    compressor = CompressorFilter(enabled=True)
+
+    assert compressor.type == "compressor"
+    assert compressor.threshold == -18.0
+    assert compressor.ratio == 2.0
+    assert compressor.attack == 20.0
+    assert compressor.release == 250.0
+    assert compressor.knee == 9.0
+    assert compressor.makeup == 0.0
+
+    compressor.validate()
+
+
+def test_compressor_filter_validate() -> None:
+    """Each Compressor field validates within its range and rejects values just outside."""
+    # An in-range configuration passes.
+    CompressorFilter(
+        enabled=True,
+        threshold=-24.0,
+        ratio=6.0,
+        attack=10.0,
+        release=100.0,
+        knee=6.0,
+        makeup=3.0,
+    ).validate()
+
+    # threshold: -60.0 .. 0.0 dB
+    CompressorFilter(enabled=True, threshold=-60.0).validate()
+    CompressorFilter(enabled=True, threshold=0.0).validate()
+    with pytest.raises(ValueError, match="Threshold"):
+        CompressorFilter(enabled=True, threshold=-60.1).validate()
+    with pytest.raises(ValueError, match="Threshold"):
+        CompressorFilter(enabled=True, threshold=0.1).validate()
+
+    # ratio: 1.0 .. 20.0
+    CompressorFilter(enabled=True, ratio=1.0).validate()
+    CompressorFilter(enabled=True, ratio=20.0).validate()
+    with pytest.raises(ValueError, match="Ratio"):
+        CompressorFilter(enabled=True, ratio=0.9).validate()
+    with pytest.raises(ValueError, match="Ratio"):
+        CompressorFilter(enabled=True, ratio=20.1).validate()
+
+    # attack: 0.01 .. 2000.0 ms
+    CompressorFilter(enabled=True, attack=0.01).validate()
+    CompressorFilter(enabled=True, attack=2000.0).validate()
+    with pytest.raises(ValueError, match="Attack"):
+        CompressorFilter(enabled=True, attack=0.0).validate()
+    with pytest.raises(ValueError, match="Attack"):
+        CompressorFilter(enabled=True, attack=2000.1).validate()
+
+    # release: 0.01 .. 9000.0 ms
+    CompressorFilter(enabled=True, release=0.01).validate()
+    CompressorFilter(enabled=True, release=9000.0).validate()
+    with pytest.raises(ValueError, match="Release"):
+        CompressorFilter(enabled=True, release=0.0).validate()
+    with pytest.raises(ValueError, match="Release"):
+        CompressorFilter(enabled=True, release=9000.1).validate()
+
+    # knee: 0.0 .. 18.0 dB
+    CompressorFilter(enabled=True, knee=0.0).validate()
+    CompressorFilter(enabled=True, knee=18.0).validate()
+    with pytest.raises(ValueError, match="Knee"):
+        CompressorFilter(enabled=True, knee=-0.1).validate()
+    with pytest.raises(ValueError, match="Knee"):
+        CompressorFilter(enabled=True, knee=18.1).validate()
+
+    # makeup: 0.0 .. 36.0 dB
+    CompressorFilter(enabled=True, makeup=0.0).validate()
+    CompressorFilter(enabled=True, makeup=36.0).validate()
+    with pytest.raises(ValueError, match="Make-up gain"):
+        CompressorFilter(enabled=True, makeup=-0.1).validate()
+    with pytest.raises(ValueError, match="Make-up gain"):
+        CompressorFilter(enabled=True, makeup=36.1).validate()


### PR DESCRIPTION
Add two new DSP filter types to the DSPFilter union: a Limiter with a single ceiling control, and a full dynamic range Compressor (threshold, ratio, attack, release, knee, makeup). All fields are user-facing units (dB / ms / ratio) with defaults; conversion to ffmpeg's native linear parameters is left to the server mapping layer.