### PR TITLE
Add StereoWidth and Crossfeed DSP filters

### DIFF
--- a/music_assistant_models/dsp.py
+++ b/music_assistant_models/dsp.py
@@ -31,6 +31,8 @@ class DSPFilterType(StrEnum):
     TONE_CONTROL = "tone_control"
     GAIN = "gain"
     BALANCE = "balance"
+    STEREO_WIDTH = "stereo_width"
+    CROSSFEED = "crossfeed"
 
 
 @dataclass
@@ -164,8 +166,49 @@ class BalanceFilter(DSPFilterBase):
             raise ValueError("Balance must be in the range -100.0 to 100.0")
 
 
+@dataclass
+class StereoWidthFilter(DSPFilterBase):
+    """Model for a Stereo Width filter."""
+
+    type: Literal[DSPFilterType.STEREO_WIDTH] = DSPFilterType.STEREO_WIDTH
+    # Stereo width multiplier applied to the side (L-R) signal.
+    # 1.0 = unchanged, 0.0 = mono (dual-mono), >1.0 = wider. The center
+    # (mid) signal is left untouched.
+    width: float = 1.0
+
+    def validate(self) -> None:
+        """Validate the Stereo Width filter."""
+        if not 0.0 <= self.width <= 2.0:
+            raise ValueError("Width must be in the range 0.0 to 2.0")
+
+
+@dataclass
+class CrossfeedFilter(DSPFilterBase):
+    """Model for a headphone Crossfeed filter."""
+
+    type: Literal[DSPFilterType.CROSSFEED] = DSPFilterType.CROSSFEED
+    # Crossfeed strength; 0.0 = subtle, 1.0 = maximum blending of L/R.
+    strength: float = 0.2
+    # Soundstage wideness (maps to ffmpeg crossfeed "range").
+    soundstage: float = 0.5
+
+    def validate(self) -> None:
+        """Validate the Crossfeed filter."""
+        if not 0.0 <= self.strength <= 1.0:
+            raise ValueError("Strength must be in the range 0.0 to 1.0")
+        if not 0.0 <= self.soundstage <= 1.0:
+            raise ValueError("Soundstage must be in the range 0.0 to 1.0")
+
+
 # Type alias for all possible DSP filters
-DSPFilter = ParametricEQFilter | ToneControlFilter | GainFilter | BalanceFilter
+DSPFilter = (
+    ParametricEQFilter
+    | ToneControlFilter
+    | GainFilter
+    | BalanceFilter
+    | StereoWidthFilter
+    | CrossfeedFilter
+)
 
 
 @dataclass

--- a/tests/test_dsp.py
+++ b/tests/test_dsp.py
@@ -4,8 +4,10 @@ import pytest
 
 from music_assistant_models.dsp import (
     BalanceFilter,
+    CrossfeedFilter,
     DSPConfig,
     GainFilter,
+    StereoWidthFilter,
 )
 
 
@@ -89,3 +91,78 @@ def test_balance_filter_validate() -> None:
         BalanceFilter(enabled=True, balance=-100.1).validate()
     with pytest.raises(ValueError, match="Balance"):
         BalanceFilter(enabled=True, balance=100.1).validate()
+
+
+def test_dsp_config_stereo_width_crossfeed_roundtrip() -> None:
+    """A DSPConfig with StereoWidth and Crossfeed filters round-trips to the correct classes."""
+    config = DSPConfig(
+        enabled=True,
+        filters=[
+            StereoWidthFilter(enabled=True, width=1.5),
+            CrossfeedFilter(enabled=False, strength=0.4, soundstage=0.6),
+        ],
+    )
+    serialized = config.to_dict()
+
+    assert serialized["filters"][0]["type"] == "stereo_width"
+    assert serialized["filters"][1]["type"] == "crossfeed"
+
+    restored = DSPConfig.from_dict(serialized)
+
+    assert restored == config
+    assert isinstance(restored.filters[0], StereoWidthFilter)
+    assert isinstance(restored.filters[1], CrossfeedFilter)
+
+
+def test_stereo_width_filter_defaults() -> None:
+    """Stereo Width constructs with its documented defaults and validates."""
+    stereo_width = StereoWidthFilter(enabled=True)
+
+    assert stereo_width.type == "stereo_width"
+    assert stereo_width.width == 1.0
+
+    stereo_width.validate()
+
+
+def test_stereo_width_filter_validate() -> None:
+    """Width validates within 0.0..2.0 and rejects values outside."""
+    StereoWidthFilter(enabled=True, width=0.0).validate()
+    StereoWidthFilter(enabled=True, width=2.0).validate()
+
+    with pytest.raises(ValueError, match="Width"):
+        StereoWidthFilter(enabled=True, width=-0.1).validate()
+    with pytest.raises(ValueError, match="Width"):
+        StereoWidthFilter(enabled=True, width=2.1).validate()
+
+
+def test_crossfeed_filter_defaults() -> None:
+    """Crossfeed constructs with its documented defaults and validates."""
+    crossfeed = CrossfeedFilter(enabled=True)
+
+    assert crossfeed.type == "crossfeed"
+    assert crossfeed.strength == 0.2
+    assert crossfeed.soundstage == 0.5
+
+    crossfeed.validate()
+
+
+def test_crossfeed_filter_validate() -> None:
+    """Each Crossfeed field validates within 0.0..1.0 and rejects values just outside."""
+    # An in-range configuration passes.
+    CrossfeedFilter(enabled=True, strength=0.5, soundstage=0.5).validate()
+
+    # strength: 0.0 .. 1.0
+    CrossfeedFilter(enabled=True, strength=0.0).validate()
+    CrossfeedFilter(enabled=True, strength=1.0).validate()
+    with pytest.raises(ValueError, match="Strength"):
+        CrossfeedFilter(enabled=True, strength=-0.1).validate()
+    with pytest.raises(ValueError, match="Strength"):
+        CrossfeedFilter(enabled=True, strength=1.1).validate()
+
+    # soundstage: 0.0 .. 1.0
+    CrossfeedFilter(enabled=True, soundstage=0.0).validate()
+    CrossfeedFilter(enabled=True, soundstage=1.0).validate()
+    with pytest.raises(ValueError, match="Soundstage"):
+        CrossfeedFilter(enabled=True, soundstage=-0.1).validate()
+    with pytest.raises(ValueError, match="Soundstage"):
+        CrossfeedFilter(enabled=True, soundstage=1.1).validate()


### PR DESCRIPTION
Two new stereo-only filters for the DSP chain:

- Stereo Width - narrow or widen the stereo image (mono at 0, unchanged at 1, wider above).
- Crossfeed - blends L/R for a more natural, less "split" sound on headphones. Two controls: strength and soundstage.