### PR TITLE
Add ConvolutionFilter and High/Low DSP filter types

### DIFF
--- a/music_assistant_models/dsp.py
+++ b/music_assistant_models/dsp.py
@@ -31,6 +31,7 @@ class DSPFilterType(StrEnum):
     TONE_CONTROL = "tone_control"
     GAIN = "gain"
     BALANCE = "balance"
+    CONVOLUTION = "convolution"
 
 
 @dataclass
@@ -164,8 +165,26 @@ class BalanceFilter(DSPFilterBase):
             raise ValueError("Balance must be in the range -100.0 to 100.0")
 
 
+@dataclass
+class ConvolutionFilter(DSPFilterBase):
+    """Model for a Convolution (impulse response) filter."""
+
+    type: Literal[DSPFilterType.CONVOLUTION] = DSPFilterType.CONVOLUTION
+    # Identifier of the stored impulse response to convolve with.
+    # Empty means none is selected yet; the server treats that as a no-op,
+    # so it is not validated here.
+    ir_id: str = ""
+    # Output gain in dB applied after the convolution, can be negative or positive
+    gain: float = 0.0
+
+    def validate(self) -> None:
+        """Validate the Convolution filter."""
+        if not -60.0 <= self.gain <= 60.0:
+            raise ValueError("Gain must be in the range -60.0 to 60.0 dB")
+
+
 # Type alias for all possible DSP filters
-DSPFilter = ParametricEQFilter | ToneControlFilter | GainFilter | BalanceFilter
+DSPFilter = ParametricEQFilter | ToneControlFilter | GainFilter | BalanceFilter | ConvolutionFilter
 
 
 @dataclass

--- a/music_assistant_models/dsp.py
+++ b/music_assistant_models/dsp.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from enum import StrEnum
+from enum import IntEnum, StrEnum
 from typing import Literal
 
 from mashumaro import DataClassDictMixin
@@ -198,6 +198,19 @@ class HighLowPassMode(StrEnum):
         return cls.HIGH_PASS
 
 
+class HighLowPassSlope(IntEnum):
+    """Steepness of a High/Low-pass filter, in dB per octave."""
+
+    DB12 = 12
+    DB24 = 24
+    DB48 = 48
+
+    @classmethod
+    def _missing_(cls, _: object) -> HighLowPassSlope:
+        """Set default enum member if an unknown value is provided."""
+        return cls.DB12
+
+
 @dataclass
 class HighLowPassFilter(DSPFilterBase):
     """Model for a High-pass / Low-pass filter."""
@@ -208,13 +221,15 @@ class HighLowPassFilter(DSPFilterBase):
     # Cutoff (corner) frequency in Hz
     frequency: float = 80.0
     # Filter steepness in dB per octave
-    slope: int = 12
+    slope: HighLowPassSlope = HighLowPassSlope.DB12
 
     def validate(self) -> None:
         """Validate the High/Low-pass filter."""
         if not 20.0 <= self.frequency <= 20000.0:
             raise ValueError("Cutoff frequency must be in the range 20.0 to 20000.0 Hz")
-        if self.slope not in (12, 24, 48):
+        # An exact type check (not ==) so a raw 12.0 float cannot slip through
+        # and get serialized back out as a float
+        if type(self.slope) is not HighLowPassSlope:
             raise ValueError("Slope must be one of 12, 24 or 48 dB/octave")
 
 

--- a/music_assistant_models/dsp.py
+++ b/music_assistant_models/dsp.py
@@ -32,6 +32,7 @@ class DSPFilterType(StrEnum):
     GAIN = "gain"
     BALANCE = "balance"
     CONVOLUTION = "convolution"
+    HIGH_LOW_PASS = "high_low_pass"
 
 
 @dataclass
@@ -183,8 +184,47 @@ class ConvolutionFilter(DSPFilterBase):
             raise ValueError("Gain must be in the range -60.0 to 60.0 dB")
 
 
+class HighLowPassMode(StrEnum):
+    """Direction of a High/Low-pass filter."""
+
+    HIGH_PASS = "high_pass"
+    LOW_PASS = "low_pass"
+
+    @classmethod
+    def _missing_(cls, _: object) -> HighLowPassMode:
+        """Set default enum member if an unknown value is provided."""
+        return cls.HIGH_PASS
+
+
+@dataclass
+class HighLowPassFilter(DSPFilterBase):
+    """Model for a High-pass / Low-pass filter."""
+
+    type: Literal[DSPFilterType.HIGH_LOW_PASS] = DSPFilterType.HIGH_LOW_PASS
+    # High-pass removes content below the cutoff; low-pass removes content above it
+    mode: HighLowPassMode = HighLowPassMode.HIGH_PASS
+    # Cutoff (corner) frequency in Hz
+    frequency: float = 80.0
+    # Filter steepness in dB per octave
+    slope: int = 12
+
+    def validate(self) -> None:
+        """Validate the High/Low-pass filter."""
+        if not 20.0 <= self.frequency <= 20000.0:
+            raise ValueError("Cutoff frequency must be in the range 20.0 to 20000.0 Hz")
+        if self.slope not in (12, 24, 48):
+            raise ValueError("Slope must be one of 12, 24 or 48 dB/octave")
+
+
 # Type alias for all possible DSP filters
-DSPFilter = ParametricEQFilter | ToneControlFilter | GainFilter | BalanceFilter | ConvolutionFilter
+DSPFilter = (
+    ParametricEQFilter
+    | ToneControlFilter
+    | GainFilter
+    | BalanceFilter
+    | ConvolutionFilter
+    | HighLowPassFilter
+)
 
 
 @dataclass

--- a/music_assistant_models/dsp.py
+++ b/music_assistant_models/dsp.py
@@ -216,6 +216,9 @@ class HighLowPassFilter(DSPFilterBase):
             raise ValueError("Cutoff frequency must be in the range 20.0 to 20000.0 Hz")
         if self.slope not in (12, 24, 48):
             raise ValueError("Slope must be one of 12, 24 or 48 dB/octave")
+
+
+@dataclass
 class StereoWidthFilter(DSPFilterBase):
     """Model for a Stereo Width filter."""
 

--- a/tests/test_dsp.py
+++ b/tests/test_dsp.py
@@ -11,6 +11,7 @@ from music_assistant_models.dsp import (
     GainFilter,
     HighLowPassFilter,
     HighLowPassMode,
+    HighLowPassSlope,
     StereoWidthFilter,
 )
 
@@ -160,7 +161,12 @@ def test_dsp_config_stereo_width_crossfeed_roundtrip() -> None:
 
 def test_high_low_pass_valid() -> None:
     """A configured High/Low-pass filter validates without raising."""
-    f = HighLowPassFilter(enabled=True, mode=HighLowPassMode.LOW_PASS, frequency=12000.0, slope=24)
+    f = HighLowPassFilter(
+        enabled=True,
+        mode=HighLowPassMode.LOW_PASS,
+        frequency=12000.0,
+        slope=HighLowPassSlope.DB24,
+    )
     f.validate()
 
 
@@ -171,7 +177,7 @@ def test_high_low_pass_defaults() -> None:
     assert f.type == DSPFilterType.HIGH_LOW_PASS
     assert f.mode is HighLowPassMode.HIGH_PASS
     assert f.frequency == 80.0
-    assert f.slope == 12
+    assert f.slope is HighLowPassSlope.DB12
 
     f.validate()
 
@@ -185,9 +191,24 @@ def test_high_low_pass_bad_frequency() -> None:
 
 def test_high_low_pass_bad_slope() -> None:
     """Slopes outside the allowed {12, 24, 48} set are rejected."""
-    for slope in (6, 18, 96):
+    for slope in (6, 18, 96, 12.0):
         with pytest.raises(ValueError, match="Slope"):
-            HighLowPassFilter(enabled=True, slope=slope).validate()
+            HighLowPassFilter(enabled=True, slope=slope).validate()  # type: ignore[arg-type]
+
+
+def test_high_low_pass_unknown_slope_defaults() -> None:
+    """An unknown slope value falls back to 12 dB/octave."""
+    assert HighLowPassSlope(18) is HighLowPassSlope.DB12
+
+
+def test_high_low_pass_slope_serializes_as_int() -> None:
+    """The slope stays a plain int on the wire."""
+    f = HighLowPassFilter(enabled=True, slope=HighLowPassSlope.DB48)
+    serialized = f.to_dict()
+
+    assert serialized["slope"] == 48
+    assert type(serialized["slope"]) is int
+    assert HighLowPassFilter.from_dict(serialized).slope is HighLowPassSlope.DB48
 
 
 def test_high_low_pass_unknown_mode_defaults() -> None:
@@ -201,7 +222,10 @@ def test_dsp_config_high_low_pass_roundtrip() -> None:
         enabled=True,
         filters=[
             HighLowPassFilter(
-                enabled=True, mode=HighLowPassMode.LOW_PASS, frequency=8000.0, slope=48
+                enabled=True,
+                mode=HighLowPassMode.LOW_PASS,
+                frequency=8000.0,
+                slope=HighLowPassSlope.DB48,
             ),
         ],
     )

--- a/tests/test_dsp.py
+++ b/tests/test_dsp.py
@@ -125,6 +125,18 @@ def test_dsp_config_convolution_roundtrip() -> None:
         enabled=True,
         filters=[
             ConvolutionFilter(enabled=True, ir_id="ir-abc123", gain=-3.0),
+        ],
+    )
+    serialized = config.to_dict()
+
+    assert serialized["filters"][0]["type"] == "convolution"
+
+    restored = DSPConfig.from_dict(serialized)
+
+    assert restored == config
+    assert isinstance(restored.filters[0], ConvolutionFilter)
+
+
 def test_dsp_config_stereo_width_crossfeed_roundtrip() -> None:
     """A DSPConfig with StereoWidth and Crossfeed filters round-trips to the correct classes."""
     config = DSPConfig(
@@ -136,14 +148,14 @@ def test_dsp_config_stereo_width_crossfeed_roundtrip() -> None:
     )
     serialized = config.to_dict()
 
-    assert serialized["filters"][0]["type"] == "convolution"
     assert serialized["filters"][0]["type"] == "stereo_width"
     assert serialized["filters"][1]["type"] == "crossfeed"
 
     restored = DSPConfig.from_dict(serialized)
 
     assert restored == config
-    assert isinstance(restored.filters[0], ConvolutionFilter)
+    assert isinstance(restored.filters[0], StereoWidthFilter)
+    assert isinstance(restored.filters[1], CrossfeedFilter)
 
 
 def test_high_low_pass_valid() -> None:
@@ -201,8 +213,6 @@ def test_dsp_config_high_low_pass_roundtrip() -> None:
 
     assert restored == config
     assert isinstance(restored.filters[0], HighLowPassFilter)
-    assert isinstance(restored.filters[0], StereoWidthFilter)
-    assert isinstance(restored.filters[1], CrossfeedFilter)
 
 
 def test_stereo_width_filter_defaults() -> None:

--- a/tests/test_dsp.py
+++ b/tests/test_dsp.py
@@ -4,7 +4,9 @@ import pytest
 
 from music_assistant_models.dsp import (
     BalanceFilter,
+    ConvolutionFilter,
     DSPConfig,
+    DSPFilterType,
     GainFilter,
 )
 
@@ -89,3 +91,43 @@ def test_balance_filter_validate() -> None:
         BalanceFilter(enabled=True, balance=-100.1).validate()
     with pytest.raises(ValueError, match="Balance"):
         BalanceFilter(enabled=True, balance=100.1).validate()
+
+
+def test_convolution_filter_defaults() -> None:
+    """Convolution constructs with its documented defaults and validates."""
+    convolution = ConvolutionFilter(enabled=True)
+
+    assert convolution.type == DSPFilterType.CONVOLUTION
+    assert convolution.ir_id == ""
+    assert convolution.gain == 0.0
+
+    convolution.validate()
+
+
+def test_convolution_filter_validate() -> None:
+    """Gain validates within +-60 dB and rejects values outside."""
+    ConvolutionFilter(enabled=True, gain=-60.0).validate()
+    ConvolutionFilter(enabled=True, gain=60.0).validate()
+
+    with pytest.raises(ValueError, match="Gain"):
+        ConvolutionFilter(enabled=True, gain=-60.1).validate()
+    with pytest.raises(ValueError, match="Gain"):
+        ConvolutionFilter(enabled=True, gain=60.1).validate()
+
+
+def test_dsp_config_convolution_roundtrip() -> None:
+    """A DSPConfig with a Convolution filter round-trips to the correct class."""
+    config = DSPConfig(
+        enabled=True,
+        filters=[
+            ConvolutionFilter(enabled=True, ir_id="ir-abc123", gain=-3.0),
+        ],
+    )
+    serialized = config.to_dict()
+
+    assert serialized["filters"][0]["type"] == "convolution"
+
+    restored = DSPConfig.from_dict(serialized)
+
+    assert restored == config
+    assert isinstance(restored.filters[0], ConvolutionFilter)

--- a/tests/test_dsp.py
+++ b/tests/test_dsp.py
@@ -8,6 +8,8 @@ from music_assistant_models.dsp import (
     DSPConfig,
     DSPFilterType,
     GainFilter,
+    HighLowPassFilter,
+    HighLowPassMode,
 )
 
 
@@ -131,3 +133,60 @@ def test_dsp_config_convolution_roundtrip() -> None:
 
     assert restored == config
     assert isinstance(restored.filters[0], ConvolutionFilter)
+
+
+def test_high_low_pass_valid() -> None:
+    """A configured High/Low-pass filter validates without raising."""
+    f = HighLowPassFilter(enabled=True, mode=HighLowPassMode.LOW_PASS, frequency=12000.0, slope=24)
+    f.validate()
+
+
+def test_high_low_pass_defaults() -> None:
+    """High/Low-pass constructs with its documented defaults and validates."""
+    f = HighLowPassFilter(enabled=True)
+
+    assert f.type == DSPFilterType.HIGH_LOW_PASS
+    assert f.mode is HighLowPassMode.HIGH_PASS
+    assert f.frequency == 80.0
+    assert f.slope == 12
+
+    f.validate()
+
+
+def test_high_low_pass_bad_frequency() -> None:
+    """Cutoff frequencies outside the audible band are rejected."""
+    for freq in (10.0, 25000.0):
+        with pytest.raises(ValueError, match="Cutoff frequency"):
+            HighLowPassFilter(enabled=True, frequency=freq).validate()
+
+
+def test_high_low_pass_bad_slope() -> None:
+    """Slopes outside the allowed {12, 24, 48} set are rejected."""
+    for slope in (6, 18, 96):
+        with pytest.raises(ValueError, match="Slope"):
+            HighLowPassFilter(enabled=True, slope=slope).validate()
+
+
+def test_high_low_pass_unknown_mode_defaults() -> None:
+    """An unknown mode value falls back to high-pass."""
+    assert HighLowPassMode("sideways") is HighLowPassMode.HIGH_PASS
+
+
+def test_dsp_config_high_low_pass_roundtrip() -> None:
+    """A DSPConfig with a High/Low-pass filter round-trips to the correct class."""
+    config = DSPConfig(
+        enabled=True,
+        filters=[
+            HighLowPassFilter(
+                enabled=True, mode=HighLowPassMode.LOW_PASS, frequency=8000.0, slope=48
+            ),
+        ],
+    )
+    serialized = config.to_dict()
+
+    assert serialized["filters"][0]["type"] == "high_low_pass"
+
+    restored = DSPConfig.from_dict(serialized)
+
+    assert restored == config
+    assert isinstance(restored.filters[0], HighLowPassFilter)


### PR DESCRIPTION
This PR adds two new filter types following the existing filter models

The convolution (impulse response) filter carries an `ir_id` referencing a server-stored impulse response file and a gain output trim in dB, validated -60 to 60 the same as `GainFilter`. The server resolves `ir_id` to a file at playback time; this model only carries the reference and the trim.

The high-pass / low-pass filter carries a mode toggle (high_pass or low_pass), a cutoff frequency in Hz, and a slope in dB/octave, validated to 20–20000 Hz with slope restricted to 12, 24, or 48. A single type covers both directions via the mode field. Resonance/Q is intentionally omitted that's what the Parametric EQ is for; the server derives per-stage Butterworth Q from the slope and cascades biquads to realise the steeper rolloffs. This model only carries the cutoff, direction, and slope.
