### PR TITLE
Add show_dashboard provider feature and dashboard models

### DIFF
--- a/music_assistant_models/dashboard.py
+++ b/music_assistant_models/dashboard.py
@@ -11,16 +11,11 @@ from mashumaro import DataClassDictMixin
 class DashboardDevice(DataClassDictMixin):
     """Model for a display device capable of showing a MA dashboard."""
 
-    # device_id: provider-scoped unique id of the display device
+    # provider-scoped unique id
     device_id: str
-
-    # provider_instance: instance_id of the provider that can drive this device
     provider_instance: str
-
-    # name: human readable name of the display device
     name: str
-
-    # player_id: set when this display device is also registered as a MA player
+    # set when this display device is also registered as a MA player
     player_id: str | None = None
 
 
@@ -28,11 +23,9 @@ class DashboardDevice(DataClassDictMixin):
 class DashboardSession(DataClassDictMixin):
     """Model for an active dashboard cast session on a display device."""
 
-    # device_id: provider-scoped unique id of the display device
+    # provider-scoped unique id
     device_id: str
-
-    # provider_instance: instance_id of the provider driving this session
     provider_instance: str
-
-    # path: the dashboard route being shown (e.g. "/party")
+    name: str
+    # the dashboard route being shown (e.g. "/party")
     path: str

--- a/music_assistant_models/dashboard.py
+++ b/music_assistant_models/dashboard.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 
 from mashumaro import DataClassDictMixin
 
+from .enums import DashboardType
+
 
 @dataclass
 class DashboardDevice(DataClassDictMixin):
@@ -27,5 +29,6 @@ class DashboardSession(DataClassDictMixin):
     device_id: str
     provider_instance: str
     name: str
-    # the dashboard route being shown (e.g. "/party")
-    path: str
+    dashboard: DashboardType
+    # set for dashboards scoped to a single player (e.g. now playing)
+    player_id: str | None = None

--- a/music_assistant_models/dashboard.py
+++ b/music_assistant_models/dashboard.py
@@ -1,0 +1,24 @@
+"""Model(s) for dashboard casting to display devices."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mashumaro import DataClassDictMixin
+
+
+@dataclass
+class DashboardDevice(DataClassDictMixin):
+    """Model for a display device capable of showing a MA dashboard."""
+
+    # device_id: provider-scoped unique id of the display device
+    device_id: str
+
+    # provider_instance: instance_id of the provider that can drive this device
+    provider_instance: str
+
+    # name: human readable name of the display device
+    name: str
+
+    # player_id: set when this display device is also registered as a MA player
+    player_id: str | None = None

--- a/music_assistant_models/dashboard.py
+++ b/music_assistant_models/dashboard.py
@@ -17,8 +17,8 @@ class DashboardDevice(DataClassDictMixin):
     dashboard_id: str
     name: str
     supported_types: set[DashboardType] = field(default_factory=set)
-    # material design (mdi-*) or MA/lucide icon name
-    icon: str | None = None
+    # provider domain this endpoint belongs to; used only as a hint to resolve its icon
+    provider_domain_hint: str | None = None
 
 
 @dataclass

--- a/music_assistant_models/dashboard.py
+++ b/music_assistant_models/dashboard.py
@@ -17,6 +17,8 @@ class DashboardDevice(DataClassDictMixin):
     dashboard_id: str
     name: str
     supported_types: set[DashboardType] = field(default_factory=set)
+    # material design (mdi-*) or MA/lucide icon name
+    icon: str | None = None
     # set when this dashboard endpoint is also registered as a MA player
     player_id: str | None = None
 

--- a/music_assistant_models/dashboard.py
+++ b/music_assistant_models/dashboard.py
@@ -1,8 +1,8 @@
-"""Model(s) for dashboard casting to display devices."""
+"""Model(s) for dashboards shown on display devices and (api) clients."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from mashumaro import DataClassDictMixin
 
@@ -11,23 +11,21 @@ from .enums import DashboardType
 
 @dataclass
 class DashboardDevice(DataClassDictMixin):
-    """Model for a display device capable of showing a MA dashboard."""
+    """Model for a registered dashboard endpoint capable of showing a MA dashboard."""
 
-    # provider-scoped unique id
-    device_id: str
-    provider_instance: str
+    # unique id chosen by the registering client (e.g. a device uuid)
+    dashboard_id: str
     name: str
-    # set when this display device is also registered as a MA player
+    supported_types: set[DashboardType] = field(default_factory=set)
+    # set when this dashboard endpoint is also registered as a MA player
     player_id: str | None = None
 
 
 @dataclass
 class DashboardSession(DataClassDictMixin):
-    """Model for an active dashboard cast session on a display device."""
+    """Model for an active dashboard session on a registered dashboard endpoint."""
 
-    # provider-scoped unique id
-    device_id: str
-    provider_instance: str
+    dashboard_id: str
     name: str
     dashboard: DashboardType
     # set for dashboards scoped to a single player (e.g. now playing)

--- a/music_assistant_models/dashboard.py
+++ b/music_assistant_models/dashboard.py
@@ -22,3 +22,17 @@ class DashboardDevice(DataClassDictMixin):
 
     # player_id: set when this display device is also registered as a MA player
     player_id: str | None = None
+
+
+@dataclass
+class DashboardSession(DataClassDictMixin):
+    """Model for an active dashboard cast session on a display device."""
+
+    # device_id: provider-scoped unique id of the display device
+    device_id: str
+
+    # provider_instance: instance_id of the provider driving this session
+    provider_instance: str
+
+    # path: the dashboard route being shown (e.g. "/party")
+    path: str

--- a/music_assistant_models/dashboard.py
+++ b/music_assistant_models/dashboard.py
@@ -19,8 +19,6 @@ class DashboardDevice(DataClassDictMixin):
     supported_types: set[DashboardType] = field(default_factory=set)
     # material design (mdi-*) or MA/lucide icon name
     icon: str | None = None
-    # set when this dashboard endpoint is also registered as a MA player
-    player_id: str | None = None
 
 
 @dataclass

--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -589,6 +589,7 @@ class EventType(StrEnum):
     PROVIDER_EVENT = "provider_event"
     SYNC_TASKS_UPDATED = "sync_tasks_updated"
     TASKS_UPDATED = "tasks_updated"
+    DASHBOARD_SESSIONS_UPDATED = "dashboard_sessions_updated"
     MUSIC_SYNC_COMPLETED = "music_sync_completed"
     AUTH_SESSION = "auth_session"
     CORE_STATE_UPDATED = "core_state_updated"

--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -51,6 +51,19 @@ class MediaType(StrEnum, metaclass=MediaTypeMeta):
         return cls.UNKNOWN
 
 
+class DashboardType(StrEnum):
+    """Enum with the dashboards that can be cast to a display device."""
+
+    PARTY = "party"
+    NOW_PLAYING = "now_playing"
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def _missing_(cls, value: object) -> DashboardType:  # noqa: ARG003
+        """Set default enum member if an unknown value is provided."""
+        return cls.UNKNOWN
+
+
 class SourceControl(StrEnum):
     """Control actions issued to a live AudioSource by the player controller."""
 

--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -603,6 +603,13 @@ class EventType(StrEnum):
     PROVIDER_EVENT = "provider_event"
     SYNC_TASKS_UPDATED = "sync_tasks_updated"
     TASKS_UPDATED = "tasks_updated"
+    # request to show a dashboard on a registered dashboard endpoint;
+    # object_id holds the dashboard_id, data holds the DashboardSession
+    DASHBOARD_SHOW = "dashboard_show"
+    # request to hide the dashboard on a registered dashboard endpoint;
+    # object_id holds the dashboard_id
+    DASHBOARD_HIDE = "dashboard_hide"
+    DASHBOARDS_UPDATED = "dashboards_updated"
     DASHBOARD_SESSIONS_UPDATED = "dashboard_sessions_updated"
     MUSIC_SYNC_COMPLETED = "music_sync_completed"
     AUTH_SESSION = "auth_session"
@@ -697,8 +704,6 @@ class ProviderFeature(StrEnum):
     REMOVE_PLAYER = "remove_player"
     CREATE_GROUP_PLAYER = "create_group_player"
     REMOVE_GROUP_PLAYER = "remove_group_player"
-    # provider can show MA dashboards (e.g. party mode) on display devices
-    SHOW_DASHBOARD = "show_dashboard"
 
     #
     # METADATAPROVIDER FEATURES

--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -682,6 +682,8 @@ class ProviderFeature(StrEnum):
     REMOVE_PLAYER = "remove_player"
     CREATE_GROUP_PLAYER = "create_group_player"
     REMOVE_GROUP_PLAYER = "remove_group_player"
+    # provider can show MA dashboards (e.g. party mode) on display devices
+    SHOW_DASHBOARD = "show_dashboard"
 
     #
     # METADATAPROVIDER FEATURES

--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -603,11 +603,7 @@ class EventType(StrEnum):
     PROVIDER_EVENT = "provider_event"
     SYNC_TASKS_UPDATED = "sync_tasks_updated"
     TASKS_UPDATED = "tasks_updated"
-    # request to show a dashboard on a registered dashboard endpoint;
-    # object_id holds the dashboard_id, data holds the DashboardSession
     DASHBOARD_SHOW = "dashboard_show"
-    # request to hide the dashboard on a registered dashboard endpoint;
-    # object_id holds the dashboard_id
     DASHBOARD_HIDE = "dashboard_hide"
     DASHBOARDS_UPDATED = "dashboards_updated"
     DASHBOARD_SESSIONS_UPDATED = "dashboard_sessions_updated"

--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -56,6 +56,7 @@ class DashboardType(StrEnum):
 
     PARTY = "party"
     NOW_PLAYING = "now_playing"
+    MUSIC_QUIZ = "music_quiz"
     UNKNOWN = "unknown"
 
     @classmethod


### PR DESCRIPTION
Shared models for showing Music Assistant dashboards (party mode, now-playing) on display devices and (api) clients — Chromecast/Nest Hub today, native TV apps or webviews later. Consumed by the server (dashboard controller + chromecast provider) and the frontend (cast button, viewer session).

Dashboards are intentionally not part of the provider model: any API client can register itself as a dashboard endpoint, and show/hide are intent events on the event bus.

## Changes
- `DashboardType` — the dashboards that can be shown (`party`, `now_playing`, `music_quiz` reserved).
- `DashboardDevice` — a registered dashboard endpoint (`dashboard_id`, `name`, `supported_types`, optional `icon`).
- `DashboardSession` — an active dashboard session (`dashboard_id`, `name`, `dashboard`, optional `player_id`).
- `EventType` additions: `DASHBOARD_SHOW` / `DASHBOARD_HIDE` (intent events toward a registered endpoint), `DASHBOARDS_UPDATED` (endpoint registry changed), `DASHBOARD_SESSIONS_UPDATED` (active sessions changed).

Companion PRs: server (music-assistant/server#4887), frontend (music-assistant/frontend#2176), receiver (music-assistant/cast-receiver#1). This models PR needs to be released and pinned before the server PR's CI is green.
