### PR TITLE
Replace inline icon SVGs with an icon_images variant list

### DIFF
--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -873,6 +873,14 @@ class ProviderStage(StrEnum):
         return cls.STABLE
 
 
+class ProviderIconVariant(StrEnum):
+    """Enum of provider icon variants that a provider can supply."""
+
+    DEFAULT = "default"
+    DARK = "dark"
+    MONOCHROME = "monochrome"
+
+
 class CoreState(StrEnum):
     """Enum representing the core state of the Music Assistant server."""
 

--- a/music_assistant_models/provider.py
+++ b/music_assistant_models/provider.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from mashumaro.mixins.orjson import DataClassORJSONMixin
 
-from .enums import ProviderFeature, ProviderStage, ProviderType
+from .enums import ProviderFeature, ProviderIconVariant, ProviderStage, ProviderType
 from .translations import resolve_translation
 
 
@@ -41,18 +41,9 @@ class ProviderManifest(DataClassORJSONMixin):
     depends_on: str | None = None
     # icon: name of the material design icon (https://pictogrammers.com/library/mdi)
     icon: str | None = None
-    # icon_svg: svg icon (full xml string)
-    # if this attribute is omitted and an icon.svg is found in the provider
-    # folder, the file contents will be read instead.
-    icon_svg: str | None = None
-    # icon_svg_dark: optional separate dark svg icon (full xml string)
-    # if this attribute is omitted and an icon_dark.svg is found in the provider
-    # folder, the file contents will be read instead.
-    icon_svg_dark: str | None = None
-    # icon_svg_monochrome: optional separate monochrome svg icon (full xml string)
-    # if this attribute is omitted and an monochrome_icon.svg is found in the provider
-    # folder, the file contents will be read instead.
-    icon_svg_monochrome: str | None = None
+    # icon_images: which icon variants this provider supplies as image files
+    # (svg or transparent png in the provider folder).
+    icon_images: list[ProviderIconVariant] = field(default_factory=list)
     # mdns_discovery: list of mdns types to discover
     mdns_discovery: list[str] | None = None
     # upnp_discovery: list of SSDP search targets to discover

--- a/tests/test_provider_manifest.py
+++ b/tests/test_provider_manifest.py
@@ -1,0 +1,48 @@
+"""Tests for ProviderManifest icon handling."""
+
+from music_assistant_models.enums import ProviderIconVariant, ProviderType
+from music_assistant_models.provider import ProviderManifest
+
+
+def _manifest(**kwargs) -> ProviderManifest:
+    return ProviderManifest(
+        type=ProviderType.MUSIC,
+        domain="dummy",
+        name="Dummy",
+        description="Dummy provider",
+        codeowners=[],
+        **kwargs,
+    )
+
+
+def test_icon_variant_values() -> None:
+    """Test ProviderIconVariant enum values."""
+    assert ProviderIconVariant.DEFAULT == "default"
+    assert ProviderIconVariant.DARK == "dark"
+    assert ProviderIconVariant.MONOCHROME == "monochrome"
+
+
+def test_icon_images_defaults_empty() -> None:
+    """Test that icon_images defaults to empty list."""
+    assert _manifest().icon_images == []
+
+
+def test_icon_images_roundtrip() -> None:
+    """Test icon_images survives JSON roundtrip."""
+    manifest = _manifest(icon_images=[ProviderIconVariant.DEFAULT, ProviderIconVariant.DARK])
+    restored = ProviderManifest.from_json(manifest.to_json())
+    assert restored.icon_images == [
+        ProviderIconVariant.DEFAULT,
+        ProviderIconVariant.DARK,
+    ]
+
+
+def test_legacy_icon_svg_key_ignored() -> None:
+    """Test that legacy icon_svg key in JSON is safely ignored."""
+    # old servers/persisted json may still contain icon_svg; it must be ignored
+    restored = ProviderManifest.from_json(
+        '{"type":"music","domain":"d","name":"N","description":"x",'
+        '"codeowners":[],"icon_svg":"<svg/>"}'
+    )
+    assert restored.icon_images == []
+    assert not hasattr(restored, "icon_svg")


### PR DESCRIPTION
## Problem

Provider manifests inline every icon as full SVG XML (`icon_svg`, `icon_svg_dark`, `icon_svg_monochrome`). Aggregated across all providers, the `providers/manifests` API payload grows to ~1.6MB, which slows down and can crash the WebRTC data channel (it exceeds the message size).

## Changes

- Remove `icon_svg`, `icon_svg_dark` and `icon_svg_monochrome` from `ProviderManifest`.
- Add `icon_images: list[ProviderIconVariant]` so a manifest advertises *which* variants a provider ships; the bytes are fetched separately, on demand.
- Add a `ProviderIconVariant` enum (`default`, `dark`, `monochrome`).
- Keep the existing mdi `icon` field.

Companion PRs: music-assistant/server#4907 and music-assistant/frontend#2178.
