### PR TITLE
Add TransposeFilter DSP filter type

### DIFF
--- a/music_assistant_models/dsp.py
+++ b/music_assistant_models/dsp.py
@@ -33,6 +33,7 @@ class DSPFilterType(StrEnum):
     BALANCE = "balance"
     STEREO_WIDTH = "stereo_width"
     CROSSFEED = "crossfeed"
+    TRANSPOSE = "transpose"
 
 
 @dataclass
@@ -200,6 +201,22 @@ class CrossfeedFilter(DSPFilterBase):
             raise ValueError("Soundstage must be in the range 0.0 to 1.0")
 
 
+@dataclass
+class TransposeFilter(DSPFilterBase):
+    """Model for a Transpose (pitch shift) filter."""
+
+    type: Literal[DSPFilterType.TRANSPOSE] = DSPFilterType.TRANSPOSE
+    # Shift in semitones, negative is down and positive is up. 0.0 leaves the
+    # audio unchanged. Fractional values are allowed so alternative concert
+    # pitches can be expressed (A=432Hz is roughly -0.318 semitones).
+    semitones: float = 0.0
+
+    def validate(self) -> None:
+        """Validate the Transpose filter."""
+        if not -12.0 <= self.semitones <= 12.0:
+            raise ValueError("Semitones must be in the range -12.0 to 12.0")
+
+
 # Type alias for all possible DSP filters
 DSPFilter = (
     ParametricEQFilter
@@ -208,6 +225,7 @@ DSPFilter = (
     | BalanceFilter
     | StereoWidthFilter
     | CrossfeedFilter
+    | TransposeFilter
 )
 
 

--- a/music_assistant_models/dsp.py
+++ b/music_assistant_models/dsp.py
@@ -283,7 +283,7 @@ class TransposeFilter(DSPFilterBase):
     def validate(self) -> None:
         """Validate the Transpose filter."""
         if not -12.0 <= self.semitones <= 12.0:
-            raise ValueError("Semitones must be in the range -12.0 to 12.0"
+            raise ValueError("Semitones must be in the range -12.0 to 12.0")
 
 
 @dataclass

--- a/tests/test_dsp.py
+++ b/tests/test_dsp.py
@@ -8,6 +8,7 @@ from music_assistant_models.dsp import (
     DSPConfig,
     GainFilter,
     StereoWidthFilter,
+    TransposeFilter,
 )
 
 
@@ -166,3 +167,53 @@ def test_crossfeed_filter_validate() -> None:
         CrossfeedFilter(enabled=True, soundstage=-0.1).validate()
     with pytest.raises(ValueError, match="Soundstage"):
         CrossfeedFilter(enabled=True, soundstage=1.1).validate()
+
+
+def test_transpose_filter_defaults() -> None:
+    """Transpose constructs with its documented defaults and validates."""
+    transpose = TransposeFilter(enabled=True)
+
+    assert transpose.type == "transpose"
+    assert transpose.semitones == 0.0
+
+    transpose.validate()
+
+
+def test_transpose_filter_roundtrip() -> None:
+    """A Transpose filter round-trips through to_dict/from_dict."""
+    transpose = TransposeFilter(enabled=True, semitones=-3.0)
+    payload = transpose.to_dict()
+
+    assert payload["type"] == "transpose"
+    assert payload["semitones"] == -3.0
+    assert TransposeFilter.from_dict(payload) == transpose
+
+
+def test_transpose_filter_validate() -> None:
+    """Semitones validates within +-12 and rejects values outside."""
+    TransposeFilter(enabled=True, semitones=-12.0).validate()
+    # Alternative concert pitch (A=432Hz) is a fraction of a semitone.
+    TransposeFilter(enabled=True, semitones=-0.318).validate()
+    TransposeFilter(enabled=True, semitones=0.0).validate()
+    TransposeFilter(enabled=True, semitones=12.0).validate()
+
+    with pytest.raises(ValueError, match="Semitones"):
+        TransposeFilter(enabled=True, semitones=-12.1).validate()
+    with pytest.raises(ValueError, match="Semitones"):
+        TransposeFilter(enabled=True, semitones=12.1).validate()
+
+
+def test_dsp_config_transpose_roundtrip() -> None:
+    """A DSPConfig containing a Transpose filter resolves back to TransposeFilter."""
+    config = DSPConfig(
+        enabled=True,
+        filters=[TransposeFilter(enabled=True, semitones=2.0)],
+    )
+    serialized = config.to_dict()
+
+    assert serialized["filters"][0]["type"] == "transpose"
+
+    restored = DSPConfig.from_dict(serialized)
+
+    assert restored == config
+    assert isinstance(restored.filters[0], TransposeFilter)


### PR DESCRIPTION
Adds a transpose (pitch shift) DSP filter carrying a single semitones value (float, validated -12..12), where negative shifts down, positive shifts up and 0.0 is a no-op.

Named "transpose" rather than "pitch" because it shifts the key while leaving tempo unchanged; "pitch" tends to read as a DJ-style pitch fader that changes both. The field is a float rather than an int so alternative concert pitches can be expressed (A=432Hz is about -0.318 semitones).
