### PR TITLE
Add setup flow primitives

### DIFF
--- a/music_assistant_models/config_entries.py
+++ b/music_assistant_models/config_entries.py
@@ -60,6 +60,7 @@ ConfigEntryTypeMap: dict[ConfigEntryType, type[ConfigValueType]] = {
     ConfigEntryType.ACTION: str,
     ConfigEntryType.ALERT: str,
     ConfigEntryType.ICON: str,
+    ConfigEntryType.IMAGE: str,
 }
 
 UI_ONLY = (
@@ -67,6 +68,7 @@ UI_ONLY = (
     ConfigEntryType.DIVIDER,
     ConfigEntryType.ACTION,
     ConfigEntryType.ALERT,
+    ConfigEntryType.IMAGE,
 )
 
 
@@ -477,6 +479,11 @@ class ProviderConfig(Config):
     # status: load/lifecycle status, derived and stamped server-side on the api read path.
     # Never persisted (see to_raw) and not set during normal config save/load.
     status: ProviderStatus | None = None
+    # setup_data: values collected by the (re)configure setup flow (credentials, tokens, pairing
+    # data), owned exclusively by the setup flows. Persisted to storage but NEVER serialized over
+    # the API. Any secrets in here are pre-encrypted by the server before they are stored; the
+    # models keep the value as-is and do not encrypt/decrypt anything themselves.
+    setup_data: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
     def __pre_deserialize__(cls, d: dict[Any, Any]) -> dict[Any, Any]:
@@ -486,10 +493,17 @@ class ProviderConfig(Config):
             d["last_error"] = {"error_code": 999, "message": last_error}
         return d
 
+    def __post_serialize__(self, d: dict[str, Any]) -> dict[str, Any]:
+        """Drop the storage-only setup_data from the api payload; keep the base behavior."""
+        d = super().__post_serialize__(d)
+        d.pop("setup_data", None)
+        return d
+
     def to_raw(self) -> dict[str, Any]:
-        """Return minimized/raw dict to store; the derived `status` is never persisted."""
+        """Return minimized/raw dict to store; status is dropped, setup_data is persisted."""
         res = super().to_raw()
         res.pop("status", None)
+        res["setup_data"] = self.setup_data
         return res
 
     def _translation_owner(self) -> str | None:
@@ -510,6 +524,23 @@ class PlayerConfig(Config):
     default_name: str | None = None
     # player_type: type of player (player, protocol, group etc.)
     player_type: PlayerType = PlayerType.PLAYER
+    # setup_data: values collected by the (re)configure setup flow (credentials, tokens, pairing
+    # data), owned exclusively by the setup flows. Persisted to storage but NEVER serialized over
+    # the API. Any secrets in here are pre-encrypted by the server before they are stored; the
+    # models keep the value as-is and do not encrypt/decrypt anything themselves.
+    setup_data: dict[str, Any] = field(default_factory=dict)
+
+    def __post_serialize__(self, d: dict[str, Any]) -> dict[str, Any]:
+        """Drop the storage-only setup_data from the api payload; keep the base behavior."""
+        d = super().__post_serialize__(d)
+        d.pop("setup_data", None)
+        return d
+
+    def to_raw(self) -> dict[str, Any]:
+        """Return minimized/raw dict to store; setup_data is persisted, not exposed via the api."""
+        res = super().to_raw()
+        res["setup_data"] = self.setup_data
+        return res
 
     def _translation_owner(self) -> str | None:
         return f"provider.{self.provider}"

--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -601,6 +601,9 @@ class EventType(StrEnum):
     # object_id = provider instance_id (optionally suffixed with /sub_scope),
     # data = provider-defined payload
     PROVIDER_EVENT = "provider_event"
+    # setup_flow_updated: a running setup flow produced a new/updated step;
+    # object_id is the flow_id
+    SETUP_FLOW_UPDATED = "setup_flow_updated"
     SYNC_TASKS_UPDATED = "sync_tasks_updated"
     TASKS_UPDATED = "tasks_updated"
     DASHBOARD_SHOW = "dashboard_show"
@@ -765,10 +768,39 @@ class ConfigEntryType(StrEnum):
     ACTION = "action"
     ICON = "icon"
     ALERT = "alert"
+    IMAGE = "image"
     UNKNOWN = "unknown"
 
     @classmethod
     def _missing_(cls, value: object) -> ConfigEntryType:  # noqa: ARG003
+        """Set default enum member if an unknown value is provided."""
+        return cls.UNKNOWN
+
+
+class FlowStepType(StrEnum):
+    """Enum with the possible types of a setup flow step."""
+
+    # form: render config entries and wait for the user to submit
+    FORM = "form"
+
+    # external: the user must open an external url (e.g. OAuth);
+    # the server advances the flow on the callback
+    EXTERNAL = "external"
+
+    # progress: the server is working/waiting on something; no user input
+    PROGRESS = "progress"
+
+    # finish: the flow completed; result references the created/updated object
+    FINISH = "finish"
+
+    # abort: the flow ended without a result
+    ABORT = "abort"
+
+    # fallback
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def _missing_(cls, value: object) -> FlowStepType:  # noqa: ARG003
         """Set default enum member if an unknown value is provided."""
         return cls.UNKNOWN
 

--- a/music_assistant_models/setup_flow.py
+++ b/music_assistant_models/setup_flow.py
@@ -84,9 +84,12 @@ class SetupFlowStep(DataClassDictMixin):
         )
         if description is not None:
             d["description"] = description
-        progress_text = resolve_translation(f"setup_flow.{self.step_id}.progress_text", owner=owner)
-        if progress_text is not None:
-            d["progress_text"] = progress_text
+        if self.progress_text is not None:
+            progress_text = resolve_translation(
+                f"setup_flow.{self.step_id}.progress_text", owner=owner
+            )
+            if progress_text is not None:
+                d["progress_text"] = progress_text
         if self.reason is not None:
             reason = resolve_translation(f"setup_flow.abort.{self.reason}", owner=owner)
             if reason is not None:

--- a/music_assistant_models/setup_flow.py
+++ b/music_assistant_models/setup_flow.py
@@ -1,0 +1,98 @@
+"""Model for a step of a running setup flow."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from mashumaro import DataClassDictMixin, field_options
+
+from .config_entries import ConfigEntry
+from .enums import FlowStepType
+from .translations import resolve_translation
+
+
+@dataclass(kw_only=True)
+class SetupFlowStep(DataClassDictMixin):
+    """
+    Model for a single step of a running setup flow.
+
+    A setup flow is the interactive, multi-step process (credentials, OAuth, pairing, ...) that
+    creates or reconfigures a provider or player. Each step is serialized to the API client, which
+    renders it based on its type and posts the user input back to advance the flow.
+    """
+
+    # flow_id: identifier of the running flow this step belongs to
+    flow_id: str
+    # step_id: stable slug identifying this step; also the i18n key segment
+    step_id: str
+    type: FlowStepType
+    # title: display title for the step, resolved from the translations at serialization
+    title: str | None = None
+    # description: extended description for the step, resolved from the translations
+    # at serialization
+    description: str | None = None
+    # entries [FORM]: the config entries that make up the form fields
+    entries: list[ConfigEntry] = field(default_factory=list)
+    # errors [FORM]: field-key (or "base") -> error slug/message, resolved from the translations
+    errors: dict[str, str] = field(default_factory=dict)
+    # last_step [FORM]: hint for the submit button label (final step vs. continue)
+    last_step: bool | None = None
+    # url [EXTERNAL]: url the user must open (e.g. an OAuth authorize url)
+    url: str | None = None
+    # progress_text [PROGRESS]: status slug/message, resolved from the translations at serialization
+    progress_text: str | None = None
+    # progress [PROGRESS]: optional completion fraction between 0 and 1
+    progress: float | None = None
+    # image [PROGRESS]: optional data-URI illustration (e.g. a pairing QR code)
+    image: str | None = None
+    # expires_at [FORM/EXTERNAL/PROGRESS]: UTC epoch deadline for this step; the client countdown
+    # is cosmetic, the server enforces the deadline
+    expires_at: float | None = None
+    # result [FINISH]: reference to the created/updated object (e.g. {"instance_id": ...})
+    result: dict[str, str] | None = None
+    # reason [ABORT]: reason slug/message, resolved from the translations at serialization
+    reason: str | None = None
+    # translation_owner: the namespace ("provider.<domain>") this step's strings are resolved
+    # under; stamped by the server when the step is served. Not serialized.
+    translation_owner: str | None = field(
+        default=None, metadata=field_options(serialize="omit"), repr=False
+    )
+    # translation_params: optional positional arguments for the {0}/{1} placeholders in this
+    # step's title/description translation, provided by the implementer. Not serialized.
+    translation_params: list[str] | None = field(
+        default=None, metadata=field_options(serialize="omit"), repr=False
+    )
+
+    def __post_serialize__(self, d: dict[str, Any]) -> dict[str, Any]:
+        """
+        Localize human-readable fields from the translations for the connection locale.
+
+        Resolves title/description (setup_flow.<step_id>.*), progress_text, the abort reason
+        (setup_flow.abort.<reason>) and each error value (errors.<slug>) under this step's owner
+        namespace. No-op when nothing matches, so the in-code values/slugs are kept. The
+        translation machinery fields are not serialized.
+        """
+        owner = self.translation_owner
+        title = resolve_translation(
+            f"setup_flow.{self.step_id}.title", owner=owner, params=self.translation_params
+        )
+        if title is not None:
+            d["title"] = title
+        description = resolve_translation(
+            f"setup_flow.{self.step_id}.description", owner=owner, params=self.translation_params
+        )
+        if description is not None:
+            d["description"] = description
+        progress_text = resolve_translation(f"setup_flow.{self.step_id}.progress_text", owner=owner)
+        if progress_text is not None:
+            d["progress_text"] = progress_text
+        if self.reason is not None:
+            reason = resolve_translation(f"setup_flow.abort.{self.reason}", owner=owner)
+            if reason is not None:
+                d["reason"] = reason
+        for field_key, slug in self.errors.items():
+            localized = resolve_translation(f"errors.{slug}", owner=owner)
+            if localized is not None:
+                d["errors"][field_key] = localized
+        return d

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -1,0 +1,101 @@
+"""Tests for the IMAGE config entry type and the storage-only setup_data field."""
+
+from typing import Any
+
+from music_assistant_models.config_entries import (
+    UI_ONLY,
+    ConfigEntry,
+    ConfigEntryTypeMap,
+    PlayerConfig,
+    ProviderConfig,
+)
+from music_assistant_models.enums import ConfigEntryType, ProviderType
+
+
+def _provider_raw(**overrides: Any) -> dict[str, Any]:
+    """Minimal raw ProviderConfig dict as stored in settings.json."""
+    return {
+        "values": {},
+        "type": ProviderType.MUSIC.value,
+        "domain": "demo",
+        "instance_id": "demo--1",
+        **overrides,
+    }
+
+
+def _player_raw(**overrides: Any) -> dict[str, Any]:
+    """Minimal raw PlayerConfig dict as stored in settings.json."""
+    return {
+        "values": {},
+        "provider": "demo",
+        "player_id": "demo--player-1",
+        **overrides,
+    }
+
+
+def test_config_entry_type_unknown_fallback() -> None:
+    """IMAGE is a known ConfigEntryType member; an unknown value falls back to UNKNOWN."""
+    assert ConfigEntryType("image") is ConfigEntryType.IMAGE
+    assert ConfigEntryType("does-not-exist") is ConfigEntryType.UNKNOWN
+
+
+def test_image_entry_is_ui_only_and_not_required() -> None:
+    """An IMAGE entry is presentational: maps to str, is UI-only and never required."""
+    assert ConfigEntryType.IMAGE in UI_ONLY
+    assert ConfigEntryTypeMap[ConfigEntryType.IMAGE] is str
+    entry = ConfigEntry(
+        key="qr",
+        type=ConfigEntryType.IMAGE,
+        default_value="data:image/png;base64,AAAA",
+        required=True,
+    )
+    # __post_init__ forces required False for UI-only entries, even when constructed required
+    assert entry.required is False
+
+
+def test_image_entry_excluded_from_to_raw_values() -> None:
+    """A UI-only IMAGE entry is never persisted in Config.to_raw values."""
+    entries = [
+        ConfigEntry(
+            key="qr", type=ConfigEntryType.IMAGE, default_value="data:image/png;base64,AAAA"
+        ),
+        ConfigEntry(key="server_url", type=ConfigEntryType.STRING),
+    ]
+    conf = ProviderConfig.parse(entries, _provider_raw(values={"server_url": "abc"}))
+    raw = conf.to_raw()
+    assert "qr" not in raw["values"]
+    assert raw["values"]["server_url"] == "abc"
+
+
+def test_provider_setup_data_parses_roundtrips_and_drops_on_api() -> None:
+    """ProviderConfig.setup_data is parsed, persisted via to_raw, but dropped from to_dict."""
+    conf = ProviderConfig.parse([], _provider_raw(setup_data={"token": "enc:secret"}))
+    assert conf.setup_data == {"token": "enc:secret"}
+    # persisted (to_raw) keeps it
+    assert conf.to_raw()["setup_data"] == {"token": "enc:secret"}
+    # api payload (to_dict) never exposes it
+    assert "setup_data" not in conf.to_dict()
+
+
+def test_provider_legacy_raw_without_setup_data_parses() -> None:
+    """A legacy ProviderConfig store without setup_data parses to an empty dict."""
+    conf = ProviderConfig.parse([], _provider_raw())
+    assert conf.setup_data == {}
+    assert conf.to_raw()["setup_data"] == {}
+    assert "setup_data" not in conf.to_dict()
+
+
+def test_player_setup_data_parses_roundtrips_and_drops_on_api() -> None:
+    """PlayerConfig.setup_data is parsed, persisted via to_raw, but dropped from to_dict."""
+    conf = PlayerConfig.parse([], _player_raw(setup_data={"paired": "enc:key"}))
+    assert conf.setup_data == {"paired": "enc:key"}
+    assert conf.to_raw()["setup_data"] == {"paired": "enc:key"}
+    assert "setup_data" not in conf.to_dict()
+
+
+def test_player_legacy_raw_without_setup_data_parses() -> None:
+    """A legacy PlayerConfig store without setup_data parses to an empty dict."""
+    conf = PlayerConfig.parse([], _player_raw())
+    assert conf.setup_data == {}
+    assert conf.to_raw()["setup_data"] == {}
+    assert "setup_data" not in conf.to_dict()

--- a/tests/test_setup_flow.py
+++ b/tests/test_setup_flow.py
@@ -175,6 +175,19 @@ def test_progress_text_resolves() -> None:
         assert step.to_dict()["progress_text"] == "Bezig met verbinden..."
 
 
+def test_progress_text_not_injected_when_unset() -> None:
+    """A step without progress_text never gains one, even when a translation key exists."""
+    catalog = {"provider.demo.setup_flow.credentials.progress_text": "Bezig..."}
+    step = SetupFlowStep(
+        flow_id="f",
+        step_id="credentials",
+        type=FlowStepType.FORM,
+        translation_owner="provider.demo",
+    )
+    with _resolver_active(catalog):
+        assert step.to_dict()["progress_text"] is None
+
+
 def test_abort_reason_resolves_by_value_and_keeps_slug_when_unresolved() -> None:
     """The abort reason resolves setup_flow.abort.<reason> owner-first; an unknown slug is kept."""
     catalog = {

--- a/tests/test_setup_flow.py
+++ b/tests/test_setup_flow.py
@@ -1,0 +1,233 @@
+"""Tests for the SetupFlowStep model and the FlowStepType enum."""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+from music_assistant_models.config_entries import ConfigEntry
+from music_assistant_models.enums import ConfigEntryType, FlowStepType
+from music_assistant_models.setup_flow import SetupFlowStep
+from music_assistant_models.translations import TRANSLATION_RESOLVER
+
+
+@contextmanager
+def _resolver_active(catalog: dict[str, str]) -> Iterator[None]:
+    """Bind a fake catalog resolver for the duration of the block."""
+
+    def resolve(key: str, owner: str | None = None, params: list[Any] | None = None) -> str | None:
+        for candidate in [f"{owner}.{key}", key] if owner else [key]:
+            if (value := catalog.get(candidate)) is not None:
+                return value.format(*params) if params else value
+        return None
+
+    token = TRANSLATION_RESOLVER.set(resolve)
+    try:
+        yield
+    finally:
+        TRANSLATION_RESOLVER.reset(token)
+
+
+def test_flow_step_type_unknown_fallback() -> None:
+    """A known FlowStepType value resolves; an unknown value falls back to UNKNOWN."""
+    assert FlowStepType("form") is FlowStepType.FORM
+    assert FlowStepType("does-not-exist") is FlowStepType.UNKNOWN
+
+
+def test_form_step_shape() -> None:
+    """A FORM step serializes its entries, errors and submit hint; machinery is omitted."""
+    step = SetupFlowStep(
+        flow_id="flow-1",
+        step_id="credentials",
+        type=FlowStepType.FORM,
+        title="Credentials",
+        entries=[ConfigEntry(key="username", type=ConfigEntryType.STRING)],
+        errors={"base": "invalid_auth"},
+        last_step=True,
+        translation_owner="provider.demo",
+        translation_params=["x"],
+    )
+    d = step.to_dict()
+    assert d["flow_id"] == "flow-1"
+    assert d["step_id"] == "credentials"
+    assert d["type"] == "form"
+    assert d["title"] == "Credentials"
+    assert d["entries"][0]["key"] == "username"
+    assert d["errors"] == {"base": "invalid_auth"}
+    assert d["last_step"] is True
+    # translation machinery is never serialized
+    assert "translation_owner" not in d
+    assert "translation_params" not in d
+
+
+def test_external_step_shape() -> None:
+    """An EXTERNAL step carries the url to open and an optional deadline."""
+    step = SetupFlowStep(
+        flow_id="f",
+        step_id="oauth",
+        type=FlowStepType.EXTERNAL,
+        url="https://example.test/authorize",
+        expires_at=1234.5,
+    )
+    d = step.to_dict()
+    assert d["type"] == "external"
+    assert d["url"] == "https://example.test/authorize"
+    assert d["expires_at"] == 1234.5
+
+
+def test_progress_step_shape() -> None:
+    """A PROGRESS step carries status text, an optional fraction and an optional image."""
+    step = SetupFlowStep(
+        flow_id="f",
+        step_id="working",
+        type=FlowStepType.PROGRESS,
+        progress_text="Working...",
+        progress=0.25,
+        image="data:image/png;base64,AAAA",
+    )
+    d = step.to_dict()
+    assert d["type"] == "progress"
+    assert d["progress_text"] == "Working..."
+    assert d["progress"] == 0.25
+    assert d["image"] == "data:image/png;base64,AAAA"
+
+
+def test_finish_step_shape() -> None:
+    """A FINISH step references the created/updated object via result."""
+    step = SetupFlowStep(
+        flow_id="f", step_id="done", type=FlowStepType.FINISH, result={"instance_id": "demo--1"}
+    )
+    d = step.to_dict()
+    assert d["type"] == "finish"
+    assert d["result"] == {"instance_id": "demo--1"}
+
+
+def test_abort_step_shape() -> None:
+    """An ABORT step carries a reason slug."""
+    step = SetupFlowStep(
+        flow_id="f", step_id="failed", type=FlowStepType.ABORT, reason="already_configured"
+    )
+    d = step.to_dict()
+    assert d["type"] == "abort"
+    assert d["reason"] == "already_configured"
+
+
+def test_title_and_description_resolve_owner_first() -> None:
+    """title/description resolve under setup_flow.<step_id>.*, owner-first then common."""
+    catalog = {
+        "setup_flow.credentials.title": "Inloggegevens",
+        "provider.demo.setup_flow.credentials.title": "Demo-inloggegevens",
+        "setup_flow.credentials.description": "Voer je gegevens in.",
+    }
+    owned = SetupFlowStep(
+        flow_id="f",
+        step_id="credentials",
+        type=FlowStepType.FORM,
+        title="Credentials",
+        description="Enter your details.",
+        translation_owner="provider.demo",
+    )
+    with _resolver_active(catalog):
+        d = owned.to_dict()
+    # owner-specific title wins; the description has no owner key and falls back to common
+    assert d["title"] == "Demo-inloggegevens"
+    assert d["description"] == "Voer je gegevens in."
+    # the same step without an owner hits the common title
+    common = SetupFlowStep(
+        flow_id="f", step_id="credentials", type=FlowStepType.FORM, title="Credentials"
+    )
+    with _resolver_active(catalog):
+        assert common.to_dict()["title"] == "Inloggegevens"
+
+
+def test_unresolved_title_keeps_in_code_value() -> None:
+    """When nothing matches, the in-code title is kept (no-op resolution)."""
+    step = SetupFlowStep(
+        flow_id="f", step_id="credentials", type=FlowStepType.FORM, title="Credentials"
+    )
+    # no resolver bound
+    assert step.to_dict()["title"] == "Credentials"
+    # resolver bound but nothing matches for this step
+    with _resolver_active({"setup_flow.other.title": "x"}):
+        assert step.to_dict()["title"] == "Credentials"
+
+
+def test_title_interpolates_translation_params() -> None:
+    """translation_params fill positional placeholders in the resolved title."""
+    catalog = {"setup_flow.pairing.title": "Koppel met {0}"}
+    step = SetupFlowStep(
+        flow_id="f",
+        step_id="pairing",
+        type=FlowStepType.FORM,
+        title="Pair with Speaker",
+        translation_params=["Speaker"],
+    )
+    with _resolver_active(catalog):
+        assert step.to_dict()["title"] == "Koppel met Speaker"
+
+
+def test_progress_text_resolves() -> None:
+    """progress_text resolves under setup_flow.<step_id>.progress_text."""
+    catalog = {"setup_flow.working.progress_text": "Bezig met verbinden..."}
+    step = SetupFlowStep(
+        flow_id="f", step_id="working", type=FlowStepType.PROGRESS, progress_text="Connecting..."
+    )
+    with _resolver_active(catalog):
+        assert step.to_dict()["progress_text"] == "Bezig met verbinden..."
+
+
+def test_abort_reason_resolves_by_value_and_keeps_slug_when_unresolved() -> None:
+    """The abort reason resolves setup_flow.abort.<reason> owner-first; an unknown slug is kept."""
+    catalog = {
+        "setup_flow.abort.already_configured": "Al geconfigureerd.",
+        "provider.demo.setup_flow.abort.already_configured": "Demo: al geconfigureerd.",
+    }
+    # a provider that owns the reason string resolves its own before common
+    owned = SetupFlowStep(
+        flow_id="f",
+        step_id="x",
+        type=FlowStepType.ABORT,
+        reason="already_configured",
+        translation_owner="provider.demo",
+    )
+    with _resolver_active(catalog):
+        assert owned.to_dict()["reason"] == "Demo: al geconfigureerd."
+    # without an owner the common string is used
+    common = SetupFlowStep(
+        flow_id="f", step_id="x", type=FlowStepType.ABORT, reason="already_configured"
+    )
+    with _resolver_active(catalog):
+        assert common.to_dict()["reason"] == "Al geconfigureerd."
+    # an unknown reason keeps its slug verbatim
+    unknown = SetupFlowStep(flow_id="f", step_id="x", type=FlowStepType.ABORT, reason="mystery")
+    with _resolver_active(catalog):
+        assert unknown.to_dict()["reason"] == "mystery"
+
+
+def test_errors_resolve_owner_first_and_keep_slug_when_unresolved() -> None:
+    """Each error value resolves errors.<slug> owner-first; an unknown slug is kept as-is."""
+    catalog = {
+        "errors.invalid_auth": "Ongeldige login.",
+        "provider.demo.errors.invalid_auth": "Demo: ongeldige login.",
+    }
+    owned = SetupFlowStep(
+        flow_id="f",
+        step_id="credentials",
+        type=FlowStepType.FORM,
+        errors={"base": "invalid_auth", "pin": "too_short"},
+        translation_owner="provider.demo",
+    )
+    with _resolver_active(catalog):
+        errors = owned.to_dict()["errors"]
+    # provider-owned string wins for the resolvable slug
+    assert errors["base"] == "Demo: ongeldige login."
+    # the unresolved slug is kept verbatim
+    assert errors["pin"] == "too_short"
+    # without an owner the common string is used
+    common = SetupFlowStep(
+        flow_id="f",
+        step_id="credentials",
+        type=FlowStepType.FORM,
+        errors={"base": "invalid_auth"},
+    )
+    with _resolver_active(catalog):
+        assert common.to_dict()["errors"]["base"] == "Ongeldige login."


### PR DESCRIPTION
Groundwork for the new interactive setup flows: splitting provider/player setup (credentials, OAuth, pairing) from the regular config options. Purely additive, so the current server release keeps working against this package.

- New `SetupFlowStep` model + `FlowStepType` enum: the typed steps (form / external / progress / finish / abort) a running setup flow serves to clients, with server-side translation resolution
- New `ConfigEntryType.IMAGE`: presentational image (data-URI) inside forms, e.g. pairing QR codes or illustrations
- New `SETUP_FLOW_UPDATED` event to push flow step updates to clients
- New `setup_data` on ProviderConfig/PlayerConfig: storage for values collected by setup flows — persisted, but never exposed over the API