### PR TITLE
Use bot tokens for automated releases

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -22,7 +22,7 @@ jobs:
       should_release: ${{ steps.check_commits.outputs.has_commits }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0 # Fetch all history for proper comparison
 

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -102,5 +102,5 @@ jobs:
     with:
       version: ${{ needs.check-and-release.outputs.version }}
     secrets:
+      MUSIC_ASSISTANT_BOT_PRIVATE_KEY: ${{ secrets.MUSIC_ASSISTANT_BOT_PRIVATE_KEY }}
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      PRIVILEGED_GITHUB_TOKEN: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}

--- a/.github/workflows/auto_approve_dependabot.yml
+++ b/.github/workflows/auto_approve_dependabot.yml
@@ -9,4 +9,4 @@ jobs:
       pull-requests: write
     if: github.actor == 'dependabot[bot]'
     steps:
-      - uses: hmarr/auto-approve-action@v4
+      - uses: hmarr/auto-approve-action@8f929096a962e83ccdfa8afcf855f39f12d4dac7 # v4

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🏷 Verify PR has a valid label
-        uses: ludeeus/action-require-labels@2.0.0
+        uses: ludeeus/action-require-labels@be19cd7f04c6fad46a85336f9e9cebdf961807bb # 2.0.0
         with:
          labels: >-
             breaking-change, bugfix, refactor, new-feature, maintenance, ci, dependencies, documentation, new-provider, enhancement

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,9 +41,15 @@ jobs:
     name: Verify Release Settings
     runs-on: ubuntu-latest
     steps:
-      - name: Verify immutable releases are enabled
+      - name: Verify release token and immutable releases
         run: |
           set -euo pipefail
+
+          ACTOR=$(gh api user --jq '.login')
+          if [[ "$ACTOR" != "music-assistant-bot" ]]; then
+            echo "::error::PRIVILEGED_GITHUB_TOKEN authenticates as ${ACTOR}, expected music-assistant-bot."
+            exit 1
+          fi
 
           # This endpoint requires repository administration read access.
           ENABLED=$(
@@ -74,25 +80,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Create or reuse tag
         run: |
           set -euo pipefail
 
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "music-assistant-bot"
+          git config user.email "music-assistant-bot@users.noreply.github.com"
 
           if git show-ref --verify --quiet "refs/tags/${VERSION}"; then
             echo "Reusing existing tag ${VERSION}"
           else
             git tag -a "$VERSION" -m "Release $VERSION"
+            gh auth setup-git
             git push origin "refs/tags/${VERSION}"
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
           VERSION: ${{ inputs.version }}
 
       - name: Check release state
@@ -117,7 +125,7 @@ jobs:
       - name: Generate release notes with Release Drafter
         id: release_drafter
         if: steps.release_state.outputs.published != 'true'
-        uses: release-drafter/release-drafter@v7.6.0
+        uses: release-drafter/release-drafter@eada3c96a64734dd381cfbda23511034e328ddb0 # v7.6.0
         with:
           commitish: refs/tags/${{ inputs.version }} # codespell:ignore commitish
           config-name: release-drafter.yml
@@ -160,7 +168,7 @@ jobs:
             exit 1
           fi
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
           RELEASE_BODY: ${{ steps.release_drafter.outputs.body }}
           VERSION: ${{ inputs.version }}
 
@@ -200,7 +208,7 @@ jobs:
             echo "Release notes already contain content from Release Drafter."
           fi
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
           VERSION: ${{ inputs.version }}
 
   build-and-publish:
@@ -209,7 +217,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.version }}
 
@@ -234,7 +242,7 @@ jobs:
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         if: steps.release_state.outputs.published != 'true'
-        uses: actions/setup-python@v7.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -288,7 +296,7 @@ jobs:
 
           gh release upload "$VERSION" "${ASSETS[@]}"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
           VERSION: ${{ inputs.version }}
 
       - name: Verify draft release assets
@@ -353,7 +361,7 @@ jobs:
         if: steps.release_state.outputs.published != 'true'
         run: gh release edit "$VERSION" --draft=false --latest --verify-tag
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
           VERSION: ${{ inputs.version }}
 
       - name: Download published release assets
@@ -395,7 +403,7 @@ jobs:
           VERSION: ${{ inputs.version }}
 
       - name: Publish release to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.14.1
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}
@@ -454,7 +462,7 @@ jobs:
           fi
 
       - name: Checkout server repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: music-assistant/server
           ref: ${{ steps.target.outputs.branch }}
@@ -476,7 +484,7 @@ jobs:
 
       - name: Create Pull Request
         id: create_pr
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
           commit-message: "⬆️ Update music-assistant-models to ${{ inputs.version }}"
@@ -501,7 +509,7 @@ jobs:
     if: ${{ !contains(inputs.version, '.post') }}
     steps:
       - name: Checkout client repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: music-assistant/client
           token: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
@@ -519,7 +527,7 @@ jobs:
 
       - name: Create Pull Request
         id: create_pr
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
           commit-message: "⬆️ Update music-assistant-models to ${{ inputs.version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,24 +83,22 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-          persist-credentials: false
 
       - name: Create or reuse tag
         run: |
           set -euo pipefail
 
-          git config user.name "music-assistant-machine"
-          git config user.email "music-assistant-machine@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
 
           if git show-ref --verify --quiet "refs/tags/${VERSION}"; then
             echo "Reusing existing tag ${VERSION}"
           else
             git tag -a "$VERSION" -m "Release $VERSION"
-            gh auth setup-git
             git push origin "refs/tags/${VERSION}"
           fi
         env:
-          GH_TOKEN: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ inputs.version }}
 
       - name: Check release state
@@ -168,7 +166,7 @@ jobs:
             exit 1
           fi
         env:
-          GH_TOKEN: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_BODY: ${{ steps.release_drafter.outputs.body }}
           VERSION: ${{ inputs.version }}
 
@@ -208,7 +206,7 @@ jobs:
             echo "Release notes already contain content from Release Drafter."
           fi
         env:
-          GH_TOKEN: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ inputs.version }}
 
   build-and-publish:
@@ -296,7 +294,7 @@ jobs:
 
           gh release upload "$VERSION" "${ASSETS[@]}"
         env:
-          GH_TOKEN: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ inputs.version }}
 
       - name: Verify draft release assets
@@ -361,7 +359,7 @@ jobs:
         if: steps.release_state.outputs.published != 'true'
         run: gh release edit "$VERSION" --draft=false --latest --verify-tag
         env:
-          GH_TOKEN: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ inputs.version }}
 
       - name: Download published release assets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -485,7 +485,6 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: server
           permission-contents: write
-          permission-issues: write
           permission-pull-requests: write
 
       - name: Checkout server repository
@@ -545,7 +544,6 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: client
           permission-contents: write
-          permission-issues: write
           permission-pull-requests: write
 
       - name: Checkout client repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,9 @@ on:
         required: true
         type: string
     secrets:
-      PYPI_TOKEN:
+      MUSIC_ASSISTANT_BOT_PRIVATE_KEY:
         required: true
-      PRIVILEGED_GITHUB_TOKEN:
+      PYPI_TOKEN:
         required: true
 
 permissions:
@@ -41,13 +41,20 @@ jobs:
     name: Verify Release Settings
     runs-on: ubuntu-latest
     steps:
-      - name: Verify release token and immutable releases
+      - name: Create release settings token
+        id: release_settings_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.MUSIC_ASSISTANT_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.MUSIC_ASSISTANT_BOT_PRIVATE_KEY }}
+          permission-administration: read
+
+      - name: Verify bot token and immutable releases
         run: |
           set -euo pipefail
 
-          ACTOR=$(gh api user --jq '.login')
-          if [[ "$ACTOR" != "music-assistant-machine" ]]; then
-            echo "::error::PRIVILEGED_GITHUB_TOKEN authenticates as ${ACTOR}, expected music-assistant-machine."
+          if [[ "$APP_SLUG" != "musicassistant-bot" ]]; then
+            echo "::error::GitHub App token belongs to ${APP_SLUG}, expected musicassistant-bot."
             exit 1
           fi
 
@@ -65,7 +72,8 @@ jobs:
             exit 1
           fi
         env:
-          GH_TOKEN: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
+          APP_SLUG: ${{ steps.release_settings_token.outputs.app-slug }}
+          GH_TOKEN: ${{ steps.release_settings_token.outputs.token }}
 
   test:
     name: Run Tests
@@ -335,6 +343,15 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ inputs.version }}
 
+      - name: Create release settings token
+        id: release_settings_token
+        if: steps.release_state.outputs.published != 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.MUSIC_ASSISTANT_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.MUSIC_ASSISTANT_BOT_PRIVATE_KEY }}
+          permission-administration: read
+
       - name: Recheck immutable release setting
         if: steps.release_state.outputs.published != 'true'
         run: |
@@ -353,7 +370,7 @@ jobs:
             exit 1
           fi
         env:
-          GH_TOKEN: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.release_settings_token.outputs.token }}
 
       - name: Publish GitHub release
         if: steps.release_state.outputs.published != 'true'
@@ -441,7 +458,7 @@ jobs:
             echo EOF
           } >> $GITHUB_OUTPUT
         env:
-          GH_TOKEN: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   server-repo-pr:
     name: Server repo PR
@@ -459,12 +476,25 @@ jobs:
             echo "branch=dev" >> $GITHUB_OUTPUT
           fi
 
+      - name: Create server repository token
+        id: app_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.MUSIC_ASSISTANT_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.MUSIC_ASSISTANT_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: server
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+
       - name: Checkout server repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           repository: music-assistant/server
           ref: ${{ steps.target.outputs.branch }}
-          token: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
+          token: ${{ steps.app_token.outputs.token }}
           path: .
 
       - name: Update models version
@@ -484,7 +514,7 @@ jobs:
         id: create_pr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
+          token: ${{ steps.app_token.outputs.token }}
           commit-message: "⬆️ Update music-assistant-models to ${{ inputs.version }}"
           branch: "auto-update-models-${{ inputs.version }}"
           delete-branch: true
@@ -506,11 +536,24 @@ jobs:
     # downgrade its models pin
     if: ${{ !contains(inputs.version, '.post') }}
     steps:
+      - name: Create client repository token
+        id: app_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.MUSIC_ASSISTANT_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.MUSIC_ASSISTANT_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: client
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+
       - name: Checkout client repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           repository: music-assistant/client
-          token: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
+          token: ${{ steps.app_token.outputs.token }}
           path: .
 
       - name: Update models version
@@ -527,7 +570,7 @@ jobs:
         id: create_pr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
+          token: ${{ steps.app_token.outputs.token }}
           commit-message: "⬆️ Update music-assistant-models to ${{ inputs.version }}"
           branch: "auto-update-models-${{ inputs.version }}"
           delete-branch: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,8 +46,8 @@ jobs:
           set -euo pipefail
 
           ACTOR=$(gh api user --jq '.login')
-          if [[ "$ACTOR" != "music-assistant-bot" ]]; then
-            echo "::error::PRIVILEGED_GITHUB_TOKEN authenticates as ${ACTOR}, expected music-assistant-bot."
+          if [[ "$ACTOR" != "music-assistant-machine" ]]; then
+            echo "::error::PRIVILEGED_GITHUB_TOKEN authenticates as ${ACTOR}, expected music-assistant-machine."
             exit 1
           fi
 
@@ -89,8 +89,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          git config user.name "music-assistant-bot"
-          git config user.email "music-assistant-bot@users.noreply.github.com"
+          git config user.name "music-assistant-machine"
+          git config user.email "music-assistant-machine@users.noreply.github.com"
 
           if git show-ref --verify --quiet "refs/tags/${VERSION}"; then
             echo "Reusing existing tag ${VERSION}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,9 +19,9 @@ jobs:
 
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Python
-        uses: actions/setup-python@v7.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.13"
       - name: Install dependencies
@@ -42,9 +42,9 @@ jobs:
 
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v7.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies


### PR DESCRIPTION
Automated release administration and downstream updates should use the `music-assistant-bot` GitHub App instead of a long-lived personal token.

- Mint short-lived, repository-scoped App tokens with only each job's required permissions
- Keep same-repository releases on the built-in GitHub Actions token
- Pin external GitHub Actions while retaining Dependabot updates

Requires the bot App on `models`, `server`, and `client` with the requested permissions.