### PR TITLE
Add setup_reason to the player state

### DIFF
--- a/music_assistant_models/player.py
+++ b/music_assistant_models/player.py
@@ -419,6 +419,9 @@ class Player(DataClassDictMixin):
 
     # needs_setup: if True, the player needs to be set up before it can be used
     needs_setup: bool = False
+    # setup_reason: short (translatable) slug describing why the player needs setup
+    # (e.g. "pairing_required", "password_required"); None when no setup is needed
+    setup_reason: str | None = None
 
     # sleep_timer_expires_at: unix (utc) timestamp at which the active sleep timer will
     # stop playback, or None if no sleep timer is currently set for this player


### PR DESCRIPTION
Companion to the server's player setup flows: a short translatable slug on the player state describing why a player needs setup (e.g. pairing or a password), so clients can show it on the "Setup required" indicator.

- New optional `setup_reason` field on the Player state (default `None`)