### PR TITLE
Fix automated client model updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -573,7 +573,10 @@ jobs:
             content = f.read()
 
           pattern = re.compile(r"music_assistant_models==[^\"']+")
-          content, count = pattern.subn(f"music_assistant_models=={VERSION}", content)
+          content, count = pattern.subn(
+            lambda _match: f"music_assistant_models=={VERSION}",
+            content,
+          )
 
           if count != 1:
             raise SystemExit(

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -566,7 +566,9 @@ jobs:
 
           # The client depends on the underscore-named package
           # (music_assistant_models), not the hyphenated PyPI project name.
-          with open("pyproject.toml", encoding="utf-8") as f:
+          # newline="" keeps existing line endings untouched so only the
+          # version substring changes.
+          with open("pyproject.toml", encoding="utf-8", newline="") as f:
             content = f.read()
 
           pattern = re.compile(r"music_assistant_models==[^\"']+")
@@ -577,7 +579,7 @@ jobs:
               f"Expected exactly one music_assistant_models pin in pyproject.toml, found {count}"
             )
 
-          with open("pyproject.toml", "w", encoding="utf-8") as f:
+          with open("pyproject.toml", "w", encoding="utf-8", newline="") as f:
             f.write(content)
 
       - name: Create Pull Request

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -555,14 +555,30 @@ jobs:
           path: .
 
       - name: Update models version
-        run: |
-          VERSION="${{ inputs.version }}"
+        shell: python
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |-
+          import os
+          import re
 
-          # Update pyproject.toml
-          sed -i.bak "s/music-assistant-models==.*/music-assistant-models==$VERSION\",/" pyproject.toml
+          VERSION = os.environ["VERSION"]
 
-          # Remove backup file
-          rm -f pyproject.toml.bak
+          # The client depends on the underscore-named package
+          # (music_assistant_models), not the hyphenated PyPI project name.
+          with open("pyproject.toml", encoding="utf-8") as f:
+            content = f.read()
+
+          pattern = re.compile(r"music_assistant_models==[^\"']+")
+          content, count = pattern.subn(f"music_assistant_models=={VERSION}", content)
+
+          if count != 1:
+            raise SystemExit(
+              f"Expected exactly one music_assistant_models pin in pyproject.toml, found {count}"
+            )
+
+          with open("pyproject.toml", "w", encoding="utf-8") as f:
+            f.write(content)
 
       - name: Create Pull Request
         id: create_pr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -517,6 +517,7 @@ jobs:
           commit-message: "⬆️ Update music-assistant-models to ${{ inputs.version }}"
           branch: "auto-update-models-${{ inputs.version }}"
           delete-branch: true
+          sign-commits: true
           title: "⬆️ Update music-assistant-models to ${{ inputs.version }}"
           base: ${{ steps.target.outputs.branch }}
           body: |
@@ -590,6 +591,7 @@ jobs:
           commit-message: "⬆️ Update music-assistant-models to ${{ inputs.version }}"
           branch: "auto-update-models-${{ inputs.version }}"
           delete-branch: true
+          sign-commits: true
           title: "⬆️ Update music-assistant-models to ${{ inputs.version }}"
           body: |
             Update music-assistant-models to version [${{ inputs.version }}](https://github.com/music-assistant/models/releases/tag/${{ inputs.version }})


### PR DESCRIPTION
Client model updates silently did nothing because the workflow searched for the wrong package spelling.

- Update the actual `music_assistant_models` pin and fail unless exactly one pin changes
- Preserve file formatting during replacement
- Sign downstream server and client commits as `musicassistant-bot[bot]`