### PR TITLE
Add URL config entry type and Player.has_setup_flow

### DIFF
--- a/music_assistant_models/config_entries.py
+++ b/music_assistant_models/config_entries.py
@@ -61,6 +61,7 @@ ConfigEntryTypeMap: dict[ConfigEntryType, type[ConfigValueType]] = {
     ConfigEntryType.ALERT: str,
     ConfigEntryType.ICON: str,
     ConfigEntryType.IMAGE: str,
+    ConfigEntryType.URL: str,
 }
 
 UI_ONLY = (
@@ -69,6 +70,7 @@ UI_ONLY = (
     ConfigEntryType.ACTION,
     ConfigEntryType.ALERT,
     ConfigEntryType.IMAGE,
+    ConfigEntryType.URL,
 )
 
 

--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -770,6 +770,9 @@ class ConfigEntryType(StrEnum):
     ICON = "icon"
     ALERT = "alert"
     IMAGE = "image"
+    # url: a clickable link; when returned from a config invoke_action response,
+    # the frontend opens the value (one-shot) instead of rendering a field
+    URL = "url"
     UNKNOWN = "unknown"
 
     @classmethod

--- a/music_assistant_models/player.py
+++ b/music_assistant_models/player.py
@@ -423,6 +423,11 @@ class Player(DataClassDictMixin):
     # (e.g. "pairing_required", "password_required"); None when no setup is needed
     setup_reason: str | None = None
 
+    # has_setup_flow: if True, this player (or a protocol child it wraps) offers an
+    # interactive setup flow that can also be re-run on demand (reconfigure/re-pair),
+    # regardless of whether setup is currently needed
+    has_setup_flow: bool = False
+
     # sleep_timer_expires_at: unix (utc) timestamp at which the active sleep timer will
     # stop playback, or None if no sleep timer is currently set for this player
     sleep_timer_expires_at: float | None = None

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -67,6 +67,32 @@ def test_image_entry_excluded_from_to_raw_values() -> None:
     assert raw["values"]["server_url"] == "abc"
 
 
+def test_url_entry_is_ui_only_and_not_required() -> None:
+    """A URL entry is one-shot presentational: maps to str, is UI-only and never required."""
+    assert ConfigEntryType("url") is ConfigEntryType.URL
+    assert ConfigEntryType.URL in UI_ONLY
+    assert ConfigEntryTypeMap[ConfigEntryType.URL] is str
+    entry = ConfigEntry(
+        key="connect_wizard_url",
+        type=ConfigEntryType.URL,
+        value="https://example.com/connect",
+        required=True,
+    )
+    assert entry.required is False
+
+
+def test_url_entry_excluded_from_to_raw_values() -> None:
+    """A UI-only URL entry is never persisted in Config.to_raw values."""
+    entries = [
+        ConfigEntry(key="wizard", type=ConfigEntryType.URL, value="https://example.com/x"),
+        ConfigEntry(key="server_url", type=ConfigEntryType.STRING),
+    ]
+    conf = ProviderConfig.parse(entries, _provider_raw(values={"server_url": "abc"}))
+    raw = conf.to_raw()
+    assert "wizard" not in raw["values"]
+    assert raw["values"]["server_url"] == "abc"
+
+
 def test_provider_setup_data_parses_roundtrips_and_drops_on_api() -> None:
     """ProviderConfig.setup_data is parsed, persisted via to_raw, but dropped from to_dict."""
     conf = ProviderConfig.parse([], _provider_raw(setup_data={"token": "enc:secret"}))


### PR DESCRIPTION
Two small additions for the setup-flows follow-up work:

- `ConfigEntryType.URL` — a clickable link entry. When one is returned in a `config/*/invoke_action` response, the frontend opens the URL (one-shot, anchor-click) instead of rendering a field. First consumer: the MCP server's Connect Wizard button, replacing the old `AUTH_SESSION` event side-channel (whose frontend listener was removed with the setup-flow dialog).
- `Player.has_setup_flow` — serialized flag telling the UI this player offers an interactive setup flow that can be re-run on demand, so players get a persistent "Reconfigure" entry point (e.g. to redo the optional Apple TV companion pairing after dismissing it).