### PR TITLE
Add per-provider search status reporting to SearchResults

### DIFF
--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -961,3 +961,21 @@ class ProviderStatus(StrEnum):
     INCOMPATIBLE = "incompatible"
     # error: setup failed for any other reason (see the provider's last_error)
     ERROR = "error"
+
+
+class ProviderSearchStatus(StrEnum):
+    """
+    Enum representing how a single provider contributed to a global search.
+
+    Reported per provider on SearchResults.provider_search_statuses so clients can
+    distinguish "this provider genuinely found nothing" from "this provider did not
+    answer in time / errored" instead of guessing from an empty result.
+    """
+
+    # complete: the provider answered, even if it returned no items
+    COMPLETE = "complete"
+    # timeout: the provider did not answer within the soft timeout; its search
+    # continues server-side and a retry can pick up the cached result
+    TIMEOUT = "timeout"
+    # failed: the provider search errored or exceeded the hard timeout
+    FAILED = "failed"

--- a/music_assistant_models/media_items/__init__.py
+++ b/music_assistant_models/media_items/__init__.py
@@ -8,7 +8,7 @@ from typing import Any, TypeGuard
 
 from mashumaro import DataClassDictMixin
 
-from music_assistant_models.enums import MediaType
+from music_assistant_models.enums import MediaType, ProviderSearchStatus
 from music_assistant_models.errors import InvalidDataError
 from music_assistant_models.unique_list import UniqueList
 
@@ -121,6 +121,9 @@ class SearchResults(DataClassDictMixin):
     audiobooks: Sequence[Audiobook | ItemMapping] = field(default_factory=list)
     podcasts: Sequence[Podcast | ItemMapping] = field(default_factory=list)
     sound_effects: Sequence[SoundEffect | ItemMapping] = field(default_factory=list)
+    # per-provider search status, keyed by provider instance_id (special key "library"
+    # for the library search); empty when the server does not report statuses
+    provider_search_statuses: dict[str, ProviderSearchStatus] = field(default_factory=dict)
 
 
 def media_from_dict(media_item: dict[str, Any]) -> MediaItemType | ItemMapping:


### PR DESCRIPTION
Adds ProviderSearchStatus enum to allow for less guess work in frontend search