### PR TITLE
Add provider capability flag for re-runnable setup flows

### DIFF
--- a/music_assistant_models/provider.py
+++ b/music_assistant_models/provider.py
@@ -48,6 +48,9 @@ class ProviderManifest(DataClassORJSONMixin):
     mdns_discovery: list[str] | None = None
     # upnp_discovery: list of SSDP search targets to discover
     upnp_discovery: list[str] | None = None
+    # has_setup_flow: if True, this provider offers an interactive setup flow
+    # that can also be re-run on demand (reconfigure), regardless of auth state
+    has_setup_flow: bool = False
 
     # credits: list of credits/attributions
     # e.g. for libraries used, icons, etc.

--- a/tests/test_provider_manifest.py
+++ b/tests/test_provider_manifest.py
@@ -46,3 +46,23 @@ def test_legacy_icon_svg_key_ignored() -> None:
     )
     assert restored.icon_images == []
     assert not hasattr(restored, "icon_svg")
+
+
+def test_has_setup_flow_defaults_false() -> None:
+    """Test that has_setup_flow defaults to False."""
+    assert _manifest().has_setup_flow is False
+
+
+def test_has_setup_flow_roundtrip() -> None:
+    """Test has_setup_flow survives JSON roundtrip."""
+    manifest = _manifest(has_setup_flow=True)
+    restored = ProviderManifest.from_json(manifest.to_json())
+    assert restored.has_setup_flow is True
+
+
+def test_has_setup_flow_missing_key_backward_compatible() -> None:
+    """Test that JSON without has_setup_flow (old server payload) defaults to False."""
+    restored = ProviderManifest.from_json(
+        '{"type":"music","domain":"d","name":"N","description":"x","codeowners":[]}'
+    )
+    assert restored.has_setup_flow is False


### PR DESCRIPTION
Frontend needs a way to know whether a provider's interactive setup flow can be re-run on demand (reconfigure), separate from whether it currently needs auth.

- Add `has_setup_flow: bool = False` to `ProviderManifest`
- Defaults to `False` for backward compatibility with older server payloads
- Add tests covering the default, roundtrip, and missing-key cases