### PR TITLE
Let a config option name the slug used for its translations

### DIFF
--- a/music_assistant_models/config_entries.py
+++ b/music_assistant_models/config_entries.py
@@ -96,6 +96,12 @@ class ConfigValueOption(DataClassDictMixin):
     # (keyed by the owning entry: option_descriptions.<value>). Lets a single option explain itself
     # instead of cramming the explanation into the option title or the shared entry description.
     description: str | None = None
+    # translation_key: bare slug that replaces this option's value in all of its translation keys.
+    # For options whose value is data-driven - a player or device id - so their texts can still be
+    # localized: the slug names what the option means (e.g. "needs_setup"). Not serialized.
+    translation_key: str | None = field(
+        default=None, metadata=field_options(serialize="omit"), repr=False
+    )
 
 
 MULTI_VALUE_SPLITTER: Final[str] = "||"
@@ -211,8 +217,9 @@ class ConfigEntry(DataClassDictMixin):
         Resolves label/description/option titles and the category name under this entry's owner
         namespace (keyed by config_entries.<key> / config_categories.<category>). A server-set
         translation_key/category_translation_key override is the bare slug under that same group,
-        unless it is fully qualified. No-op when nothing matches, so the in-code values are kept.
-        The translation machinery fields are not serialized.
+        unless it is fully qualified. An option's own translation_key does the same for the option's
+        texts, which are otherwise keyed by its value. No-op when nothing matches, so the in-code
+        values are kept. The translation machinery fields are not serialized.
         """
         owner = self.translation_owner
         base = _localized_base(self.translation_key, self.key, "config_entries")
@@ -229,16 +236,17 @@ class ConfigEntry(DataClassDictMixin):
             if action_label is not None:
                 d["action_label"] = action_label
         for option_dict, option in zip(d.get("options", []), self.options, strict=False):
-            title = resolve_translation(f"{base}.options.{option.value}", owner=owner)
+            slug = option.value if option.translation_key is None else option.translation_key
+            title = resolve_translation(f"{base}.options.{slug}", owner=owner)
             if title is not None:
                 option_dict["title"] = title
             option_description = resolve_translation(
-                f"{base}.option_descriptions.{option.value}", owner=owner
+                f"{base}.option_descriptions.{slug}", owner=owner
             )
             if option_description is not None:
                 option_dict["description"] = option_description
             if option.disabled:
-                reason = resolve_translation(f"{base}.disabled_reasons.{option.value}", owner=owner)
+                reason = resolve_translation(f"{base}.disabled_reasons.{slug}", owner=owner)
                 if reason is not None:
                     option_dict["disabled_reason"] = reason
         category_key = _localized_base(

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -35,6 +35,7 @@ _CATALOG = {
     "config_entries.crossfade_mode.options.global": "Globaal",
     "config_entries.crossfade_mode.option_descriptions.global": "Volg de standaardinstelling.",
     "config_entries.crossfade_mode.disabled_reasons.smart_crossfade": "Niet beschikbaar.",
+    "config_entries.preferred_output.disabled_reasons.needs_setup": "Moet nog ingesteld worden.",
     "config_categories.generic": "Algemeen",
     "media.recommendations.recently_played.name": "Onlangs afgespeeld",
     "media.recommendations.recently_played.subtitle": "Ga verder waar je gebleven was",
@@ -125,6 +126,30 @@ def test_config_entry_resolves_option_title_description_and_disabled_reason() ->
     assert options[1]["description"] is None
     # disabled_reason still resolves for the disabled option
     assert options[1]["disabled_reason"] == "Niet beschikbaar."
+
+
+def test_config_value_option_translation_key_is_a_bare_slug() -> None:
+    """An option's translation_key replaces its value when its strings are resolved."""
+    # e.g. a data-driven value (a player id) that still needs a localized disabled_reason
+    entry = ConfigEntry(
+        key="preferred_output",
+        type=ConfigEntryType.STRING,
+        options=[
+            ConfigValueOption(
+                value="airplay_aabbccddeeff",
+                title="AirPlay",
+                disabled=True,
+                translation_key="needs_setup",
+            )
+        ],
+    )
+    plain = entry.to_dict()["options"][0]
+    assert "translation_key" not in plain
+    with _resolver_active():
+        option = entry.to_dict()["options"][0]
+    assert option["disabled_reason"] == "Moet nog ingesteld worden."
+    # the data-driven title is kept: the slug only names why the option is disabled
+    assert option["title"] == "AirPlay"
 
 
 def test_media_item_resolves_name_subtitle_and_strips_machinery() -> None:


### PR DESCRIPTION
A `ConfigValueOption`'s texts are keyed by its value: `options.<value>`, `option_descriptions.<value>` and `disabled_reasons.<value>`. That works for a bounded set of values, but not for a select whose values are data-driven - a player or device id - so those options can never carry a localized description or disabled reason. The server needs one to explain why an output protocol that still needs pairing is shown greyed out.

- Add `ConfigValueOption.translation_key`: a bare slug that replaces the option's value in all three lookups (e.g. `needs_setup`)
- Falls back to the value, so every existing option resolves exactly as before
- Not serialized, like the other translation machinery
- Add a test covering the slug override and the data-driven title it leaves alone