### PR TITLE
Add DSP_IRS_UPDATED enum for DSP updates

### DIFF
--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -589,6 +589,7 @@ class EventType(StrEnum):
     PLAYER_OPTIONS_UPDATED = "player_options_updated"
     PLAYER_SLEEP_TIMER_UPDATED = "player_sleep_timer_updated"
     DSP_PRESETS_UPDATED = "dsp_presets_updated"
+    DSP_IRS_UPDATED = "dsp_irs_updated"
     QUEUE_ADDED = "queue_added"
     QUEUE_UPDATED = "queue_updated"
     QUEUE_ITEMS_UPDATED = "queue_items_updated"


### PR DESCRIPTION
Steven highlighted that we need an event so all clients known when an Impule Response file (for the convolution DSP filter) is added or removed.