### PR TITLE
Fix: add MediaType.SOUND_EFFECT to allowed playlist supported_mediatypes

### DIFF
--- a/music_assistant_models/media_items/media_item.py
+++ b/music_assistant_models/media_items/media_item.py
@@ -395,6 +395,7 @@ class Playlist(_LocalizableTitle, MediaItem):
             MediaType.AUDIOBOOK,
             MediaType.PODCAST_EPISODE,
             MediaType.RADIO,
+            MediaType.SOUND_EFFECT,
             MediaType.TRACK,
         }
         if len(self.supported_mediatypes.difference(_supported)) > 0:


### PR DESCRIPTION
Since c0a6f7228 / PR #3407 the server includes MediaType.SOUND_EFFECT in playlist supported_mediatypes, but the model's __post_init__ validator (models PR #169) doesn't allow it, causing TypeError on every playlist operation.
