### PR TITLE
Add external ID lookup provider features

### DIFF
--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -686,6 +686,11 @@ class ProviderFeature(StrEnum):
     # can show in the UI.
     SIMILAR_ARTISTS = "similar_artists"
 
+    # lookup by external ID (ISRC, MusicBrainz, etc.) per mediatype
+    TRACK_BY_EXTERNAL_ID = "track_by_external_id"
+    ALBUM_BY_EXTERNAL_ID = "album_by_external_id"
+    ARTIST_BY_EXTERNAL_ID = "artist_by_external_id"
+
     # playlist-specific features
     PLAYLIST_TRACKS_EDIT = "playlist_tracks_edit"
     # PLAYLIST_CREATE is deprecated: replaced by PLAYLIST_CREATE_TRACKS (and others)


### PR DESCRIPTION
## Summary

Adds three new `ProviderFeature` enum values to enable looking up media items by external identifiers (ISRC, MusicBrainz IDs, Discogs, etc.):

- `TRACK_BY_EXTERNAL_ID` 
- `ALBUM_BY_EXTERNAL_ID`
- `ARTIST_BY_EXTERNAL_ID`

## Motivation

This is the foundation for the **SharedLink** feature discussed in https://github.com/orgs/music-assistant/discussions/5869.

SharedLinks will allow users to share MA items with others who may have different music providers. When the recipient opens a SharedLink, MA will:
1. Extract external IDs (ISRC, MusicBrainz, etc.) from the original item
2. Use these new provider features to look up the same track/album/artist on the recipient's available providers
3. Add the matched item to the recipient's library or queue

## Changes

```python
# music_assistant_models/enums.py
class ProviderFeature(StrEnum):
    # ...existing features...
    TRACK_BY_EXTERNAL_ID = "track_by_external_id"
    ALBUM_BY_EXTERNAL_ID = "album_by_external_id"  
    ARTIST_BY_EXTERNAL_ID = "artist_by_external_id"
```

## Implementation notes

- Separate features per media type allows providers to implement only what they support
- Spotify supports ISRC lookup for tracks
- Apple Music supports ISRC (tracks) + MusicBrainz IDs (albums/artists)
- Library DB already stores external IDs, so lookup works immediately

## Related

- Server PR (depends on this): https://github.com/music-assistant/server/pull/5110