### PR TITLE
Add a flag for a queue that finished playing

### DIFF
--- a/music_assistant_models/player_queue.py
+++ b/music_assistant_models/player_queue.py
@@ -56,6 +56,11 @@ class PlayerQueue(DataClassDictMixin):
     current_index: int | None = None
     # index_in_buffer: index that has been preloaded/buffered by the player
     index_in_buffer: int | None = None
+    # ended: True when the queue played all the way to its end and is waiting to be restarted.
+    # Set by the server and cleared as soon as playback starts or the items change. The playback
+    # position is deliberately left on the last item, so this flag is what tells a finished queue
+    # apart from one that is merely stopped on that item.
+    ended: bool = False
 
     elapsed_time: float = 0
     elapsed_time_last_updated: float = field(default_factory=time.time)

--- a/tests/test_player_queue.py
+++ b/tests/test_player_queue.py
@@ -66,3 +66,26 @@ def test_payload_without_overlay_keys_deserializes() -> None:
     assert restored.overlay_enabled is False
     assert restored.overlay_source is None
     assert restored.overlay_volume == 100
+
+
+def test_ended_defaults_to_false() -> None:
+    """A fresh queue has not ended."""
+    assert _queue().ended is False
+
+
+def test_ended_serialize_roundtrip() -> None:
+    """A queue that reached its end survives a to_dict -> from_dict round-trip."""
+    queue = _queue()
+    queue.ended = True
+    queue.current_index = 4
+    restored = PlayerQueue.from_dict(queue.to_dict())
+    assert restored.ended is True
+    # the position stays on the item that finished; `ended` is what makes it legible
+    assert restored.current_index == 4
+
+
+def test_payload_without_ended_key_deserializes() -> None:
+    """Payloads from older servers without the ended key still deserialize."""
+    legacy = _queue().to_dict()
+    legacy.pop("ended", None)
+    assert PlayerQueue.from_dict(legacy).ended is False


### PR DESCRIPTION
When a queue plays all the way to its end, it keeps its items and leaves its position on the last track — which looks exactly like a queue that is paused on that track. Clients had no way to tell the two apart, so a finished queue could not say it finished, or offer to start over.

- Add `ended` to `PlayerQueue`, set by the server when a queue plays through and cleared again as soon as playback starts or the items change