### PR TITLE
Add a separate stream duration to PlayerMedia

### DIFF
--- a/music_assistant_models/player.py
+++ b/music_assistant_models/player.py
@@ -115,6 +115,10 @@ class PlayerMedia(DataClassDictMixin):
     image_url: str | None = None  # optional
     palette: MediaItemPalette | None = None  # optional
     duration: int | None = None  # optional
+    # optional - length of the audio stream as delivered to the player
+    # (differs from duration after a seek on transports whose stream restarts
+    # at position zero); None when identical to duration
+    stream_duration: int | None = None
     source_id: str | None = None  # optional (ID of the source, may be a queue id)
     queue_item_id: str | None = None  # only present for requests from queue controller
     custom_data: dict[str, Any] | None = None  # optional - must be serializable

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -1,0 +1,29 @@
+"""Tests for the PlayerMedia model (stream_duration serialization/back-compat)."""
+
+from music_assistant_models.enums import MediaType
+from music_assistant_models.player import PlayerMedia
+
+
+def _media() -> PlayerMedia:
+    return PlayerMedia(uri="library://track/1", media_type=MediaType.TRACK, duration=300)
+
+
+def test_stream_duration_defaults_to_none() -> None:
+    """Media that plays from the start has no separate stream length."""
+    assert _media().stream_duration is None
+
+
+def test_stream_duration_serialize_roundtrip() -> None:
+    """A seeked item keeps the full duration and the shorter stream length apart."""
+    media = _media()
+    media.stream_duration = 120
+    restored = PlayerMedia.from_dict(media.to_dict())
+    assert restored.duration == 300
+    assert restored.stream_duration == 120
+
+
+def test_payload_without_stream_duration_key_deserializes() -> None:
+    """Payloads from older servers without the stream_duration key still deserialize."""
+    legacy = _media().to_dict()
+    legacy.pop("stream_duration", None)
+    assert PlayerMedia.from_dict(legacy).stream_duration is None


### PR DESCRIPTION
`PlayerMedia.duration` is meant to be the true full length of the media item. For players whose audio stream restarts at zero after a seek, the server currently has to overwrite it with the remaining time instead, so the reported track length changes on every seek. That is wrong for players that report an absolute position, and devices that re-render their now-playing screen when the track length changes (an Apple TV, for example) visibly flicker on each seek.

This adds a second, optional field so both meanings can be expressed at once. No behaviour changes here — the server change that starts filling it follows separately.

- Added `PlayerMedia.stream_duration`: the length of the audio stream as delivered to the player, `None` when it is identical to `duration`
- `duration` keeps its meaning as the full media length

Companion server PR to follow.