### PR TITLE
Move create_safe_string helper to models add search_string to MediaItemCollection

### DIFF
--- a/music_assistant_models/helpers.py
+++ b/music_assistant_models/helpers.py
@@ -12,6 +12,8 @@ from typing import Any
 from unicodedata import combining, normalize
 from uuid import UUID
 
+import unidecode
+
 from music_assistant_models.enums import MediaType
 
 DO_NOT_SERIALIZE_TYPES = (MethodType, Task)
@@ -84,6 +86,23 @@ def create_sort_name(input_str: str) -> str:
             input_str = input_str.replace(item, "", 1) + f", {item}"
             break
     return input_str.strip()
+
+
+def create_safe_string(input_str: str, lowercase: bool = True, replace_space: bool = False) -> str:
+    """Return clean lowered string for compare actions."""
+    # handle some special cases
+    if input_str in ("P!nk", "p!nk"):
+        input_str = input_str.replace("!", "i")
+    if input_str in ("Wh♂", "wh♂"):
+        input_str = input_str.replace("♂", "o")
+    if input_str in ("KoЯn", "koЯn"):
+        input_str = input_str.replace("Я", "r")
+    if input_str == "$hort":
+        input_str = input_str.replace("$hort", "short")
+    input_str = input_str.lower().strip() if lowercase else input_str.strip()
+    unaccented_string = unidecode.unidecode(input_str)
+    regex = r"[^a-zA-Z0-9]" if replace_space else r"[^a-zA-Z0-9 ]"
+    return re.sub(regex, "", unaccented_string)
 
 
 def is_valid_uuid(uuid_to_test: str) -> bool:

--- a/music_assistant_models/media_items/metadata.py
+++ b/music_assistant_models/media_items/metadata.py
@@ -11,7 +11,7 @@ from typing import Any
 from mashumaro import DataClassDictMixin
 
 from music_assistant_models.enums import ArtistEntityType, ImageType, LinkType
-from music_assistant_models.helpers import merge_lists
+from music_assistant_models.helpers import create_safe_string, create_sort_name, merge_lists
 from music_assistant_models.unique_list import UniqueList
 
 # ContextVar set by the Music Assistant server during outbound API serialization.
@@ -135,6 +135,14 @@ class MediaItemCollection(DataClassDictMixin):
     def __hash__(self) -> int:
         """Return custom hash."""
         return hash(self.title)
+
+    def __post_serialize__(self, d: dict[str, Any]) -> dict[str, Any]:
+        """Add search strings."""
+        d["search_title"] = create_safe_string(self.title, lowercase=True, replace_space=True)
+        d["search_sort_title"] = create_safe_string(
+            create_sort_name(self.title), lowercase=True, replace_space=True
+        )
+        return d
 
 
 @dataclass(kw_only=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
 ]
-dependencies = ["orjson>=3.9", "mashumaro>=3.14"]
+dependencies = ["orjson>=3.9", "mashumaro>=3.14", "unidecode==1.4.0"]
 description = "Music Assistant Base Models"
 license = {text = "Apache-2.0"}
 readme = "README.md"


### PR DESCRIPTION
- Move the create_safe_string helper to models and adapt requirements
- Add search strings to MediaItemCollection, so they can be used in the backend