### PR TITLE
Remove a note about a class that no longer exists

### DIFF
--- a/music_assistant_models/config_entries.py
+++ b/music_assistant_models/config_entries.py
@@ -130,8 +130,7 @@ class ConfigEntry(DataClassDictMixin):
     # help_link [optional]: link to help article.
     help_link: str | None = None
     # multi_value [optional]: allow multiple values from the list
-    # NOTE: for using multi_value, it is required to use the MultiValueConfigEntry
-    # class instead of ConfigEntry to prevent (de)serialization issues
+    # NOTE: the value is stored as a list, so default_value must be a list (or None)
     multi_value: bool = False
     # depends_on [optional]: needs to be set before this setting is visible in the frontend
     depends_on: str | None = None

--- a/music_assistant_models/config_entries.py
+++ b/music_assistant_models/config_entries.py
@@ -130,7 +130,7 @@ class ConfigEntry(DataClassDictMixin):
     # help_link [optional]: link to help article.
     help_link: str | None = None
     # multi_value [optional]: allow multiple values from the list
-    # NOTE: the value is stored as a list, so default_value must be a list (or None)
+    # NOTE: when set, the value is stored as a list, so default_value must be a list (or None)
     multi_value: bool = False
     # depends_on [optional]: needs to be set before this setting is visible in the frontend
     depends_on: str | None = None


### PR DESCRIPTION
# What does this implement/fix?

The `multi_value` field on `ConfigEntry` carries a note telling authors to use a `MultiValueConfigEntry` class instead. That class was removed in dcab630 ("Final round of fixes for multi value serializing mess"), which replaced the `isinstance(self, MultiValueConfigEntry)` check with a plain list check on `ConfigEntry` itself. The note has pointed at a non-existent class ever since, and it steers provider authors away from a field that works fine.

## Changes

- Replace the stale note with the constraint that actually applies: the value is stored as a list, so `default_value` must be a list (or None)