### PR TITLE
Document how depends_on actually renders

### DIFF
--- a/music_assistant_models/config_entries.py
+++ b/music_assistant_models/config_entries.py
@@ -137,7 +137,7 @@ class ConfigEntry(DataClassDictMixin):
     # have nothing to disable, so the frontend hides them instead.
     depends_on: str | None = None
     # depends_on_value [optional]: complementary to depends_on, the dependency is only met when
-    # the other entry holds this exact value (without it, any truthy value will do)
+    # the other entry holds this exact value (without it, any value the frontend reads as truthy)
     depends_on_value: ConfigValueType | None = None
     # depends_on_value_not [optional]: same as depends_on_value but inverted
     depends_on_value_not: ConfigValueType | None = None

--- a/music_assistant_models/config_entries.py
+++ b/music_assistant_models/config_entries.py
@@ -132,9 +132,9 @@ class ConfigEntry(DataClassDictMixin):
     # multi_value [optional]: allow multiple values from the list
     # NOTE: when set, the value is stored as a list, so default_value must be a list (or None)
     multi_value: bool = False
-    # depends_on [optional]: key of another entry that gates this one. While the dependency is
-    # unmet, input types and ACTION stay visible but render disabled; DIVIDER/LABEL/ALERT/IMAGE
-    # have nothing to disable, so the frontend hides them instead.
+    # depends_on [optional]: key of another entry that gates this one; an unresolved key counts
+    # as unmet. While unmet, input types and ACTION stay visible but render disabled;
+    # DIVIDER/LABEL/ALERT/IMAGE have nothing to disable, so the frontend hides them instead.
     depends_on: str | None = None
     # depends_on_value [optional]: complementary to depends_on, the dependency is only met when
     # the other entry holds this exact value (without it, any value the frontend reads as truthy)

--- a/music_assistant_models/config_entries.py
+++ b/music_assistant_models/config_entries.py
@@ -132,9 +132,12 @@ class ConfigEntry(DataClassDictMixin):
     # multi_value [optional]: allow multiple values from the list
     # NOTE: when set, the value is stored as a list, so default_value must be a list (or None)
     multi_value: bool = False
-    # depends_on [optional]: needs to be set before this setting is visible in the frontend
+    # depends_on [optional]: key of another entry that gates this one. While the dependency is
+    # unmet, input types and ACTION stay visible but render disabled; DIVIDER/LABEL/ALERT/IMAGE
+    # have nothing to disable, so the frontend hides them instead.
     depends_on: str | None = None
-    # depends_on_value [optional]: complementary to depends_on, only show if this value is set
+    # depends_on_value [optional]: complementary to depends_on, the dependency is only met when
+    # the other entry holds this exact value (without it, any truthy value will do)
     depends_on_value: ConfigValueType | None = None
     # depends_on_value_not [optional]: same as depends_on_value but inverted
     depends_on_value_not: ConfigValueType | None = None


### PR DESCRIPTION
The comment on `depends_on` said a setting is not visible until its dependency is set. That was never what the frontend did, and it led providers to gate status labels and alerts on `depends_on` alone expecting them to stay hidden — they rendered unconditionally instead.

music-assistant/frontend#2270 settled the real behaviour, which has two modes, so the comment now describes both.

- `depends_on`: while the dependency is unmet, inputs and action buttons stay visible but greyed out; dividers, labels, alerts and images are hidden instead, since there is nothing to grey out
- `depends_on_value`: reworded to say when the dependency counts as met, rather than "only show if"

Comments only, no behaviour change.