### PR TITLE
Don't demand a setting the user cannot fill in

### DIFF
--- a/music_assistant_models/config_entries.py
+++ b/music_assistant_models/config_entries.py
@@ -261,6 +261,26 @@ class ConfigEntry(DataClassDictMixin):
             d["category_label"] = category_label
         return d
 
+    def dependency_met(self, entries: Iterable[ConfigEntry]) -> bool:
+        """
+        Return whether this entry's `depends_on` dependency is satisfied within `entries`.
+
+        An entry without a dependency is always satisfied, while one naming a key that is
+        not among `entries` never is. `depends_on_value` requires the dependency to hold
+        that exact value and `depends_on_value_not` requires it not to; with neither, any
+        truthy value satisfies it.
+        """
+        if self.depends_on is None:
+            return True
+        dependency = next((e for e in entries if e.key == self.depends_on), None)
+        if dependency is None:
+            return False
+        if self.depends_on_value is not None:
+            return dependency.value == self.depends_on_value
+        if self.depends_on_value_not is not None:
+            return dependency.value != self.depends_on_value_not
+        return bool(dependency.value)
+
     def parse_value(
         self,
         value: ConfigValueType,
@@ -439,8 +459,11 @@ class Config(DataClassDictMixin):
         """Validate if configuration is valid."""
         # For now we just use the parse method to check for not allowed None values
         # this can be extended later
-        for value in self.values.values():
-            value.parse_value(value.value, allow_none=False)
+        entries = list(self.values.values())
+        for entry in entries:
+            # an entry whose dependency is unmet renders disabled, so there is no way to
+            # give it a value - demanding one would make the config permanently unsavable
+            entry.parse_value(entry.value, allow_none=not entry.dependency_met(entries))
 
 
 @dataclass

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -1,6 +1,8 @@
-"""Tests for the IMAGE config entry type and the storage-only setup_data field."""
+"""Tests for config entry types, the storage-only setup_data field and dependency gating."""
 
 from typing import Any
+
+import pytest
 
 from music_assistant_models.config_entries import (
     UI_ONLY,
@@ -125,3 +127,84 @@ def test_player_legacy_raw_without_setup_data_parses() -> None:
     assert conf.setup_data == {}
     assert conf.to_raw()["setup_data"] == {}
     assert "setup_data" not in conf.to_dict()
+
+
+def _gated(**overrides: Any) -> ConfigEntry:
+    """Build a required STRING entry with no default, gated on the `use_proxy` entry."""
+    return ConfigEntry(
+        key="proxy_url",
+        type=ConfigEntryType.STRING,
+        required=True,
+        depends_on="use_proxy",
+        **overrides,
+    )
+
+
+def _switch(*, on: bool) -> ConfigEntry:
+    """Build the BOOLEAN entry the gated entry depends on, as it looks once parsed."""
+    return ConfigEntry(
+        key="use_proxy",
+        type=ConfigEntryType.BOOLEAN,
+        required=False,
+        default_value=on,
+        value=on,
+    )
+
+
+def _dependency(value: Any) -> ConfigEntry:
+    """Build the dependency as a STRING entry already holding `value`."""
+    return ConfigEntry(key="use_proxy", type=ConfigEntryType.STRING, value=value)
+
+
+def test_dependency_met_without_depends_on() -> None:
+    """Report an entry that names no dependency as satisfied."""
+    entry = ConfigEntry(key="token", type=ConfigEntryType.STRING)
+    assert entry.dependency_met([entry]) is True
+
+
+def test_dependency_met_follows_the_dependency_value() -> None:
+    """Treat any truthy value on the dependency as satisfying it when no bound is given."""
+    assert _gated().dependency_met([_switch(on=True), _gated()]) is True
+    assert _gated().dependency_met([_switch(on=False), _gated()]) is False
+
+
+def test_dependency_met_honours_the_value_bounds() -> None:
+    """Demand the exact depends_on_value, and forbid the depends_on_value_not."""
+    exact = _gated(depends_on_value="ha")
+    assert exact.dependency_met([_dependency("ha")]) is True
+    assert exact.dependency_met([_dependency("other")]) is False
+
+    inverted = _gated(depends_on_value_not="off")
+    assert inverted.dependency_met([_dependency("off")]) is False
+    assert inverted.dependency_met([_dependency("ha")]) is True
+
+
+def test_dependency_met_is_false_for_an_unresolved_key() -> None:
+    """Count a dependency key that is not among the entries as unmet."""
+    assert _gated().dependency_met([]) is False
+
+
+def test_validate_skips_a_required_entry_behind_an_unmet_dependency() -> None:
+    """Accept a config whose required entry the user has no way to fill in."""
+    conf = ProviderConfig.parse([_switch(on=False), _gated()], _provider_raw())
+
+    conf.validate()
+
+
+def test_validate_enforces_a_required_entry_once_its_dependency_is_met() -> None:
+    """Demand the same entry again as soon as its dependency is satisfied."""
+    conf = ProviderConfig.parse([_switch(on=True), _gated()], _provider_raw())
+
+    with pytest.raises(ValueError, match="proxy_url is required"):
+        conf.validate()
+
+
+def test_validate_still_enforces_a_required_entry_without_a_dependency() -> None:
+    """Reject an ordinary required entry that holds no value."""
+    conf = ProviderConfig.parse(
+        [ConfigEntry(key="token", type=ConfigEntryType.STRING, required=True)],
+        _provider_raw(),
+    )
+
+    with pytest.raises(ValueError, match="token is required"):
+        conf.validate()


### PR DESCRIPTION
A setting marked required can be gated behind another setting via `depends_on`. While that dependency is unmet the field renders disabled, so there is no way to give it a value — but config validation still demanded one, which made the whole config permanently unsavable.

Not reachable with the settings any provider ships today, so this is a latent fix rather than a reported bug. Companion to music-assistant/frontend#2284, which fixes the same blind spot in the Save button.

- `validate()` no longer demands a value for an entry whose dependency is unmet
- New `ConfigEntry.dependency_met()` evaluates `depends_on` / `depends_on_value` / `depends_on_value_not`, matching what the frontend already does (an unresolved key counts as unmet)
