### PR TITLE
Add a users.read scope

### DIFF
--- a/music_assistant_models/auth.py
+++ b/music_assistant_models/auth.py
@@ -55,6 +55,7 @@ class Scope(StrEnum):
     CONFIG_PROVIDERS_WRITE = "config.providers.write"
     CONFIG_CORE_READ = "config.core.read"
     CONFIG_CORE_WRITE = "config.core.write"
+    USERS_READ = "users.read"
     USERS_MANAGE = "users.manage"
     USERS_IMPERSONATE = "users.impersonate"
     USERS_INVITE = "users.invite"


### PR DESCRIPTION
Adds a `users.read` scope so read-only access to user accounts can be granted without handing out `users.manage` or `users.impersonate`.

Needed by music-assistant/server#5410: the Home Assistant integration has to list users to resolve the calling user, but it should not gain user management rights to do so.

- Add `Scope.USERS_READ` (`users.read`)