### PR TITLE
Skip a config entry's own checks while it has no value

### DIFF
--- a/music_assistant_models/config_entries.py
+++ b/music_assistant_models/config_entries.py
@@ -287,7 +287,16 @@ class ConfigEntry(DataClassDictMixin):
         allow_none: bool = True,
         raise_on_error: bool = True,
     ) -> ConfigValueType:
-        """Parse value from the config entry details and plain value."""
+        """
+        Coerce a plain value into this entry's value and store it, falling back to the default.
+
+        :param value: The plain value to parse, as submitted or as read from storage.
+        :param allow_none: Whether an entry that ends up without any value is acceptable, used
+            for a required entry the user has no way to fill in (e.g. one rendered disabled
+            behind an unmet `depends_on`).
+        :param raise_on_error: Whether to reject an unusable value instead of silently falling
+            back to the default.
+        """
         if self.type == ConfigEntryType.LABEL:
             value = self.label
         elif self.type in UI_ONLY:
@@ -295,6 +304,14 @@ class ConfigEntry(DataClassDictMixin):
 
         if value is None:
             value = self.default_value
+
+        if value is None:
+            # nothing to work with: the shape checks and the validate callback below all
+            # describe a value the user supplied, so only the required check applies here
+            if self.required and not allow_none and raise_on_error:
+                raise ValueError(f"{self.key} is required")
+            self.value = None
+            return self.value
 
         if isinstance(value, list) and not self.multi_value:
             if raise_on_error:
@@ -315,13 +332,9 @@ class ConfigEntry(DataClassDictMixin):
                 return bool(_value)
             return _value
 
-        if value is None and self.required and not allow_none:
-            if raise_on_error:
-                raise ValueError(f"{self.key} is required")
-            value = self.default_value
-
         # handle optional validation callback
-        if self.validate is not None and not (self.validate(value)):
+        # (value can be None again here when a shape check fell back to an empty default)
+        if value is not None and self.validate is not None and not (self.validate(value)):
             if raise_on_error:
                 raise ValueError(f"{value} is not a valid value for {self.key}")
             value = self.default_value

--- a/music_assistant_models/config_entries.py
+++ b/music_assistant_models/config_entries.py
@@ -168,7 +168,8 @@ class ConfigEntry(DataClassDictMixin):
         default=None, metadata=field_options(serialize="omit"), repr=False
     )
 
-    # validate: an optional custom validation callback (author-provided)
+    # validate: an optional custom validation callback (author-provided), only ever called
+    # with a value the entry actually holds - never to check whether it holds one at all
     validate: Callable[[ConfigValueType], bool] | None = field(
         default=None,
         compare=False,
@@ -307,7 +308,7 @@ class ConfigEntry(DataClassDictMixin):
 
         if value is None:
             # nothing to work with: the shape checks and the validate callback below all
-            # describe a value the user supplied, so only the required check applies here
+            # describe a value that was actually given, so only the required check applies
             if self.required and not allow_none and raise_on_error:
                 raise ValueError(f"{self.key} is required")
             self.value = None

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -1,5 +1,6 @@
 """Tests for config entry types, the storage-only setup_data field and dependency gating."""
 
+from collections.abc import Callable
 from typing import Any, cast
 
 import pytest
@@ -157,6 +158,16 @@ def _dependency(value: Any) -> ConfigEntry:
     return ConfigEntry(key="use_proxy", type=ConfigEntryType.STRING, value=value)
 
 
+def _recording(seen: list[ConfigValueType]) -> Callable[[ConfigValueType], bool]:
+    """Build a validation callback that accepts anything and records what it was handed."""
+
+    def _validate(value: ConfigValueType) -> bool:
+        seen.append(value)
+        return True
+
+    return _validate
+
+
 def test_dependency_met_without_depends_on() -> None:
     """Report an entry that names no dependency as satisfied."""
     entry = ConfigEntry(key="token", type=ConfigEntryType.STRING)
@@ -217,13 +228,13 @@ def test_an_entry_without_a_value_never_reaches_its_own_callback() -> None:
     entries = [
         _switch(on=False),
         # gated and disabled, so the user cannot fill it in
-        _gated(validate=lambda value: seen.append(value) is None),
+        _gated(validate=_recording(seen)),
         # not gated, but optional and left empty
         ConfigEntry(
             key="chime_url",
             type=ConfigEntryType.STRING,
             required=False,
-            validate=lambda value: seen.append(value) is None,
+            validate=_recording(seen),
         ),
     ]
 
@@ -278,3 +289,27 @@ def test_a_supplied_value_still_has_to_match_the_entry_shape() -> None:
 
     with pytest.raises(ValueError, match="proxy_url must be a single value"):
         _gated().parse_value(["http://proxy", "http://elsewhere"])
+
+
+def test_a_value_of_the_wrong_shape_does_not_reach_the_callback() -> None:
+    """Keep the callback out of the way when a value of the wrong shape is dropped."""
+    seen: list[ConfigValueType] = []
+    entry = ConfigEntry(
+        key="proxy_url", type=ConfigEntryType.STRING, required=False, validate=_recording(seen)
+    )
+
+    assert entry.parse_value(["http://proxy"], raise_on_error=False) is None
+    assert seen == []
+
+
+def test_a_falsy_value_still_counts_as_a_value() -> None:
+    """Treat False and an empty string as values the user gave, not as an empty entry."""
+    seen: list[ConfigValueType] = []
+    switch = ConfigEntry(
+        key="use_proxy", type=ConfigEntryType.BOOLEAN, required=True, validate=_recording(seen)
+    )
+
+    assert switch.parse_value(value=False, allow_none=False) is False
+    assert seen == [False]
+
+    assert _gated().parse_value("", allow_none=False) == ""

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -1,6 +1,6 @@
 """Tests for config entry types, the storage-only setup_data field and dependency gating."""
 
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -8,6 +8,7 @@ from music_assistant_models.config_entries import (
     UI_ONLY,
     ConfigEntry,
     ConfigEntryTypeMap,
+    ConfigValueType,
     PlayerConfig,
     ProviderConfig,
 )
@@ -208,3 +209,72 @@ def test_validate_still_enforces_a_required_entry_without_a_dependency() -> None
 
     with pytest.raises(ValueError, match="token is required"):
         conf.validate()
+
+
+def test_an_entry_without_a_value_never_reaches_its_own_callback() -> None:
+    """Keep an entry's validation callback out of the way while it holds no value."""
+    seen: list[ConfigValueType] = []
+    entries = [
+        _switch(on=False),
+        # gated and disabled, so the user cannot fill it in
+        _gated(validate=lambda value: seen.append(value) is None),
+        # not gated, but optional and left empty
+        ConfigEntry(
+            key="chime_url",
+            type=ConfigEntryType.STRING,
+            required=False,
+            validate=lambda value: seen.append(value) is None,
+        ),
+    ]
+
+    ProviderConfig.parse(entries, _provider_raw()).validate()
+
+    assert seen == []
+
+
+def test_validate_accepts_a_gated_entry_whose_callback_assumes_a_value() -> None:
+    """Accept a config holding a disabled entry whose callback would choke on an empty value."""
+    conf = ProviderConfig.parse(
+        [_switch(on=False), _gated(validate=lambda value: cast("str", value).isascii())],
+        _provider_raw(),
+    )
+
+    conf.validate()
+
+    assert conf.values["proxy_url"].value is None
+
+
+def test_validate_accepts_a_gated_multi_value_entry() -> None:
+    """Accept a disabled entry that expects a list, rather than demanding one."""
+    conf = ProviderConfig.parse([_switch(on=False), _gated(multi_value=True)], _provider_raw())
+
+    conf.validate()
+
+    assert conf.values["proxy_url"].value is None
+
+
+def test_validate_demands_a_gated_multi_value_entry_once_its_dependency_is_met() -> None:
+    """Report the same list entry as required as soon as the user can fill it in."""
+    conf = ProviderConfig.parse([_switch(on=True), _gated(multi_value=True)], _provider_raw())
+
+    with pytest.raises(ValueError, match="proxy_url is required"):
+        conf.validate()
+
+
+def test_a_supplied_value_is_still_run_through_the_callback() -> None:
+    """Keep validating a value the user did give."""
+    entry = _gated(validate=lambda value: value == "http://proxy")
+
+    assert entry.parse_value("http://proxy") == "http://proxy"
+
+    with pytest.raises(ValueError, match="is not a valid value for proxy_url"):
+        entry.parse_value("http://elsewhere")
+
+
+def test_a_supplied_value_still_has_to_match_the_entry_shape() -> None:
+    """Keep rejecting a value whose shape does not match the entry."""
+    with pytest.raises(ValueError, match="value for proxy_url must be a list"):
+        _gated(multi_value=True).parse_value("http://proxy")
+
+    with pytest.raises(ValueError, match="proxy_url must be a single value"):
+        _gated().parse_value(["http://proxy", "http://elsewhere"])


### PR DESCRIPTION
A config entry gated behind another one (`depends_on`) renders disabled, so the user cannot give it a value. #348 stopped us demanding one, but two other checks in `parse_value` still fired on the empty value, leaving such an entry impossible to satisfy on both the settings page and the setup wizard:

- the entry's own `validate` callback ran with an empty value — a callback written for a real value either crashes (which wedges the setup flow with a server error) or reports the disabled field as invalid
- an entry expecting a list still complained that the empty value was not a list

Fixed at the root, so both surfaces benefit and providers need no special-casing.

**Changes**
- `parse_value` short-circuits on an empty value: the shape checks and the validate callback both describe a value the user supplied, so only the required check still applies
- a required list entry with no value now reports "is required" instead of "must be a list"
- an entry that does hold a value is validated exactly as before
- tests for the gated cases and for the unchanged behaviour

Follow-up to #348 and music-assistant/server#5403. No shipped provider hits this today — it is a trap for the next one.