### PR TITLE
Automatically label PRs from the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+# What does this implement/fix?
+
+<!-- Quick description and explanation of changes. -->
+
+**Related issue (if applicable):**
+
+- related issue <link to issue>
+
+## Types of changes
+
+<!--
+Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
+the label from the ticked box and applies it automatically; the
+release-notes generator uses that same label to slot this change
+into the next release notes.
+-->
+
+- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
+- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
+- [ ] Enhancement to an existing feature — `enhancement`
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
+- [ ] Refactor (no behaviour change) — `refactor`
+- [ ] Documentation only — `documentation`
+- [ ] Maintenance / chore — `maintenance`
+- [ ] CI / workflow change — `ci`
+- [ ] Dependencies bump — `dependencies`
+
+## Checklist
+
+- [ ] The code change is tested and works locally.
+- [ ] `pre-commit run --all-files` passes.
+- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
+- [ ] Any consumer of a changed model is updated, and the companion PR in `music-assistant/server` is linked.
+- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -28,6 +28,7 @@ categories:
       - "ci"
       - "documentation"
       - "maintenance"
+      - "refactor"
       - "dependencies"
 
 template: |

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -58,7 +58,7 @@ jobs:
             const re = /^\s*-\s*\[x\][^`\n]*`([^`]+)`/gim;
             const ticked = [];
             for (const m of body.matchAll(re)) {
-              const name = m[1];
+              const name = m[1].trim();
               if (known.includes(name) && !ticked.includes(name)) {
                 ticked.push(name);
               }

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -5,8 +5,8 @@ name: PR Labels
 # generator knows how to slot into a section. We derive that label
 # from the "Types of changes" checkbox in the PR template and apply
 # it automatically — most external contributors can't label their
-# own PRs. The job fails when zero or more than one checkbox is
-# ticked.
+# own PRs. The job fails when more than one box is ticked, or when
+# none is and the PR doesn't already carry a single known label.
 
 # yamllint disable-line rule:truthy
 on:
@@ -50,19 +50,6 @@ jobs:
             const current = (context.payload.pull_request.labels || [])
               .map(l => l.name);
 
-            // If the PR already carries exactly one known-set label
-            // (e.g. applied by release tooling that doesn't use the PR
-            // template), trust it and exit. Zero or 2+ known labels
-            // still fall through to the checkbox-driven path so a
-            // stray manual label can't hide a missing template tick.
-            const alreadyLabelled = current.filter(n => known.includes(n));
-            if (alreadyLabelled.length === 1) {
-              core.info(
-                `Skipping: PR already labelled '${alreadyLabelled[0]}'.`
-              );
-              return;
-            }
-
             // Match a ticked checkbox bullet whose line ends with a
             // backticked label, e.g.  - [x] CI / workflow change — `ci`
             // The PR template puts the canonical label name in
@@ -77,18 +64,31 @@ jobs:
               }
             }
 
-            if (ticked.length === 0) {
-              core.setFailed(
-                'No "Types of changes" checkbox is ticked in the PR ' +
-                'description. Edit the description and tick exactly ' +
-                'one box so this PR can be release-noted.'
-              );
-              return;
-            }
             if (ticked.length > 1) {
               core.setFailed(
                 `Multiple "Types of changes" checkboxes are ticked ` +
                 `(${ticked.join(', ')}). Tick exactly one.`
+              );
+              return;
+            }
+
+            // The description is the source of truth, so a ticked box
+            // always wins — that keeps the label in step when someone
+            // reconsiders the type after opening. Only with nothing
+            // ticked do we fall back to a label already on the PR,
+            // covering PRs opened without the template. Two or more
+            // known labels are ambiguous, so those fail rather than
+            // guess.
+            if (ticked.length === 0) {
+              const existing = current.filter(n => known.includes(n));
+              if (existing.length === 1) {
+                core.info(`Skipping: PR already labelled '${existing[0]}'.`);
+                return;
+              }
+              core.setFailed(
+                'No "Types of changes" checkbox is ticked in the PR ' +
+                'description. Edit the description and tick exactly ' +
+                'one box so this PR can be release-noted.'
               );
               return;
             }

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -1,24 +1,112 @@
 ---
 name: PR Labels
 
+# Each PR must carry exactly one of the labels the release-notes
+# generator knows how to slot into a section. We derive that label
+# from the "Types of changes" checkbox in the PR template and apply
+# it automatically — most external contributors can't label their
+# own PRs. The job fails when zero or more than one checkbox is
+# ticked.
+
 # yamllint disable-line rule:truthy
 on:
-  pull_request:
+  pull_request_target:
     types:
+      - opened
+      - edited
       - synchronize
       - labeled
       - unlabeled
+      - reopened
+      - ready_for_review
     branches:
-      - stable
-      - dev
+      - main
+
+permissions:
+  pull-requests: write
 
 jobs:
-  pr_labels:
-    name: Verify
+  apply_label:
+    name: Apply
     runs-on: ubuntu-latest
+    # GitHub-typed bots (Dependabot, musicassistant-bot[bot], etc.)
+    # don't follow the PR template and apply their own labels, so
+    # skip them outright. Trusted automation can also pre-apply a
+    # known-set label; those PRs are handled below.
+    if: github.event.pull_request.user.type != 'Bot'
     steps:
-      - name: 🏷 Verify PR has a valid label
-        uses: ludeeus/action-require-labels@be19cd7f04c6fad46a85336f9e9cebdf961807bb # 2.0.0
+      - name: 🏷 Apply label from PR description checkbox
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
-         labels: >-
-            breaking-change, bugfix, refactor, new-feature, maintenance, ci, dependencies, documentation, new-provider, enhancement
+          script: |
+            const known = [
+              'breaking-change', 'bugfix', 'refactor',
+              'new-feature', 'enhancement', 'maintenance',
+              'ci', 'dependencies', 'documentation',
+            ];
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const current = (context.payload.pull_request.labels || [])
+              .map(l => l.name);
+
+            // If the PR already carries exactly one known-set label
+            // (e.g. applied by release tooling that doesn't use the PR
+            // template), trust it and exit. Zero or 2+ known labels
+            // still fall through to the checkbox-driven path so a
+            // stray manual label can't hide a missing template tick.
+            const alreadyLabelled = current.filter(n => known.includes(n));
+            if (alreadyLabelled.length === 1) {
+              core.info(
+                `Skipping: PR already labelled '${alreadyLabelled[0]}'.`
+              );
+              return;
+            }
+
+            // Match a ticked checkbox bullet whose line ends with a
+            // backticked label, e.g.  - [x] CI / workflow change — `ci`
+            // The PR template puts the canonical label name in
+            // backticks at the end of each "Types of changes" bullet.
+            const body = context.payload.pull_request.body || '';
+            const re = /^\s*-\s*\[x\][^`\n]*`([^`]+)`/gim;
+            const ticked = [];
+            for (const m of body.matchAll(re)) {
+              const name = m[1];
+              if (known.includes(name) && !ticked.includes(name)) {
+                ticked.push(name);
+              }
+            }
+
+            if (ticked.length === 0) {
+              core.setFailed(
+                'No "Types of changes" checkbox is ticked in the PR ' +
+                'description. Edit the description and tick exactly ' +
+                'one box so this PR can be release-noted.'
+              );
+              return;
+            }
+            if (ticked.length > 1) {
+              core.setFailed(
+                `Multiple "Types of changes" checkboxes are ticked ` +
+                `(${ticked.join(', ')}). Tick exactly one.`
+              );
+              return;
+            }
+
+            const desired = ticked[0];
+
+            // Strip any stale labels from the known set so a
+            // contributor changing their mind in the description
+            // doesn't leave the previous label behind.
+            for (const name of current) {
+              if (known.includes(name) && name !== desired) {
+                await github.rest.issues.removeLabel({
+                  owner, repo, issue_number, name,
+                }).catch(() => {});
+              }
+            }
+            if (!current.includes(desired)) {
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number, labels: [desired],
+              });
+            }


### PR DESCRIPTION
# What does this implement/fix?

The PR label check never ran. It filtered on the `stable`/`dev` branches, but every PR here targets `main`, so the workflow has zero runs to its name. PRs merged with no label at all (#351, #350, #346, #338, #337, ...) and unlabelled PRs land in the release notes as loose bullets above the categorised sections instead of under a proper heading.

This ports the pattern already used in the server repo: instead of only failing when a label is missing, CI now reads the ticked "Types of changes" box from the PR description and applies the matching label itself. That keeps contributors who can't set labels from getting stuck.

Note this turns a gate on that was previously dead, so from now on a PR needs one box ticked.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Add a PR template with a "Types of changes" section (this repo had none)
- Run the label check on `main`, and on PR open/edit/reopen/ready-for-review
- Apply the label from the ticked box instead of only verifying one is present
- Skip bot PRs — Dependabot and the release automation set their own labels
- Add the missing `refactor`, `ci` and `documentation` labels to the repo
- Give `refactor` a home in the maintenance section of the release notes

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] Any consumer of a changed model is updated, and the companion PR in `music-assistant/server` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
