### PR TITLE
Fix committing from a git worktree

### DIFF
--- a/scripts/run-in-env.sh
+++ b/scripts/run-in-env.sh
@@ -12,11 +12,22 @@ fi
 # other common virtualenvs
 my_path=$(git rev-parse --show-toplevel)
 
-for venv in venv .venv .; do
-  if [ -f "${my_path}/${venv}/bin/activate" ]; then
-    . "${my_path}/${venv}/bin/activate"
-    break
-  fi
+# A git worktree usually has no virtualenv of its own, so search the main checkout as well.
+# Its git dir is the common dir, which for a worktree differs from that worktree's own git dir.
+git_dir=$(git rev-parse --path-format=absolute --git-dir 2>/dev/null || true)
+common_dir=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
+main_path=""
+if [ -n "$common_dir" ] && [ "$git_dir" != "$common_dir" ]; then
+  main_path=$(dirname "$common_dir")
+fi
+
+for root in "$my_path" ${main_path:+"$main_path"}; do
+  for venv in venv .venv .; do
+    if [ -f "${root}/${venv}/bin/activate" ]; then
+      . "${root}/${venv}/bin/activate"
+      break 2
+    fi
+  done
 done
 
 exec "$@"

--- a/scripts/run-in-env.sh
+++ b/scripts/run-in-env.sh
@@ -13,15 +13,15 @@ fi
 my_path=$(git rev-parse --show-toplevel)
 
 # A git worktree usually has no virtualenv of its own, so search the main checkout as well.
-# Its git dir is the common dir, which for a worktree differs from that worktree's own git dir.
+# A worktree's git dir differs from the common git dir, which lives in the main checkout.
 git_dir=$(git rev-parse --path-format=absolute --git-dir 2>/dev/null || true)
 common_dir=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
-main_path=""
+main_root=""
 if [ -n "$common_dir" ] && [ "$git_dir" != "$common_dir" ]; then
-  main_path=$(dirname "$common_dir")
+  main_root=$(dirname "$common_dir")
 fi
 
-for root in "$my_path" ${main_path:+"$main_path"}; do
+for root in "$my_path" ${main_root:+"$main_root"}; do
   for venv in venv .venv .; do
     if [ -f "${root}/${venv}/bin/activate" ]; then
       . "${root}/${venv}/bin/activate"


### PR DESCRIPTION
# What does this implement/fix?

Committing from a git worktree did not work: the pre-commit helper script looks for the virtual environment in the current checkout, and a worktree does not have one. Nothing got activated, so the hooks could not start `ruff`/`mypy` and the commit was aborted. The only way around it was to point `PATH` at the main checkout's `.venv` by hand.

The helper now detects a worktree and falls back to the main checkout's virtual environment.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] Any consumer of a changed model is updated, and the companion PR in `music-assistant/server` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
