### PR TITLE
Stop a new playlist media type from breaking older clients

### DIFF
--- a/music_assistant_models/media_items/media_item.py
+++ b/music_assistant_models/media_items/media_item.py
@@ -402,9 +402,10 @@ class Playlist(_LocalizableTitle, MediaItem):
     def __post_init__(self) -> None:
         """Run some basic sanity checks after init."""
         super().__post_init__()
-        # Media types we have no concept of are dropped instead of rejected: a newer
-        # server may send a type that was added after this version, which must never
-        # make the playlist (and with it, the entire listing) fail to parse.
+        # Media types that cannot be in a playlist are dropped instead of rejected. That
+        # covers types added after this version, which deserialize to UNKNOWN here: a
+        # newer server must never make the playlist fail to parse, as that takes the
+        # entire listing down with it.
         self.supported_mediatypes &= PLAYLIST_SUPPORTED_MEDIATYPES
         if not self.supported_mediatypes:
             self.supported_mediatypes = {MediaType.TRACK}

--- a/music_assistant_models/media_items/media_item.py
+++ b/music_assistant_models/media_items/media_item.py
@@ -32,6 +32,17 @@ from music_assistant_models.unique_list import UniqueList
 from .metadata import AudioMetadata, MediaItemImage, MediaItemMetadata
 from .provider_mapping import ProviderMapping
 
+# The media types a playlist is allowed to hold.
+PLAYLIST_SUPPORTED_MEDIATYPES = frozenset(
+    {
+        MediaType.AUDIOBOOK,
+        MediaType.PODCAST_EPISODE,
+        MediaType.RADIO,
+        MediaType.SOUND_EFFECT,
+        MediaType.TRACK,
+    }
+)
+
 
 @dataclass(kw_only=True)
 class _MediaItemBase(DataClassDictMixin):
@@ -384,22 +395,19 @@ class Playlist(_LocalizableTitle, MediaItem):
     # Examples: Apple Music Artist Stations, Deezer Flow.
     is_dynamic: bool = False
 
-    # The playlist may support only a single, or a mix of multiple media types. Allowed entries:
-    # MediaType.AUDIOBOOK, MediaType.PODCAST_EPISODE, MediaType.RADIO, MediaType.TRACK
+    # The playlist may support only a single, or a mix of multiple media types,
+    # limited to the entries in PLAYLIST_SUPPORTED_MEDIATYPES.
     supported_mediatypes: set[MediaType] = field(default_factory=lambda: {MediaType.TRACK})
 
     def __post_init__(self) -> None:
         """Run some basic sanity checks after init."""
         super().__post_init__()
-        _supported = {
-            MediaType.AUDIOBOOK,
-            MediaType.PODCAST_EPISODE,
-            MediaType.RADIO,
-            MediaType.SOUND_EFFECT,
-            MediaType.TRACK,
-        }
-        if len(self.supported_mediatypes.difference(_supported)) > 0:
-            raise TypeError(f"Playlists are only supported for {_supported}.")
+        # Media types we have no concept of are dropped instead of rejected: a newer
+        # server may send a type that was added after this version, which must never
+        # make the playlist (and with it, the entire listing) fail to parse.
+        self.supported_mediatypes &= PLAYLIST_SUPPORTED_MEDIATYPES
+        if not self.supported_mediatypes:
+            self.supported_mediatypes = {MediaType.TRACK}
 
 
 @dataclass(kw_only=True)

--- a/tests/test_playlist.py
+++ b/tests/test_playlist.py
@@ -1,0 +1,62 @@
+"""Tests for the Playlist MediaItem."""
+
+from music_assistant_models.enums import MediaType
+from music_assistant_models.media_items import Playlist, media_from_dict
+
+
+def _playlist_dict(supported_mediatypes: list[str]) -> dict:
+    return {
+        "item_id": "1",
+        "provider": "library",
+        "name": "Summer",
+        "media_type": "playlist",
+        "provider_mappings": [
+            {
+                "item_id": "abc",
+                "provider_domain": "builtin",
+                "provider_instance": "builtin--1",
+            }
+        ],
+        "supported_mediatypes": supported_mediatypes,
+    }
+
+
+def test_supported_mediatypes_defaults_to_tracks() -> None:
+    """A playlist holds tracks unless it says otherwise."""
+    playlist = media_from_dict(_playlist_dict(["track"]))
+
+    assert isinstance(playlist, Playlist)
+    assert playlist.supported_mediatypes == {MediaType.TRACK}
+
+
+def test_unknown_supported_mediatype_is_dropped() -> None:
+    """A media type this version does not know is dropped, not rejected."""
+    playlist = media_from_dict(_playlist_dict(["track", "radio", "some_future_type"]))
+
+    assert isinstance(playlist, Playlist)
+    assert playlist.supported_mediatypes == {MediaType.TRACK, MediaType.RADIO}
+
+
+def test_media_type_invalid_for_playlists_is_dropped() -> None:
+    """A media type that can never be in a playlist is dropped, not rejected."""
+    playlist = media_from_dict(_playlist_dict(["track", "artist", "album"]))
+
+    assert isinstance(playlist, Playlist)
+    assert playlist.supported_mediatypes == {MediaType.TRACK}
+
+
+def test_only_unknown_supported_mediatypes_falls_back_to_tracks() -> None:
+    """A playlist that ends up supporting nothing falls back to tracks."""
+    playlist = media_from_dict(_playlist_dict(["some_future_type"]))
+
+    assert isinstance(playlist, Playlist)
+    assert playlist.supported_mediatypes == {MediaType.TRACK}
+
+
+def test_supported_mediatypes_roundtrip() -> None:
+    """The supported media types survive a serialization roundtrip."""
+    supported = {MediaType.TRACK, MediaType.RADIO, MediaType.SOUND_EFFECT}
+    playlist = media_from_dict(_playlist_dict([x.value for x in supported]))
+
+    assert isinstance(playlist, Playlist)
+    assert Playlist.from_dict(playlist.to_dict()).supported_mediatypes == supported

--- a/tests/test_playlist.py
+++ b/tests/test_playlist.py
@@ -4,8 +4,8 @@ from music_assistant_models.enums import MediaType
 from music_assistant_models.media_items import Playlist, media_from_dict
 
 
-def _playlist_dict(supported_mediatypes: list[str]) -> dict:
-    return {
+def _playlist_dict(supported_mediatypes: list[str] | None = None) -> dict:
+    playlist: dict = {
         "item_id": "1",
         "provider": "library",
         "name": "Summer",
@@ -17,13 +17,15 @@ def _playlist_dict(supported_mediatypes: list[str]) -> dict:
                 "provider_instance": "builtin--1",
             }
         ],
-        "supported_mediatypes": supported_mediatypes,
     }
+    if supported_mediatypes is not None:
+        playlist["supported_mediatypes"] = supported_mediatypes
+    return playlist
 
 
 def test_supported_mediatypes_defaults_to_tracks() -> None:
     """A playlist holds tracks unless it says otherwise."""
-    playlist = media_from_dict(_playlist_dict(["track"]))
+    playlist = media_from_dict(_playlist_dict())
 
     assert isinstance(playlist, Playlist)
     assert playlist.supported_mediatypes == {MediaType.TRACK}


### PR DESCRIPTION
# What does this implement/fix?

A playlist rejected outright any media type outside a fixed list. Because clients only get new media types when they are updated, adding one on the server side made every client already in the field fail to parse that playlist — and since listings are parsed as a whole, a single playlist took down the entire playlist list.

That is what just happened with the "sound effect" type: Home Assistant became unable to play or browse any Music Assistant playlist. Widening the list each time only fixes it after the fact, and only for clients that have already been updated.

Unknown media types are now dropped instead, so an older client quietly ignores what it does not understand rather than falling over.

- a playlist drops media types it does not know instead of raising
- falls back to tracks if nothing recognisable is left
- added tests covering unknown, invalid and roundtripped media types

**Related issue (if applicable):**

- server companion: https://github.com/music-assistant/server/pull/5489

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] Any consumer of a changed model is updated, and the companion PR in `music-assistant/server` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
