### PR TITLE
Add comprehensive sort field definitions

### DIFF
--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -970,3 +970,27 @@ class ProviderStatus(StrEnum):
     INCOMPATIBLE = "incompatible"
     # error: setup failed for any other reason (see the provider's last_error)
     ERROR = "error"
+
+
+class SortField(StrEnum):
+    """Sort fields available for media listings."""
+
+    NAME = "name"
+    SORT_NAME = "sort_name"
+    TIMESTAMP_ADDED = "timestamp_added"
+    TIMESTAMP_MODIFIED = "timestamp_modified"
+    LAST_PLAYED = "last_played"
+    PLAY_COUNT = "play_count"
+    DURATION = "duration"
+    YEAR = "year"
+    POSITION = "position"
+    ARTIST_NAME = "artist_name"
+    RANDOM = "random"
+    RANDOM_PLAY_COUNT = "random_play_count"
+
+
+class SortDirection(StrEnum):
+    """Sort direction."""
+
+    ASC = "asc"
+    DESC = "desc"


### PR DESCRIPTION
# What does this implement/fix?

Adds `SortField` and `SortDirection` enums for type-safe sorting in library API endpoints.

Related: music-assistant/server#5498

**Related discussions:**

- GitHub Discussion: https://github.com/orgs/music-assistant/discussions/6007
- Discord: https://discord.com/channels/753947050995089438/1343766783768789002/1535053832583651449
- Discord: https://discord.com/channels/753947050995089438/1098879369792983071/1535206553689260134

## Changes

- `SortField` enum: Defines all available sort fields for media listings (NAME, SORT_NAME, TIMESTAMP_ADDED, TIMESTAMP_MODIFIED, LAST_PLAYED, PLAY_COUNT, DURATION, YEAR, POSITION, ARTIST_NAME, RANDOM, RANDOM_PLAY_COUNT)
- `SortDirection` enum: Sort direction (ASC, DESC)

New typed `sort_field`/`sort_direction` parameters replace legacy string-based `order_by`. Sort field metadata (`SortFieldDefinition`, `SORT_FIELD_DEFINITIONS`, etc.) and API response models (`SortOptionInfo`) live in the server repo per Marcel's architecture guidance.

## Types of changes

New feature (non-breaking change which adds functionality) — `new-feature`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable. (No tests needed - pure data structures)
- [x] Any consumer of a changed model is updated, and the companion PR in `music-assistant/server` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.