### PR TITLE
Add 'filesystem_nfs' to local provider domains for quality ranking

### DIFF
--- a/music_assistant_models/media_items/provider_mapping.py
+++ b/music_assistant_models/media_items/provider_mapping.py
@@ -49,7 +49,7 @@ class ProviderMapping(DataClassDictMixin):
         # prefer in_library items for better instance-steering
         base_score = 1 if self.in_library else 0
         # prefer local file based providers
-        if self.provider_domain in ("filesystem_local", "filesystem_smb"):
+        if self.provider_domain in ("filesystem_local", "filesystem_smb", "filesystem_nfs"):
             return base_score + 2
         if not (local_provs := get_global_cache_value("non_streaming_providers")):
             # this is probably the client


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

A user identified the oversight of NFS missing from the local providers list 

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] Any consumer of a changed model is updated, and the companion PR in `music-assistant/server` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
