### PR TITLE
Add expanded_options to ConfigEntry

### DIFF
--- a/music_assistant_models/config_entries.py
+++ b/music_assistant_models/config_entries.py
@@ -132,6 +132,10 @@ class ConfigEntry(DataClassDictMixin):
     # multi_value [optional]: allow multiple values from the list
     # NOTE: when set, the value is stored as a list, so default_value must be a list (or None)
     multi_value: bool = False
+    # expanded_options [optional]: render the options inline - all of them, with their
+    # descriptions, visible at once (e.g. as a radio group) - instead of behind a dropdown.
+    # Ignored when the entry has no options or is multi_value.
+    expanded_options: bool = False
     # depends_on [optional]: key of another entry that gates this one; an unresolved key counts
     # as unmet. While unmet, input types and ACTION stay visible but render disabled;
     # DIVIDER/LABEL/ALERT/IMAGE have nothing to disable, so the frontend hides them instead.


### PR DESCRIPTION
# What does this implement/fix?

Add `expanded_options` to ConfigEntry.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] Any consumer of a changed model is updated, and the companion PR in `music-assistant/server` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
