### PR TITLE
Close superseded models bump PRs in the client repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -603,3 +603,46 @@ jobs:
 
           labels: |
             dependencies
+
+      - name: Close superseded bump PRs
+        if: steps.create_pr.outputs.pull-request-number
+        run: |
+          set -euo pipefail
+
+          # The prefix must match the `branch` input of the step above.
+          OPEN_BUMPS=$(
+            gh pr list \
+              --repo music-assistant/client \
+              --state open \
+              --limit 100 \
+              --json number,headRefName \
+              --jq '.[]
+                | select(.headRefName | startswith("auto-update-models-"))
+                | [.number, (.headRefName | ltrimstr("auto-update-models-"))]
+                | @tsv'
+          )
+
+          if [[ -z "$OPEN_BUMPS" ]]; then
+            exit 0
+          fi
+
+          while IFS=$'\t' read -r NUMBER BUMP_VERSION; do
+            if [[ "$NUMBER" == "$NEW_PR" ]]; then
+              continue
+            fi
+
+            # Keep bumps to a newer version so an out-of-order release cannot close them.
+            OLDEST=$(printf "%s\n%s\n" "$BUMP_VERSION" "$VERSION" | sort -V | head -n1)
+            if [[ "$OLDEST" != "$BUMP_VERSION" ]]; then
+              continue
+            fi
+
+            gh pr close "$NUMBER" \
+              --repo music-assistant/client \
+              --delete-branch \
+              --comment "Superseded by #${NEW_PR}, which updates music-assistant-models to ${VERSION}."
+          done <<< "$OPEN_BUMPS"
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          NEW_PR: ${{ steps.create_pr.outputs.pull-request-number }}
+          VERSION: ${{ inputs.version }}


### PR DESCRIPTION
# What does this implement/fix?

Every models release opens a client bump PR on its own `auto-update-models-<version>` branch, so when an older bump has not been merged yet it stays open and the PRs stack up in the client repo.

The client job now closes the bumps it replaces, right after creating the new PR:

- List open client PRs whose head branch starts with `auto-update-models-`.
- Close each one for an older version with `gh pr close --delete-branch` and a comment pointing at the new PR.
- Compare versions with `sort -V`, so a bump to a newer version is left open if a release ever runs out of order.

The server job is left as is: its `.post` releases target `stable`, so closing by branch prefix alone would cross base branches there.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] Any consumer of a changed model is updated, and the companion PR in `music-assistant/server` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
