### PR TITLE
Allow radio stations to be marked as dynamic

### DIFF
--- a/music_assistant_models/media_items/media_item.py
+++ b/music_assistant_models/media_items/media_item.py
@@ -420,9 +420,7 @@ class Radio(_LocalizableTitle, MediaItem):
 
     media_type: MediaType = MediaType.RADIO
     duration: int | None = None
-    # When True, the station is provider-driven and endless: tracks are yielded on demand
-    # via the provider's get_dynamic_radio_tracks method instead of a single live stream.
-    # Examples: Pandora Stations.
+    # When True, tracks come from get_dynamic_radio_tracks instead of a live stream.
     is_dynamic: bool = False
 
     def __post_serialize__(self, d: dict[str, Any]) -> dict[str, Any]:

--- a/music_assistant_models/media_items/media_item.py
+++ b/music_assistant_models/media_items/media_item.py
@@ -420,6 +420,10 @@ class Radio(_LocalizableTitle, MediaItem):
 
     media_type: MediaType = MediaType.RADIO
     duration: int | None = None
+    # When True, the station is provider-driven and endless: tracks are yielded on demand
+    # via the provider's get_dynamic_radio_tracks method instead of a single live stream.
+    # Examples: Pandora Stations.
+    is_dynamic: bool = False
 
     def __post_serialize__(self, d: dict[str, Any]) -> dict[str, Any]:
         """Adjust dict object after it has been serialized."""

--- a/tests/test_summary_items.py
+++ b/tests/test_summary_items.py
@@ -132,6 +132,22 @@ def test_radio_summary_duration_backcompat() -> None:
     assert radio.to_dict()["duration"] == 0
 
 
+def test_radio_is_dynamic_roundtrip() -> None:
+    """A dynamic station keeps its is_dynamic flag across serialization."""
+    radio = Radio(
+        item_id="1", provider="pandora", name="radio", provider_mappings=set(), is_dynamic=True
+    )
+    assert Radio.from_dict(radio.to_dict()).is_dynamic is True
+    summary = RadioSummary(item_id="1", provider="library", name="radio", is_dynamic=True)
+    assert Radio.from_dict(summary.to_dict()).is_dynamic is True
+
+
+def test_radio_defaults_to_a_live_stream() -> None:
+    """A station without the flag deserializes as a regular (live) radio station."""
+    payload = {"item_id": "1", "provider": "tunein", "name": "radio", "provider_mappings": []}
+    assert Radio.from_dict(payload).is_dynamic is False
+
+
 def test_per_type_summaries_serialize_sparse() -> None:
     """Every summary type serializes without None-valued keys."""
     items = [


### PR DESCRIPTION
# What does this implement/fix?

Radio stations can now be marked as "dynamic", the same way playlists already can.

A dynamic item has no fixed tracklist: the provider hands out a fresh batch of tracks on demand
and Music Assistant keeps the queue topped up. Today that is only possible for playlists, which
forces providers like Pandora to list their stations under Playlists instead of Radio, where
users look for them.

**Related issue (if applicable):**

- Companion server PR: https://github.com/music-assistant/server/pull/5628

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] Any consumer of a changed model is updated, and the companion PR in `music-assistant/server` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
