### PR TITLE
Add statistics data models for charts

### DIFF
--- a/music_assistant_models/__init__.py
+++ b/music_assistant_models/__init__.py
@@ -2,5 +2,15 @@
 
 from .background_task import BackgroundTask, TaskSchedule
 from .enums import TaskScheduleType, TaskStatus
+from .statistics import DailyStats, ListeningSummary, TopItem, TopItemResult
 
-__all__ = ["BackgroundTask", "TaskSchedule", "TaskScheduleType", "TaskStatus"]
+__all__ = [
+    "BackgroundTask",
+    "TaskSchedule",
+    "TaskScheduleType",
+    "TaskStatus",
+    "DailyStats",
+    "ListeningSummary",
+    "TopItem",
+    "TopItemResult",
+]

--- a/music_assistant_models/__init__.py
+++ b/music_assistant_models/__init__.py
@@ -6,11 +6,11 @@ from .statistics import DailyStats, ListeningSummary, TopItem, TopItemResult
 
 __all__ = [
     "BackgroundTask",
+    "DailyStats",
+    "ListeningSummary",
     "TaskSchedule",
     "TaskScheduleType",
     "TaskStatus",
-    "DailyStats",
-    "ListeningSummary",
     "TopItem",
     "TopItemResult",
 ]

--- a/music_assistant_models/statistics.py
+++ b/music_assistant_models/statistics.py
@@ -3,14 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
 
 from mashumaro.mixins.orjson import DataClassORJSONMixin
 
 from music_assistant_models.media_items import ItemMapping
-
-if TYPE_CHECKING:
-    from music_assistant_models.media_items import MediaItemType
 
 
 @dataclass(kw_only=True)

--- a/music_assistant_models/statistics.py
+++ b/music_assistant_models/statistics.py
@@ -57,3 +57,36 @@ class ListeningSummary(DataClassORJSONMixin):
     unique_albums: int
     unique_artists: int
     top_genre: str | None = None
+
+
+@dataclass(kw_only=True)
+class DistributionItem(DataClassORJSONMixin):
+    """A single item in a distribution chart (e.g., genre or artist distribution)."""
+
+    name: str
+    value: int
+
+
+@dataclass(kw_only=True)
+class TimeSeriesPoint(DataClassORJSONMixin):
+    """A single point in a time series chart."""
+
+    timestamp: str  # ISO 8601 date string
+    value: int
+
+
+@dataclass(kw_only=True)
+class HeatmapPoint(DataClassORJSONMixin):
+    """A single point in a heatmap (e.g., listening activity by hour and weekday)."""
+
+    hour: int  # 0-23
+    weekday: int  # 0-6 (Monday=0)
+    value: int
+
+
+@dataclass(kw_only=True)
+class ListeningTimeItem(DataClassORJSONMixin):
+    """An item with total listening time (e.g., artist or genre listening time)."""
+
+    name: str
+    minutes: float

--- a/music_assistant_models/statistics.py
+++ b/music_assistant_models/statistics.py
@@ -1,0 +1,59 @@
+"""Statistics models for Music Assistant."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from mashumaro.mixins.orjson import DataClassORJSONMixin
+
+from music_assistant_models.media_items import ItemMapping
+
+if TYPE_CHECKING:
+    from music_assistant_models.media_items import MediaItemType
+
+
+@dataclass(kw_only=True)
+class TopItemResult(DataClassORJSONMixin):
+    """A top played item with its ItemMapping and play count."""
+
+    item: ItemMapping
+    play_count: int
+
+
+@dataclass(kw_only=True)
+class TopItem(DataClassORJSONMixin):
+    """An item with aggregated play statistics."""
+
+    item_id: str
+    provider: str
+    media_type: str
+    play_count: int
+    total_seconds: float
+    first_played: float
+    last_played: float
+
+
+@dataclass(kw_only=True)
+class DailyStats(DataClassORJSONMixin):
+    """Listening statistics for a single day."""
+
+    date: str  # YYYY-MM-DD
+    seconds_listened: float
+    tracks_played: int
+    unique_artists: int
+
+
+@dataclass(kw_only=True)
+class ListeningSummary(DataClassORJSONMixin):
+    """Aggregated listening statistics for a time period."""
+
+    period: str
+    period_start: float
+    period_end: float
+    total_listening_seconds: float
+    total_plays: int
+    unique_tracks: int
+    unique_albums: int
+    unique_artists: int
+    top_genre: str | None = None


### PR DESCRIPTION
# What does this implement/fix?

Adds data models for the new Statistics Controller feature, defining the structure for playlog analytics responses (top items, distributions, time series, heatmaps, listening time).

⚠️ **Note:** While these models are correct, the backend statistics currently show incorrect play counts due to a playlog database design issue. See music-assistant/server#5700 for details.

**Related issue (if applicable):**

- https://github.com/music-assistant/backlog/issues/21

## New Models

- `TopItemResult`: Combines ItemMapping with play_count for top charts
- `DistributionItem`: Name/value pairs for pie/bar charts (artists, genres, decades)
- `TimeSeriesPoint`: Timestamp/value pairs for line charts (plays over time)
- `HeatmapPoint`: Hour/weekday/value tuples for activity heatmaps
- `ListeningTimeItem`: Name/minutes pairs for listening time charts

## Types of changes

- [x] New feature (non-breaking change which adds functionality) — `new-feature`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] Any consumer of a changed model is updated, and the companion PR in `music-assistant/server` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.

## Related PRs

- Server: music-assistant/server#5700
- Frontend: music-assistant/frontend#2526