### PR TITLE
Replace unidecode with anyascii to drop the GPL dependency

### DIFF
--- a/music_assistant_models/helpers.py
+++ b/music_assistant_models/helpers.py
@@ -12,7 +12,7 @@ from typing import Any
 from unicodedata import combining, normalize
 from uuid import UUID
 
-import unidecode
+from anyascii import anyascii
 
 from music_assistant_models.enums import MediaType
 
@@ -100,7 +100,10 @@ def create_safe_string(input_str: str, lowercase: bool = True, replace_space: bo
     if input_str == "$hort":
         input_str = input_str.replace("$hort", "short")
     input_str = input_str.lower().strip() if lowercase else input_str.strip()
-    unaccented_string = unidecode.unidecode(input_str)
+    unaccented_string = anyascii(input_str)
+    if lowercase:
+        # anyascii can emit uppercase for symbols and non-latin scripts (™ -> TM)
+        unaccented_string = unaccented_string.lower()
     regex = r"[^a-zA-Z0-9]" if replace_space else r"[^a-zA-Z0-9 ]"
     return re.sub(regex, "", unaccented_string)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
 ]
-dependencies = ["orjson>=3.9", "mashumaro>=3.14", "unidecode==1.4.0"]
+dependencies = ["orjson>=3.9", "mashumaro>=3.14", "anyascii==0.3.3"]
 description = "Music Assistant Base Models"
 license = {text = "Apache-2.0"}
 readme = "README.md"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -17,6 +17,31 @@ def test_create_sort_name() -> None:
     assert helpers.create_sort_name("A Perfect Circle") == "perfect circle, a"
 
 
+def test_create_safe_string() -> None:
+    """Test create_safe_string helper."""
+    # accented latin transliterates to plain ascii
+    assert helpers.create_safe_string("Café") == "cafe"
+    assert helpers.create_safe_string("Björk") == "bjork"
+    assert helpers.create_safe_string("Mötley Crüe") == "motley crue"
+    # special-cased artist names bypass general transliteration
+    assert helpers.create_safe_string("P!nk") == "pink"
+    assert helpers.create_safe_string("Wh♂") == "who"
+    assert helpers.create_safe_string("KoЯn") == "korn"
+    assert helpers.create_safe_string("$hort") == "short"
+    # non-latin scripts must transliterate, not disappear
+    assert helpers.create_safe_string("Кино") == "kino"
+    assert helpers.create_safe_string("방탄소년단") == "bangtansonyeondan"
+    # symbols that transliterate to uppercase are lowered
+    assert helpers.create_safe_string("Track™") == "tracktm"
+    # emoji transliterate to their name
+    assert helpers.create_safe_string("DJ 🔥 Snake") == "dj fire snake"
+    # spaces are kept by default, stripped with replace_space=True
+    assert helpers.create_safe_string("The Beatles") == "the beatles"
+    assert helpers.create_safe_string("The Beatles", replace_space=True) == "thebeatles"
+    # lowercase can be disabled
+    assert helpers.create_safe_string("Café", lowercase=False) == "Cafe"
+
+
 def test_is_valid_uuid() -> None:
     """Test is_valid_uuid helper."""
     assert helpers.is_valid_uuid("f47ac10b-58cc-4372-a567-0e02b2c3d479")

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "anyascii"
+version = "0.3.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/ba/edebda727008390936da4a9bf677c19cd63b32d51e864656d2cbd1028e25/anyascii-0.3.3.tar.gz", hash = "sha256:c94e9dd9d47b3d9494eca305fef9447d00b4bf1a32aff85aa746fa3ec7fb95c3", size = 264680, upload-time = "2025-06-29T03:33:30.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/76/783b75a21ce3563b8709050de030ae253853b147bd52e141edc1025aa268/anyascii-0.3.3-py3-none-any.whl", hash = "sha256:f5ab5e53c8781a36b5a40e1296a0eeda2f48c649ef10c3921c1381b1d00dee7a", size = 345090, upload-time = "2025-06-29T03:33:28.356Z" },
+]
+
+[[package]]
 name = "ast-serialize"
 version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -300,9 +309,9 @@ name = "music-assistant-models"
 version = "0.0.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "anyascii" },
     { name = "mashumaro" },
     { name = "orjson" },
-    { name = "unidecode" },
 ]
 
 [package.optional-dependencies]
@@ -320,6 +329,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anyascii", specifier = "==0.3.3" },
     { name = "codespell", marker = "extra == 'test'", specifier = "==2.4.3" },
     { name = "isort", marker = "extra == 'test'", specifier = "==8.0.1" },
     { name = "mashumaro", specifier = ">=3.14" },
@@ -331,7 +341,6 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'test'", specifier = "==7.1.0" },
     { name = "ruff", marker = "extra == 'test'", specifier = "==0.15.22" },
     { name = "tomli", marker = "extra == 'test'", specifier = "==2.4.1" },
-    { name = "unidecode", specifier = "==1.4.0" },
 ]
 provides-extras = ["test"]
 
@@ -739,15 +748,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
-]
-
-[[package]]
-name = "unidecode"
-version = "1.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/7d/a8a765761bbc0c836e397a2e48d498305a865b70a8600fd7a942e85dcf63/Unidecode-1.4.0.tar.gz", hash = "sha256:ce35985008338b676573023acc382d62c264f307c8f7963733405add37ea2b23", size = 200149, upload-time = "2025-04-24T08:45:03.798Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/b7/559f59d57d18b44c6d1250d2eeaa676e028b9c527431f5d0736478a73ba1/Unidecode-1.4.0-py3-none-any.whl", hash = "sha256:c3c7606c27503ad8d501270406e345ddb480a7b5f38827eafe4fa82a137f0021", size = 235837, upload-time = "2025-04-24T08:45:01.609Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# What does this implement/fix?

`unidecode` (pulled in via #343 for `create_safe_string`) is licensed GPLv2+, which blocks Home Assistant core from bumping `music-assistant-client` (see https://github.com/home-assistant/core/pull/179386): HA's license audit rejects GPL dependencies.

This replaces it with `anyascii` (ISC licensed), which has equivalent transliteration behavior for our use: Latin-accented input transliterates identically, non-Latin scripts (Cyrillic/CJK) differ slightly in style but never produce empty output, and the special-cased artist names (P!nk, KoЯn, Wh♂, $hort) resolve before the library call.

- Replace `unidecode==1.4.0` with `anyascii==0.3.3` in dependencies
- Swap the single call site in `create_safe_string`
- Lowercase the transliterated output when `lowercase=True` (anyascii can emit uppercase, e.g. `™` → `TM`, Hangul → CamelCase romanization)
- Add tests for `create_safe_string` (accents, non-Latin scripts, special cases, symbol/emoji transliteration, `replace_space`/`lowercase` flags)

Note for the server: no model/API change, but transliteration output differs from unidecode for non-Latin scripts (romanization style) and emoji (now transliterated to their name). Runtime comparisons recompute both sides so they are unaffected; persisted values (`search_name`/`search_sort_name` columns) keep the old style until rows are rewritten, only for non-Latin names.

**Related issue (if applicable):**

- related issue https://github.com/home-assistant/core/pull/179386

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] Any consumer of a changed model is updated, and the companion PR in `music-assistant/server` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
