### PR TITLE
Support provider filters in recommendation rows

### DIFF
--- a/music_assistant_models/media_items/media_item.py
+++ b/music_assistant_models/media_items/media_item.py
@@ -658,6 +658,8 @@ class RecommendationFolder(BrowseFolder):
     # rows off by default are noisier (e.g. random or raw play-history); the client
     # hides them until the user opts in. Only meaningful on the descriptor (rows) response.
     enabled_by_default: bool = True
+    # whether this row's items endpoint accepts a source-provider filter
+    supports_provider_filter: bool = False
 
     @property
     def _translation_group(self) -> str:

--- a/tests/test_recommendation_folder.py
+++ b/tests/test_recommendation_folder.py
@@ -17,6 +17,7 @@ def test_recommendation_folder_descriptor_defaults() -> None:
     assert folder.enabled_by_default is True
     assert folder.type is RecommendationFolderType.DEFAULT
     assert folder.is_playable is False
+    assert folder.supports_provider_filter is False
     assert list(folder.items) == []  # the rows response omits items
     assert folder.uri is not None
 
@@ -33,3 +34,37 @@ def test_recommendation_folder_enabled_by_default_roundtrip() -> None:
     assert data["enabled_by_default"] is False
     restored = RecommendationFolder.from_dict(data)
     assert restored.enabled_by_default is False
+
+
+def test_recommendation_folder_supports_provider_filter_roundtrip() -> None:
+    """supports_provider_filter defaults to False and roundtrips when explicitly True."""
+    folder = RecommendationFolder(
+        item_id="random_albums",
+        provider="library",
+        name="Random albums",
+    )
+    assert folder.supports_provider_filter is False
+
+    folder = RecommendationFolder(
+        item_id="random_albums",
+        provider="library",
+        name="Random albums",
+        supports_provider_filter=True,
+    )
+    data = folder.to_dict()
+    assert data["supports_provider_filter"] is True
+    restored = RecommendationFolder.from_dict(data)
+    assert restored.supports_provider_filter is True
+
+
+def test_recommendation_folder_supports_provider_filter_backwards_compatible() -> None:
+    """Payloads without supports_provider_filter still deserialize, defaulting to False."""
+    folder = RecommendationFolder(
+        item_id="random_albums",
+        provider="library",
+        name="Random albums",
+    )
+    data = folder.to_dict()
+    del data["supports_provider_filter"]
+    restored = RecommendationFolder.from_dict(data)
+    assert restored.supports_provider_filter is False


### PR DESCRIPTION
## What does this implement/fix?

Recommendation rows currently give clients no way to know whether a row's items can be filtered by source provider. This adds a capability flag so clients can safely offer that filtering only where it's supported.

- Add `supports_provider_filter: bool = False` to `RecommendationFolder`
- Add tests for the default value, explicit `True` round-trip, and backwards compatibility with payloads missing the field

**Related issue (if applicable):**

- related PR in `music-assistant/server`: provider-filtered recommendations (companion change, follow-up)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] Any consumer of a changed model is updated, and the companion PR in `music-assistant/server` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.