### PR TITLE
Keep the playback session id out of the player media payload

### DIFF
--- a/music_assistant_models/player.py
+++ b/music_assistant_models/player.py
@@ -122,6 +122,11 @@ class PlayerMedia(DataClassDictMixin):
     source_id: str | None = None  # optional (ID of the source, may be a queue id)
     queue_item_id: str | None = None  # only present for requests from queue controller
     custom_data: dict[str, Any] | None = None  # optional - must be serializable
+    # queue_session_id: playback session that owns this media, used to build and validate
+    # the stream URL. Server-internal, so it must never reach a client. Not serialized.
+    queue_session_id: str | None = field(
+        default=None, metadata=field_options(serialize="omit"), repr=False
+    )
 
     # optional - elapsed playback time of the currently playing media
     elapsed_time: int | None = None

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -1,7 +1,7 @@
-"""Tests for the PlayerMedia model (stream_duration serialization/back-compat)."""
+"""Tests for the PlayerMedia model."""
 
-from music_assistant_models.enums import MediaType
-from music_assistant_models.player import PlayerMedia
+from music_assistant_models.enums import MediaType, PlayerType
+from music_assistant_models.player import DeviceInfo, Player, PlayerMedia
 
 
 def _media() -> PlayerMedia:
@@ -27,3 +27,33 @@ def test_payload_without_stream_duration_key_deserializes() -> None:
     legacy = _media().to_dict()
     legacy.pop("stream_duration", None)
     assert PlayerMedia.from_dict(legacy).stream_duration is None
+
+
+def test_queue_session_id_is_not_serialized() -> None:
+    """The queue session id is server-internal and must never reach a client."""
+    media = _media()
+    media.queue_session_id = "abcd1234"
+    assert "queue_session_id" not in media.to_dict()
+
+
+def test_queue_session_id_is_not_serialized_on_a_player() -> None:
+    """Players are what clients actually read, so the nested payload must be clean too."""
+    media = _media()
+    media.queue_session_id = "abcd1234"
+    player = Player(
+        player_id="p1",
+        provider="test",
+        type=PlayerType.PLAYER,
+        name="Test",
+        available=True,
+        device_info=DeviceInfo(),
+    )
+    player.current_media = media
+    assert "queue_session_id" not in player.to_dict()["current_media"]
+
+
+def test_queue_session_id_is_kept_out_of_repr() -> None:
+    """The value must not surface through logging that prints the media."""
+    media = _media()
+    media.queue_session_id = "abcd1234"
+    assert "abcd1234" not in repr(media)


### PR DESCRIPTION
# What does this implement/fix?

`PlayerMedia.custom_data` is serialized to API clients, and the server uses it to carry the
playback session id that builds and validates stream URLs. That is server-internal
bookkeeping, so it gets its own field that is left out of the payload.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] Any consumer of a changed model is updated, and the companion PR in `music-assistant/server` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
