### PR TITLE
Add a private flag to the player model

### DIFF
--- a/music_assistant_models/player.py
+++ b/music_assistant_models/player.py
@@ -386,6 +386,11 @@ class Player(DataClassDictMixin):
     # hide_in_ui: if the player should be hidden in the UI
     hide_in_ui: bool = False
 
+    # private: if the player must not be offered to other clients as a playback
+    # or grouping target, because it belongs to a single device (a web/app client)
+    # or is an internal anchor. Not user configurable, unlike hide_in_ui.
+    private: bool = False
+
     # expose_to_ha: if the player should be exposed to Home Assistant
     # if set to False, the player will not be added to the HA integration
     expose_to_ha: bool = True

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -1,4 +1,4 @@
-"""Tests for the PlayerMedia model."""
+"""Tests for the Player and PlayerMedia models (serialization/back-compat)."""
 
 from music_assistant_models.enums import MediaType, PlayerType
 from music_assistant_models.player import DeviceInfo, Player, PlayerMedia
@@ -6,6 +6,17 @@ from music_assistant_models.player import DeviceInfo, Player, PlayerMedia
 
 def _media() -> PlayerMedia:
     return PlayerMedia(uri="library://track/1", media_type=MediaType.TRACK, duration=300)
+
+
+def _player() -> Player:
+    return Player(
+        player_id="test_player",
+        provider="test_provider",
+        type=PlayerType.PLAYER,
+        name="Test Player",
+        available=True,
+        device_info=DeviceInfo(),
+    )
 
 
 def test_stream_duration_defaults_to_none() -> None:
@@ -40,14 +51,7 @@ def test_queue_session_id_is_not_serialized_on_a_player() -> None:
     """Players are what clients actually read, so the nested payload must be clean too."""
     media = _media()
     media.queue_session_id = "abcd1234"
-    player = Player(
-        player_id="p1",
-        provider="test",
-        type=PlayerType.PLAYER,
-        name="Test",
-        available=True,
-        device_info=DeviceInfo(),
-    )
+    player = _player()
     player.current_media = media
     assert "queue_session_id" not in player.to_dict()["current_media"]
 
@@ -57,3 +61,22 @@ def test_queue_session_id_is_kept_out_of_repr() -> None:
     media = _media()
     media.queue_session_id = "abcd1234"
     assert "abcd1234" not in repr(media)
+
+
+def test_private_defaults_to_false() -> None:
+    """A player is only private when its provider marks it as such."""
+    assert _player().private is False
+
+
+def test_private_serialize_roundtrip() -> None:
+    """A private player keeps the flag across serialization."""
+    player = _player()
+    player.private = True
+    assert Player.from_dict(player.to_dict()).private is True
+
+
+def test_payload_without_private_key_deserializes() -> None:
+    """Payloads from older servers without the private key still deserialize."""
+    legacy = _player().to_dict()
+    legacy.pop("private", None)
+    assert Player.from_dict(legacy).private is False


### PR DESCRIPTION
# What does this implement/fix?

Adds a `private` flag to the player model, so clients can tell the difference between a player a user chose to hide and a player that simply must not be offered to anyone else.

Today a client only sees `hide_in_ui`, which conflates two very different things: "I hid this speaker from my lists" and "this is someone's phone / an internal helper player". That forces UIs to hide both everywhere, so a speaker you hide also disappears from the group-member picker.

Consumed by the companion server and frontend PRs.

Rebased on #366, which landed in the same two files. The player test it added now shares the `_player()` helper instead of building its own player inline.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] Any consumer of a changed model is updated, and the companion PR in `music-assistant/server` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.

