### PR TITLE
Add is_realtime flag to StreamDetails

### DIFF
--- a/music_assistant_models/streamdetails.py
+++ b/music_assistant_models/streamdetails.py
@@ -169,6 +169,18 @@ class StreamDetails(DataClassDictMixin):
         repr=False,
     )
 
+    # is_realtime: bool to indicate that the source hands over its audio just-in-time,
+    # at (about) playback pace, instead of delivering it as fast as the connection allows.
+    # Radio streams and live audio sources are always realtime; a music provider should
+    # set this when its audio arrives from a paced source such as a local daemon.
+    # The server skips optimizations that assume a source can be read ahead of playback.
+    is_realtime: bool = field(
+        default=False,
+        compare=False,
+        metadata=field_options(serialize="omit", deserialize=pass_through),
+        repr=False,
+    )
+
     # expiration: time in seconds until the streamdetails expire
     expiration: int = field(
         default=600,  # 10 minutes

--- a/tests/test_streamdetails.py
+++ b/tests/test_streamdetails.py
@@ -57,6 +57,16 @@ def test_decoded_audio_format_is_not_serialized() -> None:
     assert "decoded_audio_format" not in sd.to_dict()
 
 
+def test_is_realtime_defaults_to_false() -> None:
+    """is_realtime defaults to False, so a source is read ahead unless it says otherwise."""
+    assert _make_streamdetails().is_realtime is False
+
+
+def test_is_realtime_is_not_serialized() -> None:
+    """is_realtime is server-internal and must not be sent to clients."""
+    assert "is_realtime" not in _make_streamdetails(is_realtime=True).to_dict()
+
+
 def test_legacy_dsp_is_not_serialized() -> None:
     """Legacy DSP details are not included in stream details."""
     assert "dsp" not in _make_streamdetails().to_dict()


### PR DESCRIPTION
# What does this implement/fix?

Some sources hand their audio to Music Assistant just-in-time, at about playback pace, instead of as fast as the connection allows: radio streams, live audio sources, and music providers that stream through a paced local daemon. The server currently assumes every source can be read ahead of playback, which costs those sources stability and startup time.

Adds `StreamDetails.is_realtime` (default `False`, server-side only, not sent to clients) so a provider can declare that its audio arrives at playback pace.

**Related issue (if applicable):**

- consumed by music-assistant/server#5848 (crossfade holdback, buffer thresholds and seek handling)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] Any consumer of a changed model is updated, and the companion PR in `music-assistant/server` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.