### PR TITLE
Add genre_alias_count to GenreSummary

### DIFF
--- a/music_assistant_models/media_items/summary.py
+++ b/music_assistant_models/media_items/summary.py
@@ -145,6 +145,10 @@ class PodcastSummary(_SummaryBase, Podcast):
 class GenreSummary(_SummaryBase, Genre):
     """Summary variant of Genre, used for listings."""
 
+    # number of mapped aliases, carried instead of the full genre_aliases list to keep
+    # listings slim; the genre's own name (stored inside genre_aliases) is not counted
+    genre_alias_count: int | None = None
+
 
 MediaItemSummaryType = (
     ArtistSummary

--- a/tests/test_summary_items.py
+++ b/tests/test_summary_items.py
@@ -148,6 +148,17 @@ def test_radio_defaults_to_a_live_stream() -> None:
     assert Radio.from_dict(payload).is_dynamic is False
 
 
+def test_genre_summary_carries_alias_count() -> None:
+    """The alias count round-trips and is omitted when unset."""
+    genre = GenreSummary(item_id="1", provider="library", name="Rock", genre_alias_count=154)
+    payload = genre.to_dict()
+    assert payload["genre_alias_count"] == 154
+    assert GenreSummary.from_dict(payload).genre_alias_count == 154
+    assert (
+        "genre_alias_count" not in GenreSummary(item_id="1", provider="library", name="R").to_dict()
+    )
+
+
 def test_per_type_summaries_serialize_sparse() -> None:
     """Every summary type serializes without None-valued keys."""
     items = [


### PR DESCRIPTION
# What does this implement/fix?

Adds an optional `genre_alias_count` field to `GenreSummary` so genre listings can carry just the mapped-alias count instead of the full `genre_aliases` list, which is ~29 KB of JSON for the default genre set alone. The genre's own name (stored inside `genre_aliases`) is excluded from the count. Part of fixing the genre management table showing 0 aliases for every genre.

**Related issue (if applicable):**

- related issue: none, reported on Discord
- related server PR https://github.com/music-assistant/server/pull/5858
- related frontend PR https://github.com/music-assistant/frontend/pull/2583

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] Any consumer of a changed model is updated, and the companion PR in `music-assistant/server` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
