### PR TITLE
Add queue delegation capability declarations for audio sources

### DIFF
--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -74,6 +74,9 @@ class SourceControl(StrEnum):
     NEXT = "next"
     PREVIOUS = "previous"
     SEEK = "seek"
+    STOP = "stop"
+    SHUFFLE = "shuffle"
+    REPEAT = "repeat"
     UNKNOWN = "unknown"
 
     @classmethod

--- a/music_assistant_models/media_items/__init__.py
+++ b/music_assistant_models/media_items/__init__.py
@@ -31,6 +31,7 @@ from .media_item import (
     Radio,
     RecommendationFolder,
     SoundEffect,
+    SourceQueueCapabilities,
     Track,
 )
 from .metadata import (
@@ -101,6 +102,7 @@ __all__ = [
     "RadioSummary",
     "RecommendationFolder",
     "SoundEffect",
+    "SourceQueueCapabilities",
     "SummaryDialect",
     "Track",
     "TrackSummary",

--- a/music_assistant_models/media_items/media_item.py
+++ b/music_assistant_models/media_items/media_item.py
@@ -536,6 +536,33 @@ class SoundEffect(_LocalizableName, MediaItem):
     media_type: MediaType = MediaType.SOUND_EFFECT
 
 
+@dataclass
+class SourceQueueCapabilities(DataClassDictMixin):
+    """
+    Queue commands a live AudioSource can handle natively (session-side).
+
+    Declared by the owning plugin on its AudioSource; the queue controller
+    delegates queue commands to the plugin and mirrors the session's state
+    back into the normal PlayerQueue view.
+    """
+
+    # provider domain whose items this source can play natively (e.g. "spotify")
+    provider_domain: str | None = None
+    # media types accepted by a play/replace redirect into the session
+    playable_media_types: list[MediaType] = field(default_factory=list)
+    # media types accepted by enqueue-to-session (e.g. Spotify: tracks only)
+    enqueueable_media_types: list[MediaType] = field(default_factory=list)
+    can_shuffle: bool = False
+    can_repeat: bool = False
+    # source pushes a queue view (previous/upcoming) that MA can mirror
+    provides_queue_view: bool = False
+    # declarative: the session provides these natively, so MA's own
+    # equivalents are inert while the source owns the queue
+    native_autoplay: bool = False
+    native_crossfade: bool = False
+    native_volume_normalization: bool = False
+
+
 @dataclass(kw_only=True)
 class AudioSource(MediaItem):
     """
@@ -581,6 +608,14 @@ class AudioSource(MediaItem):
     # plugin's get_stream_details must raise (AudioError) when it cannot
     # actually acquire the upstream producer.
     can_initiate: bool = False
+
+    # queue commands the source's session handles natively;
+    # None = transport-only source (no queue delegation)
+    queue_capabilities: SourceQueueCapabilities | None = None
+
+    # the service account the session is paired to, once known/verified
+    # (e.g. the Spotify user id); used to gate playback redirects
+    account_id: str | None = None
 
 
 @dataclass(kw_only=True)

--- a/music_assistant_models/media_items/media_item.py
+++ b/music_assistant_models/media_items/media_item.py
@@ -536,7 +536,7 @@ class SoundEffect(_LocalizableName, MediaItem):
     media_type: MediaType = MediaType.SOUND_EFFECT
 
 
-@dataclass
+@dataclass(kw_only=True)
 class SourceQueueCapabilities(DataClassDictMixin):
     """
     Queue commands a live AudioSource can handle natively (session-side).

--- a/music_assistant_models/player_queue.py
+++ b/music_assistant_models/player_queue.py
@@ -80,6 +80,11 @@ class PlayerQueue(DataClassDictMixin):
     # True when the queue is in dynamic mode (one or more dynamic sources); set by the server.
     # Implies autoplay and smart shuffle are active.
     is_dynamic: bool = False
+    # queue_owner: set to the owning AudioSource's uri while queue commands are delegated
+    # to an external session (the source declares queue_capabilities); None = MA owns the
+    # queue (default). Read-only, set by the server; clients use it to render mirrored
+    # items read-only and hide controls the external session handles natively.
+    queue_owner: str | None = None
 
     # extra_attributes: additional attributes for this player_queue to store/forward
     # additional data that is not part of the standard model

--- a/tests/test_audio_source.py
+++ b/tests/test_audio_source.py
@@ -4,6 +4,7 @@ from music_assistant_models.enums import MediaType, SourceControl
 from music_assistant_models.media_items import (
     AudioSource,
     ItemMapping,
+    SourceQueueCapabilities,
     media_from_dict,
 )
 from music_assistant_models.media_items.provider_mapping import ProviderMapping
@@ -84,3 +85,65 @@ def test_item_mapping_for_audio_source() -> None:
     mapping = ItemMapping.from_item(_make_audio_source())
     assert mapping.media_type == MediaType.AUDIO_SOURCE
     assert mapping.item_id == "airplay-living-room"
+
+
+def test_source_control_queue_members() -> None:
+    """The queue-delegation SourceControl members round-trip through StrEnum."""
+    assert SourceControl("stop") is SourceControl.STOP
+    assert SourceControl("shuffle") is SourceControl.SHUFFLE
+    assert SourceControl("repeat") is SourceControl.REPEAT
+
+
+def test_audio_source_queue_capability_defaults() -> None:
+    """A plain AudioSource is transport-only: no queue capabilities, no account."""
+    item = _make_audio_source()
+    assert item.queue_capabilities is None
+    assert item.account_id is None
+    caps = SourceQueueCapabilities()
+    assert caps.provider_domain is None
+    assert caps.playable_media_types == []
+    assert caps.enqueueable_media_types == []
+    assert caps.can_shuffle is False
+    assert caps.can_repeat is False
+    assert caps.provides_queue_view is False
+    assert caps.native_autoplay is False
+    assert caps.native_crossfade is False
+    assert caps.native_volume_normalization is False
+
+
+def test_audio_source_queue_capabilities_roundtrip() -> None:
+    """queue_capabilities and account_id survive a serialize round-trip."""
+    original = _make_audio_source()
+    original.queue_capabilities = SourceQueueCapabilities(
+        provider_domain="spotify",
+        playable_media_types=[MediaType.TRACK, MediaType.ALBUM, MediaType.PLAYLIST],
+        enqueueable_media_types=[MediaType.TRACK],
+        can_shuffle=True,
+        can_repeat=True,
+        provides_queue_view=True,
+        native_autoplay=True,
+        native_crossfade=True,
+        native_volume_normalization=True,
+    )
+    original.account_id = "spotify-user-1"
+    data = original.to_dict()
+    restored = AudioSource.from_dict(data)
+    assert restored.to_dict() == data
+    assert restored.queue_capabilities is not None
+    assert restored.queue_capabilities.provider_domain == "spotify"
+    assert restored.queue_capabilities.playable_media_types == [
+        MediaType.TRACK,
+        MediaType.ALBUM,
+        MediaType.PLAYLIST,
+    ]
+    assert restored.account_id == "spotify-user-1"
+
+
+def test_audio_source_payload_without_queue_capability_keys() -> None:
+    """Payloads from servers predating queue delegation still deserialize."""
+    data = _make_audio_source().to_dict()
+    data.pop("queue_capabilities", None)
+    data.pop("account_id", None)
+    restored = AudioSource.from_dict(data)
+    assert restored.queue_capabilities is None
+    assert restored.account_id is None

--- a/tests/test_player_queue.py
+++ b/tests/test_player_queue.py
@@ -68,6 +68,26 @@ def test_payload_without_overlay_keys_deserializes() -> None:
     assert restored.overlay_volume == 100
 
 
+def test_queue_owner_defaults_to_none() -> None:
+    """queue_owner defaults to None (MA owns the queue)."""
+    assert _queue().queue_owner is None
+
+
+def test_queue_owner_serialize_roundtrip() -> None:
+    """queue_owner survives a serialize round-trip."""
+    queue = _queue()
+    queue.queue_owner = "spotify_connect://audio_source/main"
+    restored = PlayerQueue.from_dict(queue.to_dict())
+    assert restored.queue_owner == "spotify_connect://audio_source/main"
+
+
+def test_payload_without_queue_owner_key_deserializes() -> None:
+    """Payloads from servers predating queue delegation still deserialize."""
+    data = _queue().to_dict()
+    data.pop("queue_owner", None)
+    assert PlayerQueue.from_dict(data).queue_owner is None
+
+
 def test_ended_defaults_to_false() -> None:
     """A fresh queue has not ended."""
     assert _queue().ended is False


### PR DESCRIPTION
# What does this implement/fix?

Adds the model-level declarations that let a live audio source (e.g. a Spotify Connect session) own queue commands, so the Music Assistant queue can delegate to it and mirror its state:

- `SourceQueueCapabilities` dataclass + `queue_capabilities` and `account_id` fields on `AudioSource` — the owning plugin declares which queue commands the session handles natively (play/enqueue per media type, shuffle, repeat, queue view, native autoplay/crossfade/normalization) and which service account it is paired to.
- `SourceControl` gains `STOP`, `SHUFFLE` and `REPEAT` members.
- `PlayerQueue.queue_owner` — set by the server while queue commands are delegated to an external session; clients use it to render mirrored items read-only and hide controls the session handles natively.

All additions are optional with defaults, so existing clients and payloads are unaffected.

**Related issue (if applicable):**

- Groundwork for the Spotify Connect playback redirect in `music-assistant/server` (design doc in the server repo; companion server PR follows).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] Any consumer of a changed model is updated, and the companion PR in `music-assistant/server` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
