### PR TITLE
Add transcript fields to media item metadata

### DIFF
--- a/music_assistant_models/media_items/__init__.py
+++ b/music_assistant_models/media_items/__init__.py
@@ -42,6 +42,7 @@ from .metadata import (
     MediaItemLink,
     MediaItemMetadata,
     MediaItemPalette,
+    MediaItemTranscriptCue,
 )
 from .provider_mapping import ProviderMapping
 from .summary import (
@@ -85,6 +86,7 @@ __all__ = [
     "MediaItemMetadataSummary",
     "MediaItemPalette",
     "MediaItemSummaryType",
+    "MediaItemTranscriptCue",
     "MediaItemType",
     "Metadata",
     "MetadataProvider",

--- a/music_assistant_models/media_items/metadata.py
+++ b/music_assistant_models/media_items/metadata.py
@@ -116,6 +116,16 @@ class MediaItemChapter(DataClassDictMixin):
 
 
 @dataclass(frozen=True, kw_only=True)
+class MediaItemTranscriptCue(DataClassDictMixin):
+    """Model for a single timed cue of a MediaItem's transcript."""
+
+    start: float  # start position in seconds
+    end: float | None = None  # end position in seconds if known
+    text: str  # spoken text of this cue
+    speaker: str | None = None  # speaker name/label if the source identifies one
+
+
+@dataclass(frozen=True, kw_only=True)
 class MediaItemCollection(DataClassDictMixin):
     """
     Model for a MediaItem's collection.
@@ -183,6 +193,12 @@ class MediaItemMetadata(DataClassDictMixin):
     copyright: str | None = None
     lyrics: str | None = None  # tracks only
     lrc_lyrics: str | None = None  # tracks only
+    # transcript of the spoken content, most commonly used for podcast episodes
+    transcript: str | None = None
+    # transcript split into timed cues, sorted by start position
+    transcript_cues: list[MediaItemTranscriptCue] | None = None
+    # whether a transcript is available, set to None if the provider cannot tell
+    has_transcript: bool | None = None
     label: str | None = None
     links: set[MediaItemLink] | None = None
     performers: set[str] | None = None


### PR DESCRIPTION
# What does this implement/fix?

Looking to add support for Podcast transcripts as requested here https://github.com/orgs/music-assistant/discussions/4767

Research shows podcast episodes can carry a transcript, either supplied by the publisher via the podcast:transcript RSS tag or generated by the podcast service. Podcast episodes can come with a transcript. Publishers supply one through the `podcast:transcript` RSS tag, and some podcast services generate their own. There is currently nowhere in the models to put it, so the server throws that information away.

This adds the fields so the server and frontend can carry a transcript around:

- `MediaItemTranscriptCue`, a single timed line of a transcript, with an optional speaker label
- `MediaItemMetadata.transcript`, the readable text
- `MediaItemMetadata.transcript_cues`, the same text split into timed cues so a client can follow along with playback
- `MediaItemMetadata.has_transcript`, whether one is available at all, left as `None` when the provider cannot tell without fetching it

All three default to `None`, so nothing changes for existing consumers.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] Any consumer of a changed model is updated, and the companion PR in `music-assistant/server` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
