### PR TITLE
Move live source shuffle and repeat onto the source models

### DIFF
--- a/music_assistant_models/media_items/__init__.py
+++ b/music_assistant_models/media_items/__init__.py
@@ -31,7 +31,6 @@ from .media_item import (
     Radio,
     RecommendationFolder,
     SoundEffect,
-    SourceQueueCapabilities,
     Track,
 )
 from .metadata import (
@@ -104,7 +103,6 @@ __all__ = [
     "RadioSummary",
     "RecommendationFolder",
     "SoundEffect",
-    "SourceQueueCapabilities",
     "SummaryDialect",
     "Track",
     "TrackSummary",

--- a/music_assistant_models/media_items/media_item.py
+++ b/music_assistant_models/media_items/media_item.py
@@ -537,33 +537,6 @@ class SoundEffect(_LocalizableName, MediaItem):
 
 
 @dataclass(kw_only=True)
-class SourceQueueCapabilities(DataClassDictMixin):
-    """
-    Queue commands a live AudioSource can handle natively (session-side).
-
-    Declared by the owning plugin on its AudioSource; the queue controller
-    delegates queue commands to the plugin and mirrors the session's state
-    back into the normal PlayerQueue view.
-    """
-
-    # provider domain whose items this source can play natively (e.g. "spotify")
-    provider_domain: str | None = None
-    # media types accepted by a play/replace redirect into the session
-    playable_media_types: list[MediaType] = field(default_factory=list)
-    # media types accepted by enqueue-to-session (e.g. Spotify: tracks only)
-    enqueueable_media_types: list[MediaType] = field(default_factory=list)
-    can_shuffle: bool = False
-    can_repeat: bool = False
-    # source pushes a queue view (previous/upcoming) that MA can mirror
-    provides_queue_view: bool = False
-    # declarative: the session provides these natively, so MA's own
-    # equivalents are inert while the source owns the queue
-    native_autoplay: bool = False
-    native_crossfade: bool = False
-    native_volume_normalization: bool = False
-
-
-@dataclass(kw_only=True)
 class AudioSource(MediaItem):
     """
     Model for a live audio source provided by a plugin.
@@ -589,6 +562,9 @@ class AudioSource(MediaItem):
     can_play_pause: bool = False
     can_seek: bool = False
     can_next_previous: bool = False
+    # the source orders its own content, so shuffle/repeat reach its session
+    can_shuffle: bool = False
+    can_repeat: bool = False
 
     # whether this source allows only a single concurrent consumer
     # True (default) = MA fans the single stream out via sync-group machinery
@@ -608,10 +584,6 @@ class AudioSource(MediaItem):
     # plugin's get_stream_details must raise (AudioError) when it cannot
     # actually acquire the upstream producer.
     can_initiate: bool = False
-
-    # queue commands the source's session handles natively;
-    # None = transport-only source (no queue delegation)
-    queue_capabilities: SourceQueueCapabilities | None = None
 
     # the service account the session is paired to, once known/verified
     # (e.g. the Spotify user id); used to gate playback redirects

--- a/music_assistant_models/player.py
+++ b/music_assistant_models/player.py
@@ -10,7 +10,14 @@ from typing import Any
 from mashumaro import DataClassDictMixin, field_options
 
 from .constants import EXTRA_ATTRIBUTES_TYPES, PLAYER_CONTROL_NONE
-from .enums import IdentifierType, MediaType, PlaybackState, PlayerFeature, PlayerType
+from .enums import (
+    IdentifierType,
+    MediaType,
+    PlaybackState,
+    PlayerFeature,
+    PlayerType,
+    RepeatMode,
+)
 from .media_items import MediaItemPalette
 from .translations import resolve_translation, translations_active
 from .unique_list import UniqueList
@@ -154,6 +161,13 @@ class PlayerSource(DataClassDictMixin):
     can_seek: bool = False
     # can_next_previous: this source can be skipped to next/previous item
     can_next_previous: bool = False
+    # can_shuffle/can_repeat: this source orders its own content, so the
+    # commands below reach the session producing the audio
+    can_shuffle: bool = False
+    can_repeat: bool = False
+    # the ordering the source reports for itself; None = it has not said
+    shuffle_enabled: bool | None = None
+    repeat_mode: RepeatMode | None = None
 
     def __hash__(self) -> int:
         """Return custom hash."""

--- a/music_assistant_models/player.py
+++ b/music_assistant_models/player.py
@@ -168,6 +168,13 @@ class PlayerSource(DataClassDictMixin):
     # the ordering the source reports for itself; None = it has not said
     shuffle_enabled: bool | None = None
     repeat_mode: RepeatMode | None = None
+    # whether the source crossfades its own playback, so Music Assistant's own
+    # crossfade is inert while it plays. None = it has not said and cannot be
+    # asked (a native device's own setting), which is distinct from a known
+    # False — clients must not render "off" for a source that simply cannot tell
+    # them. Known either way for a session Music Assistant spawns itself, since
+    # it writes the preference before playback starts.
+    native_crossfade: bool | None = None
 
     def __hash__(self) -> int:
         """Return custom hash."""

--- a/music_assistant_models/player.py
+++ b/music_assistant_models/player.py
@@ -175,6 +175,12 @@ class PlayerSource(DataClassDictMixin):
     # them. Known either way for a session Music Assistant spawns itself, since
     # it writes the preference before playback starts.
     native_crossfade: bool | None = None
+    # the service account this source is signed in to, once established (e.g. a
+    # Spotify user id). Lives here as well as on AudioSource because a source the
+    # device runs natively has no AudioSource to carry it. None = not established,
+    # in which case anything gated on the account matching must refuse rather
+    # than guess.
+    account_id: str | None = None
 
     def __hash__(self) -> int:
         """Return custom hash."""

--- a/music_assistant_models/player_queue.py
+++ b/music_assistant_models/player_queue.py
@@ -80,12 +80,6 @@ class PlayerQueue(DataClassDictMixin):
     # True when the queue is in dynamic mode (one or more dynamic sources); set by the server.
     # Implies autoplay and smart shuffle are active.
     is_dynamic: bool = False
-    # queue_owner: set to the owning AudioSource's uri while queue commands are delegated
-    # to an external session; None = MA owns the queue (default). Read-only, set by the
-    # server; clients use it to render mirrored items read-only and hide controls the
-    # external session handles natively.
-    queue_owner: str | None = None
-
     # extra_attributes: additional attributes for this player_queue to store/forward
     # additional data that is not part of the standard model
     # must be serializable types only

--- a/music_assistant_models/player_queue.py
+++ b/music_assistant_models/player_queue.py
@@ -81,9 +81,9 @@ class PlayerQueue(DataClassDictMixin):
     # Implies autoplay and smart shuffle are active.
     is_dynamic: bool = False
     # queue_owner: set to the owning AudioSource's uri while queue commands are delegated
-    # to an external session (the source declares queue_capabilities); None = MA owns the
-    # queue (default). Read-only, set by the server; clients use it to render mirrored
-    # items read-only and hide controls the external session handles natively.
+    # to an external session; None = MA owns the queue (default). Read-only, set by the
+    # server; clients use it to render mirrored items read-only and hide controls the
+    # external session handles natively.
     queue_owner: str | None = None
 
     # extra_attributes: additional attributes for this player_queue to store/forward

--- a/tests/test_audio_source.py
+++ b/tests/test_audio_source.py
@@ -4,7 +4,6 @@ from music_assistant_models.enums import MediaType, SourceControl
 from music_assistant_models.media_items import (
     AudioSource,
     ItemMapping,
-    SourceQueueCapabilities,
     media_from_dict,
 )
 from music_assistant_models.media_items.provider_mapping import ProviderMapping
@@ -94,56 +93,35 @@ def test_source_control_queue_members() -> None:
     assert SourceControl("repeat") is SourceControl.REPEAT
 
 
-def test_audio_source_queue_capability_defaults() -> None:
-    """A plain AudioSource is transport-only: no queue capabilities, no account."""
+def test_audio_source_ordering_capability_defaults() -> None:
+    """A plain AudioSource orders nothing itself and is paired to no account."""
     item = _make_audio_source()
-    assert item.queue_capabilities is None
+    assert item.can_shuffle is False
+    assert item.can_repeat is False
     assert item.account_id is None
-    caps = SourceQueueCapabilities()
-    assert caps.provider_domain is None
-    assert caps.playable_media_types == []
-    assert caps.enqueueable_media_types == []
-    assert caps.can_shuffle is False
-    assert caps.can_repeat is False
-    assert caps.provides_queue_view is False
-    assert caps.native_autoplay is False
-    assert caps.native_crossfade is False
-    assert caps.native_volume_normalization is False
 
 
-def test_audio_source_queue_capabilities_roundtrip() -> None:
-    """queue_capabilities and account_id survive a serialize round-trip."""
+def test_audio_source_ordering_capabilities_roundtrip() -> None:
+    """The ordering flags and account_id survive a serialize round-trip."""
     original = _make_audio_source()
-    original.queue_capabilities = SourceQueueCapabilities(
-        provider_domain="spotify",
-        playable_media_types=[MediaType.TRACK, MediaType.ALBUM, MediaType.PLAYLIST],
-        enqueueable_media_types=[MediaType.TRACK],
-        can_shuffle=True,
-        can_repeat=True,
-        provides_queue_view=True,
-        native_autoplay=True,
-        native_crossfade=True,
-        native_volume_normalization=True,
-    )
+    original.can_shuffle = True
+    original.can_repeat = True
     original.account_id = "spotify-user-1"
     data = original.to_dict()
     restored = AudioSource.from_dict(data)
     assert restored.to_dict() == data
-    assert restored.queue_capabilities is not None
-    assert restored.queue_capabilities.provider_domain == "spotify"
-    assert restored.queue_capabilities.playable_media_types == [
-        MediaType.TRACK,
-        MediaType.ALBUM,
-        MediaType.PLAYLIST,
-    ]
+    assert restored.can_shuffle is True
+    assert restored.can_repeat is True
     assert restored.account_id == "spotify-user-1"
 
 
-def test_audio_source_payload_without_queue_capability_keys() -> None:
-    """Payloads from servers predating queue delegation still deserialize."""
+def test_audio_source_payload_without_ordering_keys() -> None:
+    """Payloads from servers predating the ordering flags still deserialize."""
     data = _make_audio_source().to_dict()
-    data.pop("queue_capabilities", None)
+    data.pop("can_shuffle", None)
+    data.pop("can_repeat", None)
     data.pop("account_id", None)
     restored = AudioSource.from_dict(data)
-    assert restored.queue_capabilities is None
+    assert restored.can_shuffle is False
+    assert restored.can_repeat is False
     assert restored.account_id is None

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -91,6 +91,7 @@ def test_player_source_ordering_defaults() -> None:
     # must not read as "shuffle off"
     assert source.shuffle_enabled is None
     assert source.repeat_mode is None
+    assert source.native_crossfade is None
 
 
 def test_player_source_ordering_roundtrip() -> None:
@@ -102,20 +103,42 @@ def test_player_source_ordering_roundtrip() -> None:
         can_repeat=True,
         shuffle_enabled=True,
         repeat_mode=RepeatMode.ALL,
+        native_crossfade=True,
     )
     data = original.to_dict()
     restored = PlayerSource.from_dict(data)
     assert restored.to_dict() == data
     assert restored.shuffle_enabled is True
     assert restored.repeat_mode is RepeatMode.ALL
+    assert restored.native_crossfade is True
 
 
 def test_player_source_payload_without_ordering_keys() -> None:
     """Payloads from servers predating the ordering fields still deserialize."""
     data = PlayerSource(id="line-in", name="Line In").to_dict()
-    for key in ("can_shuffle", "can_repeat", "shuffle_enabled", "repeat_mode"):
+    for key in (
+        "can_shuffle",
+        "can_repeat",
+        "shuffle_enabled",
+        "repeat_mode",
+        "native_crossfade",
+    ):
         data.pop(key, None)
     restored = PlayerSource.from_dict(data)
     assert restored.can_shuffle is False
     assert restored.shuffle_enabled is None
     assert restored.repeat_mode is None
+    assert restored.native_crossfade is None
+
+
+def test_player_source_known_off_is_not_unknown() -> None:
+    """A source reporting crossfade off is distinct from one that cannot say."""
+    known_off = PlayerSource(id="spotify", name="Spotify", native_crossfade=False)
+    cannot_say = PlayerSource(id="line-in", name="Line In")
+
+    # a client renders "off" for the first and nothing for the second, so these
+    # must survive the wire as different values rather than collapsing to falsy
+    assert known_off.native_crossfade is False
+    assert cannot_say.native_crossfade is None
+    assert PlayerSource.from_dict(known_off.to_dict()).native_crossfade is False
+    assert PlayerSource.from_dict(cannot_say.to_dict()).native_crossfade is None

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -1,7 +1,7 @@
 """Tests for the Player and PlayerMedia models (serialization/back-compat)."""
 
-from music_assistant_models.enums import MediaType, PlayerType
-from music_assistant_models.player import DeviceInfo, Player, PlayerMedia
+from music_assistant_models.enums import MediaType, PlayerType, RepeatMode
+from music_assistant_models.player import DeviceInfo, Player, PlayerMedia, PlayerSource
 
 
 def _media() -> PlayerMedia:
@@ -80,3 +80,42 @@ def test_payload_without_private_key_deserializes() -> None:
     legacy = _player().to_dict()
     legacy.pop("private", None)
     assert Player.from_dict(legacy).private is False
+
+
+def test_player_source_ordering_defaults() -> None:
+    """A source orders nothing and reports no ordering state until it says so."""
+    source = PlayerSource(id="airplay", name="AirPlay")
+    assert source.can_shuffle is False
+    assert source.can_repeat is False
+    # None rather than a default: an ordering source that has not reported yet
+    # must not read as "shuffle off"
+    assert source.shuffle_enabled is None
+    assert source.repeat_mode is None
+
+
+def test_player_source_ordering_roundtrip() -> None:
+    """The ordering capability and reported state survive a round-trip."""
+    original = PlayerSource(
+        id="spotify://audio_source/main",
+        name="Spotify Connect",
+        can_shuffle=True,
+        can_repeat=True,
+        shuffle_enabled=True,
+        repeat_mode=RepeatMode.ALL,
+    )
+    data = original.to_dict()
+    restored = PlayerSource.from_dict(data)
+    assert restored.to_dict() == data
+    assert restored.shuffle_enabled is True
+    assert restored.repeat_mode is RepeatMode.ALL
+
+
+def test_player_source_payload_without_ordering_keys() -> None:
+    """Payloads from servers predating the ordering fields still deserialize."""
+    data = PlayerSource(id="line-in", name="Line In").to_dict()
+    for key in ("can_shuffle", "can_repeat", "shuffle_enabled", "repeat_mode"):
+        data.pop(key, None)
+    restored = PlayerSource.from_dict(data)
+    assert restored.can_shuffle is False
+    assert restored.shuffle_enabled is None
+    assert restored.repeat_mode is None

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -92,6 +92,7 @@ def test_player_source_ordering_defaults() -> None:
     assert source.shuffle_enabled is None
     assert source.repeat_mode is None
     assert source.native_crossfade is None
+    assert source.account_id is None
 
 
 def test_player_source_ordering_roundtrip() -> None:
@@ -104,6 +105,7 @@ def test_player_source_ordering_roundtrip() -> None:
         shuffle_enabled=True,
         repeat_mode=RepeatMode.ALL,
         native_crossfade=True,
+        account_id="spotify-user-1",
     )
     data = original.to_dict()
     restored = PlayerSource.from_dict(data)
@@ -111,6 +113,7 @@ def test_player_source_ordering_roundtrip() -> None:
     assert restored.shuffle_enabled is True
     assert restored.repeat_mode is RepeatMode.ALL
     assert restored.native_crossfade is True
+    assert restored.account_id == "spotify-user-1"
 
 
 def test_player_source_payload_without_ordering_keys() -> None:
@@ -122,6 +125,7 @@ def test_player_source_payload_without_ordering_keys() -> None:
         "shuffle_enabled",
         "repeat_mode",
         "native_crossfade",
+        "account_id",
     ):
         data.pop(key, None)
     restored = PlayerSource.from_dict(data)
@@ -129,6 +133,7 @@ def test_player_source_payload_without_ordering_keys() -> None:
     assert restored.shuffle_enabled is None
     assert restored.repeat_mode is None
     assert restored.native_crossfade is None
+    assert restored.account_id is None
 
 
 def test_player_source_known_off_is_not_unknown() -> None:

--- a/tests/test_player_queue.py
+++ b/tests/test_player_queue.py
@@ -68,26 +68,6 @@ def test_payload_without_overlay_keys_deserializes() -> None:
     assert restored.overlay_volume == 100
 
 
-def test_queue_owner_defaults_to_none() -> None:
-    """queue_owner defaults to None (MA owns the queue)."""
-    assert _queue().queue_owner is None
-
-
-def test_queue_owner_serialize_roundtrip() -> None:
-    """queue_owner survives a serialize round-trip."""
-    queue = _queue()
-    queue.queue_owner = "spotify_connect://audio_source/main"
-    restored = PlayerQueue.from_dict(queue.to_dict())
-    assert restored.queue_owner == "spotify_connect://audio_source/main"
-
-
-def test_payload_without_queue_owner_key_deserializes() -> None:
-    """Payloads from servers predating queue delegation still deserialize."""
-    data = _queue().to_dict()
-    data.pop("queue_owner", None)
-    assert PlayerQueue.from_dict(data).queue_owner is None
-
-
 def test_ended_defaults_to_false() -> None:
     """A fresh queue has not ended."""
     assert _queue().ended is False


### PR DESCRIPTION
# What does this implement/fix?

Shuffle and repeat for a live external source (Spotify Connect, AirPlay, …) now live on the source itself instead of in a nested capabilities object.

Server PR music-assistant/server#5914 makes a live source a source on the *player* rather than an item in its queue. The queue controller no longer delegates queue commands to it, which leaves `SourceQueueCapabilities` with no reader at all — and leaves clients with no way to see whether a source can be shuffled, or what its ordering currently is. Both move onto `AudioSource` and `PlayerSource`, next to the transport flags that were already there.

**Related issue (if applicable):**

- n/a

- `AudioSource` gains `can_shuffle` / `can_repeat`, alongside the existing `can_play_pause` / `can_seek` / `can_next_previous`
- `PlayerSource` gains the same two flags plus `shuffle_enabled` / `repeat_mode`, so a client can render the live source's real ordering state (`None` = the source has not reported it)
- `SourceQueueCapabilities` and `AudioSource.queue_capabilities` are removed
- `PlayerSource` also gains `native_crossfade` — whether the source crossfades its own playback, so Music Assistant's own crossfade is inert while it plays (`None` = a native device that cannot be asked, which is not the same as a known off)
- `PlayerSource` also gains `account_id` — the service account the source is signed in to, for a source the device runs natively and so has no `AudioSource` to carry it (`None` = not established, so anything gated on it refuses rather than guesses)
- `PlayerQueue.queue_owner` is removed: there is no queue someone else owns, only another source active on the player

`SourceQueueCapabilities` only ever existed in 1.1.190–1.1.194 and its only consumer is the server's queue-delegation path, which music-assistant/server#5914 removes in the same cycle — so that PR carries the pin bump for this one. Nothing released depends on the removed class.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] Any consumer of a changed model is updated, and the companion PR in `music-assistant/server` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.



