### PR TITLE
Add task reports

### DIFF
--- a/music_assistant_models/background_task.py
+++ b/music_assistant_models/background_task.py
@@ -158,8 +158,6 @@ class BackgroundTask(DataClassDictMixin):
     failure_messages: list[str] = field(default_factory=list)
     # Extra JSON-serializable context used for filtering and UI display.
     metadata: TaskMetadata = field(default_factory=dict)
-    # Human-readable Markdown produced by the task for trusted Music Assistant clients to render.
-    report: str | None = None
     # Integer completion percentage. `None` means indeterminate.
     progress: int | None = None
     # Human-readable phase text for the current run.
@@ -168,6 +166,8 @@ class BackgroundTask(DataClassDictMixin):
     allow_retry: bool = False
     # Whether queued/running work can be interrupted from the UI.
     allow_cancel: bool = True
+    # Human-readable Markdown produced by the task for trusted Music Assistant clients to render.
+    report: str | None = None
     # translation_owner: namespace ("provider.<domain>"/"core.<domain>") the task's
     # translation_key resolves under; stamped by the tasks controller. Not serialized.
     translation_owner: str | None = field(

--- a/music_assistant_models/background_task.py
+++ b/music_assistant_models/background_task.py
@@ -158,6 +158,8 @@ class BackgroundTask(DataClassDictMixin):
     failure_messages: list[str] = field(default_factory=list)
     # Extra JSON-serializable context used for filtering and UI display.
     metadata: TaskMetadata = field(default_factory=dict)
+    # Human-readable Markdown produced by the task for trusted Music Assistant clients to render.
+    report: str | None = None
     # Integer completion percentage. `None` means indeterminate.
     progress: int | None = None
     # Human-readable phase text for the current run.

--- a/tests/test_background_task.py
+++ b/tests/test_background_task.py
@@ -1,0 +1,34 @@
+"""Tests for background task serialization."""
+
+from music_assistant_models.background_task import BackgroundTask
+
+
+def test_report_defaults_to_none() -> None:
+    """A task has no report until its work produces one."""
+    task = BackgroundTask(name="Test task")
+
+    assert task.report is None
+    assert task.to_dict()["report"] is None
+
+
+def test_markdown_report_roundtrip() -> None:
+    """Markdown reports survive serialization without transformation."""
+    report = "## Migration complete\n\n- Imported: **12**\n- Skipped: `2`"
+    task = BackgroundTask(
+        name="Import playlists",
+        metadata={"imported": 12, "skipped": 2},
+        report=report,
+    )
+
+    restored = BackgroundTask.from_dict(task.to_dict())
+
+    assert restored.report == report
+    assert restored.metadata == {"imported": 12, "skipped": 2}
+
+
+def test_payload_without_report_deserializes() -> None:
+    """Payloads created before report support retain the default."""
+    payload = BackgroundTask(name="Legacy task").to_dict()
+    payload.pop("report")
+
+    assert BackgroundTask.from_dict(payload).report is None

--- a/tests/test_background_task.py
+++ b/tests/test_background_task.py
@@ -28,7 +28,6 @@ def test_markdown_report_roundtrip() -> None:
 
 def test_payload_without_report_deserializes() -> None:
     """Payloads created before report support retain the default."""
-    payload = BackgroundTask(name="Legacy task").to_dict()
-    payload.pop("report")
+    payload = {"name": "Legacy task", "id": "legacy-task", "status": "pending"}
 
     assert BackgroundTask.from_dict(payload).report is None


### PR DESCRIPTION
# What does this implement/fix?

Managed tasks need a human-readable completion report.

- Add an optional Markdown report field to background tasks.
- Preserve backward-compatible serialization for existing payloads.

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] Any consumer of a changed model is updated, and the companion PR in `music-assistant/server` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.