### PR TITLE
Add normalization and crossfade modes for processing done at the source

### DIFF
--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -414,6 +414,9 @@ class CrossfadeMode(StrEnum):
     SMART_CROSSFADE = "smart_crossfade"  # Use smart crossfade with beat matching and EQ filters
     STANDARD_CROSSFADE = "standard_crossfade"  # Use standard crossfade only
     DISABLED = "disabled"  # No crossfade
+    # The source crossfades its own playback, so the server does not. Distinct
+    # from DISABLED, which means nothing is crossfading at all.
+    SOURCE = "source"
     UNKNOWN = "unknown"
 
     @classmethod

--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -870,6 +870,10 @@ class VolumeNormalizationMode(StrEnum):
     FALLBACK_FIXED_GAIN = "fallback_fixed_gain"
     FIXED_GAIN = "fixed_gain"
     FALLBACK_DYNAMIC = "fallback_dynamic"
+    # the source delivers its audio at a loudness target of its own, so the
+    # server leaves the level alone. Distinct from DISABLED, which means nothing
+    # normalized it at all - the audio here is normalized, just not by us.
+    SOURCE = "source"
 
     # fallback
     UNKNOWN = "unknown"

--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -873,9 +873,9 @@ class VolumeNormalizationMode(StrEnum):
     FALLBACK_FIXED_GAIN = "fallback_fixed_gain"
     FIXED_GAIN = "fixed_gain"
     FALLBACK_DYNAMIC = "fallback_dynamic"
-    # the source delivers its audio at a loudness target of its own, so the
+    # The source delivers its audio at a loudness target of its own, so the
     # server leaves the level alone. Distinct from DISABLED, which means nothing
-    # normalized it at all - the audio here is normalized, just not by us.
+    # normalized it at all: this audio is normalized, just not by us.
     SOURCE = "source"
 
     # fallback


### PR DESCRIPTION
# What does this implement/fix?

Adds a `SOURCE` value to `VolumeNormalizationMode` and to `CrossfadeMode`, for audio where the source has already done that step itself.

Some sources normalize loudness and crossfade their own playback — Spotify's playback engine is the case in hand — and doing either again on top means doing it twice. The server can already skip both, but the only outcome it can report is `DISABLED`, which the models themselves define as "nothing is happening" (`AudioQueueProcessing.crossfade_mode` is commented "DISABLED means no crossfade is active"). So the stream-path view shows those steps as off while the audio really is normalized and crossfaded — just not by us. These values give that case a name, so clients can say which of the two is doing it.

Additive: existing values are untouched, and clients that do not know the new ones fall through to `UNKNOWN` as usual.

**Related issue (if applicable):**

- companion server PR: https://github.com/music-assistant/server/pull/5918

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] Any consumer of a changed model is updated, and the companion PR in `music-assistant/server` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
