### PR TITLE
Compare audio formats on their content type

### DIFF
--- a/music_assistant_models/media_items/audio_format.py
+++ b/music_assistant_models/media_items/audio_format.py
@@ -62,10 +62,16 @@ class AudioFormat(DataClassDictMixin):
         return int(self.sample_rate * (self.bit_depth / 8) * self.channels)
 
     def __eq__(self, other: object) -> bool:
-        """Check equality of two items."""
+        """
+        Check whether both formats describe the same audio.
+
+        Two formats are equal when their content type, sample rate, bit depth and
+        channel count match. ``bit_rate`` and ``codec_type`` are informational and
+        are not taken into account.
+        """
         if not isinstance(other, AudioFormat):
             return False
-        return str(self) == str(other)
+        return self._identity == other._identity
 
     def __str__(self) -> str:
         """Return string representation."""
@@ -75,7 +81,7 @@ class AudioFormat(DataClassDictMixin):
 
     def __hash__(self) -> int:
         """Return custom hash."""
-        return hash(self.__str__())
+        return hash(self._identity)
 
     def __post_serialize__(self, d: dict[Any, Any]) -> dict[Any, Any]:
         """Execute action(s) on serialization."""
@@ -83,3 +89,11 @@ class AudioFormat(DataClassDictMixin):
         # TODO: remove this after release of MA 2.5
         d["bit_rate"] = d["bit_rate"] or 0
         return d
+
+    @property
+    def _identity(self) -> tuple[ContentType, int, int, int]:
+        """Return the fields that determine what the audio actually is."""
+        # content_type must be part of this: output_format_str renders every PCM
+        # content type identically, so a string based identity cannot tell e.g.
+        # 32 bit integer PCM apart from 32 bit float PCM.
+        return (self.content_type, self.sample_rate, self.bit_depth, self.channels)

--- a/music_assistant_models/media_items/audio_format.py
+++ b/music_assistant_models/media_items/audio_format.py
@@ -63,11 +63,11 @@ class AudioFormat(DataClassDictMixin):
 
     def __eq__(self, other: object) -> bool:
         """
-        Check whether both formats describe the same audio.
+        Check equality on content type, sample rate, bit depth and channel count.
 
-        Two formats are equal when their content type, sample rate, bit depth and
-        channel count match. ``bit_rate`` and ``codec_type`` are informational and
-        are not taken into account.
+        The other fields take no part: ``codec_type`` and ``bit_rate`` are filled in
+        while ffmpeg probes the stream, and ``output_format_str`` describes how the
+        audio is rendered rather than what it is.
         """
         if not isinstance(other, AudioFormat):
             return False
@@ -93,7 +93,6 @@ class AudioFormat(DataClassDictMixin):
     @property
     def _identity(self) -> tuple[ContentType, int, int, int]:
         """Return the fields that determine what the audio actually is."""
-        # content_type must be part of this: output_format_str renders every PCM
-        # content type identically, so a string based identity cannot tell e.g.
-        # 32 bit integer PCM apart from 32 bit float PCM.
+        # content_type carries the sample encoding: s32le and f32le share a bit depth
+        # but not a byte layout, so the numeric fields alone cannot tell them apart.
         return (self.content_type, self.sample_rate, self.bit_depth, self.channels)

--- a/tests/test_audio_format.py
+++ b/tests/test_audio_format.py
@@ -15,8 +15,10 @@ def _pcm(content_type: ContentType, bit_depth: int = 32) -> AudioFormat:
 
 def test_pcm_encodings_of_equal_depth_are_not_equal() -> None:
     """Integer and float PCM of the same depth describe different bytes."""
-    assert _pcm(ContentType.PCM_S32LE) != _pcm(ContentType.PCM_F32LE)
-    assert hash(_pcm(ContentType.PCM_S32LE)) != hash(_pcm(ContentType.PCM_F32LE))
+    s32 = _pcm(ContentType.PCM_S32LE)
+    f32 = _pcm(ContentType.PCM_F32LE)
+    assert s32 != f32
+    assert len({s32, f32}) == 2
 
 
 def test_pcm_companding_is_not_equal_to_linear_pcm() -> None:
@@ -35,29 +37,36 @@ def test_identical_formats_are_equal_and_hash_alike() -> None:
     assert hash(_pcm(ContentType.PCM_S24LE)) == hash(_pcm(ContentType.PCM_S24LE))
 
 
-def test_differing_sample_rate_or_channels_are_not_equal() -> None:
-    """Sample rate and channel count are part of the identity."""
+def test_differing_sample_rate_bit_depth_or_channels_are_not_equal() -> None:
+    """Sample rate, bit depth and channel count are all part of the identity."""
     base = AudioFormat(content_type=ContentType.FLAC, sample_rate=44100, bit_depth=16, channels=2)
     assert base != AudioFormat(
         content_type=ContentType.FLAC, sample_rate=48000, bit_depth=16, channels=2
+    )
+    assert base != AudioFormat(
+        content_type=ContentType.FLAC, sample_rate=44100, bit_depth=24, channels=2
     )
     assert base != AudioFormat(
         content_type=ContentType.FLAC, sample_rate=44100, bit_depth=16, channels=1
     )
 
 
-def test_bit_rate_and_codec_type_are_ignored() -> None:
-    """
-    Informational fields do not affect equality.
+def test_descriptive_fields_do_not_affect_equality() -> None:
+    """codec_type, bit_rate and output_format_str are excluded, and so is the hash."""
+    probed = AudioFormat(content_type=ContentType.OGG, codec_type=ContentType.VORBIS, bit_rate=320)
+    unprobed = AudioFormat(content_type=ContentType.OGG)
+    assert probed == unprobed
+    assert hash(probed) == hash(unprobed)
 
-    codec_type in particular is filled in later, once ffmpeg has probed the input.
-    """
-    assert AudioFormat(content_type=ContentType.MP3, bit_rate=128) == AudioFormat(
-        content_type=ContentType.MP3, bit_rate=320
-    )
-    assert AudioFormat(content_type=ContentType.OGG) == AudioFormat(
-        content_type=ContentType.OGG, codec_type=ContentType.VORBIS
-    )
+    renamed = AudioFormat(content_type=ContentType.FLAC, output_format_str="custom")
+    assert renamed == AudioFormat(content_type=ContentType.FLAC)
+    assert hash(renamed) == hash(AudioFormat(content_type=ContentType.FLAC))
+
+
+def test_a_serialization_round_trip_stays_equal() -> None:
+    """A format survives to_dict/from_dict as an equal format."""
+    original = AudioFormat(content_type=ContentType.MP3, sample_rate=48000, channels=2)
+    assert AudioFormat.from_dict(original.to_dict()) == original
 
 
 def test_not_equal_to_other_types() -> None:

--- a/tests/test_audio_format.py
+++ b/tests/test_audio_format.py
@@ -1,0 +1,65 @@
+"""Tests for the AudioFormat model."""
+
+from music_assistant_models.enums import ContentType
+from music_assistant_models.media_items import AudioFormat
+
+
+def _pcm(content_type: ContentType, bit_depth: int = 32) -> AudioFormat:
+    return AudioFormat(
+        content_type=content_type,
+        sample_rate=44100,
+        bit_depth=bit_depth,
+        channels=2,
+    )
+
+
+def test_pcm_encodings_of_equal_depth_are_not_equal() -> None:
+    """Integer and float PCM of the same depth describe different bytes."""
+    assert _pcm(ContentType.PCM_S32LE) != _pcm(ContentType.PCM_F32LE)
+    assert hash(_pcm(ContentType.PCM_S32LE)) != hash(_pcm(ContentType.PCM_F32LE))
+
+
+def test_pcm_companding_is_not_equal_to_linear_pcm() -> None:
+    """A-law/mu-law are PCM content types but not interchangeable with linear PCM."""
+    assert _pcm(ContentType.PCM_ALAW, bit_depth=16) != _pcm(ContentType.PCM_S16LE, bit_depth=16)
+
+
+def test_generic_pcm_is_not_equal_to_a_concrete_encoding() -> None:
+    """Generic PCM has no defined sample encoding, so it matches no concrete one."""
+    assert _pcm(ContentType.PCM, bit_depth=16) != _pcm(ContentType.PCM_S16LE, bit_depth=16)
+
+
+def test_identical_formats_are_equal_and_hash_alike() -> None:
+    """The same content type, sample rate, bit depth and channel count compare equal."""
+    assert _pcm(ContentType.PCM_S24LE) == _pcm(ContentType.PCM_S24LE)
+    assert hash(_pcm(ContentType.PCM_S24LE)) == hash(_pcm(ContentType.PCM_S24LE))
+
+
+def test_differing_sample_rate_or_channels_are_not_equal() -> None:
+    """Sample rate and channel count are part of the identity."""
+    base = AudioFormat(content_type=ContentType.FLAC, sample_rate=44100, bit_depth=16, channels=2)
+    assert base != AudioFormat(
+        content_type=ContentType.FLAC, sample_rate=48000, bit_depth=16, channels=2
+    )
+    assert base != AudioFormat(
+        content_type=ContentType.FLAC, sample_rate=44100, bit_depth=16, channels=1
+    )
+
+
+def test_bit_rate_and_codec_type_are_ignored() -> None:
+    """
+    Informational fields do not affect equality.
+
+    codec_type in particular is filled in later, once ffmpeg has probed the input.
+    """
+    assert AudioFormat(content_type=ContentType.MP3, bit_rate=128) == AudioFormat(
+        content_type=ContentType.MP3, bit_rate=320
+    )
+    assert AudioFormat(content_type=ContentType.OGG) == AudioFormat(
+        content_type=ContentType.OGG, codec_type=ContentType.VORBIS
+    )
+
+
+def test_not_equal_to_other_types() -> None:
+    """Comparing against a non-AudioFormat returns False rather than raising."""
+    assert _pcm(ContentType.PCM_S16LE, bit_depth=16) != "pcm"


### PR DESCRIPTION
# What does this implement/fix?

`AudioFormat` compared two formats through their display string, and that string renders
every PCM content type identically. So 32-bit integer PCM and 32-bit float PCM (or a-law
and linear PCM at the same depth) came out as the same format, and anything asking "can I
pass these bytes through unconverted?" got the wrong answer. That produced audibly clipped
audio in the server, which had to work around it with its own `pcm_formats_match()` helper
because `==` could not be trusted.

**Related issue (if applicable):**

- music-assistant/server#5918

## Changes

- `AudioFormat.__eq__` / `__hash__` key off `(content_type, sample_rate, bit_depth, channels)`
  instead of `str(self)`.
- `codec_type` and `bit_rate` stay out: both are only filled in once ffmpeg has probed the
  stream, and `bit_rate` comes back from a serialization round trip as `0` rather than `None`,
  so either one would make two descriptions of the same stream compare unequal.
- `__str__` and `output_format_str` are untouched — `output_format_str` is a wire string
  (ffmpeg `-f`, the HTTP `Content-Type`, the stream URL `fmt` segment), not a description.
- Added `tests/test_audio_format.py`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/`.
- [x] Consumers audited: the full server test suite (13,004 tests) was run against this branch
      and passes, except `tests/controllers/streams/test_pcm_passthrough_gate.py`, which asserts
      the old broken equality on purpose. The server follow-up (pin bump, drop the now-redundant
      `pcm_formats_match`, update that test) goes in once this is released. The python client
      does not reference `AudioFormat` at all.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
