### PR TITLE
Fix model equality with matchers

### DIFF
--- a/music_assistant_models/media_items/audio_format.py
+++ b/music_assistant_models/media_items/audio_format.py
@@ -70,7 +70,7 @@ class AudioFormat(DataClassDictMixin):
         audio is rendered rather than what it is.
         """
         if not isinstance(other, AudioFormat):
-            return False
+            return NotImplemented
         return self._identity == other._identity
 
     def __str__(self) -> str:

--- a/music_assistant_models/media_items/media_item.py
+++ b/music_assistant_models/media_items/media_item.py
@@ -120,7 +120,7 @@ class _MediaItemBase(DataClassDictMixin):
     def __eq__(self, other: object) -> bool:
         """Check equality of two items."""
         if not isinstance(other, MediaItem | ItemMapping):
-            return False
+            return NotImplemented
         return self.uri == other.uri
 
 

--- a/music_assistant_models/media_items/metadata.py
+++ b/music_assistant_models/media_items/metadata.py
@@ -42,7 +42,7 @@ class MediaItemLink(DataClassDictMixin):
     def __eq__(self, other: object) -> bool:
         """Check equality of two items."""
         if not isinstance(other, MediaItemLink):
-            return False
+            return NotImplemented
         return self.url == other.url
 
 
@@ -66,7 +66,7 @@ class MediaItemImage(DataClassDictMixin):
     def __eq__(self, other: object) -> bool:
         """Check equality of two items."""
         if not isinstance(other, MediaItemImage):
-            return False
+            return NotImplemented
         return self.__hash__() == other.__hash__()
 
     def __post_serialize__(self, d: dict[str, Any]) -> dict[str, Any]:

--- a/music_assistant_models/media_items/provider_mapping.py
+++ b/music_assistant_models/media_items/provider_mapping.py
@@ -67,5 +67,5 @@ class ProviderMapping(DataClassDictMixin):
     def __eq__(self, other: object) -> bool:
         """Check equality of two items."""
         if not isinstance(other, ProviderMapping):
-            return False
+            return NotImplemented
         return self.provider_instance == other.provider_instance and self.item_id == other.item_id

--- a/tests/test_audio_format.py
+++ b/tests/test_audio_format.py
@@ -1,5 +1,7 @@
 """Tests for the AudioFormat model."""
 
+from unittest.mock import ANY
+
 from music_assistant_models.enums import ContentType
 from music_assistant_models.media_items import AudioFormat
 
@@ -70,5 +72,7 @@ def test_a_serialization_round_trip_stays_equal() -> None:
 
 
 def test_not_equal_to_other_types() -> None:
-    """Comparing against a non-AudioFormat returns False rather than raising."""
-    assert _pcm(ContentType.PCM_S16LE, bit_depth=16) != "pcm"
+    """Unsupported operands can provide reflected equality behavior."""
+    audio_format = _pcm(ContentType.PCM_S16LE, bit_depth=16)
+    assert audio_format != "pcm"
+    assert audio_format == ANY


### PR DESCRIPTION
# What does this implement/fix?

Model equality checks returned `False` before the other operand could handle the comparison.

- Return `NotImplemented` for unsupported operand types across custom model equality methods.
- Cover reflected equality with `unittest.mock.ANY`.

**Related issue (if applicable):**

- Follow-up to #375

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] Any consumer of a changed model is updated, and the companion PR in `music-assistant/server` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
