### PR TITLE
Report active external-source audio details on players

### DIFF
--- a/music_assistant_models/audio_processing.py
+++ b/music_assistant_models/audio_processing.py
@@ -115,3 +115,17 @@ class AudioProcessingChain(DataClassDictMixin):
     input_fidelity: AudioFidelity = field(default_factory=AudioFidelity)
     queue_processing: AudioQueueProcessing | None = None
     outputs: list[AudioOutputDetails] = field(default_factory=list)
+
+
+@dataclass(kw_only=True)
+class ActiveSourceAudioDetails(DataClassDictMixin):
+    """Effective audio details for a player's active external source."""
+
+    # Original/public format of the audio delivered by the external source.
+    input_format: AudioFormat
+    input_fidelity: AudioFidelity = field(default_factory=AudioFidelity)
+    # UNKNOWN means the source has not reported its crossfade behavior.
+    crossfade_mode: CrossfadeMode = CrossfadeMode.UNKNOWN
+    # UNKNOWN means the source has not reported its normalization behavior.
+    volume_normalization_mode: VolumeNormalizationMode = VolumeNormalizationMode.UNKNOWN
+    outputs: list[AudioOutputDetails] = field(default_factory=list)

--- a/music_assistant_models/player.py
+++ b/music_assistant_models/player.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from mashumaro import DataClassDictMixin, field_options
 
+from .audio_processing import ActiveSourceAudioDetails
 from .constants import EXTRA_ATTRIBUTES_TYPES, PLAYER_CONTROL_NONE
 from .enums import (
     IdentifierType,
@@ -474,6 +475,11 @@ class Player(DataClassDictMixin):
     # sleep_timer_expires_at: unix (utc) timestamp at which the active sleep timer will
     # stop playback, or None if no sleep timer is currently set for this player
     sleep_timer_expires_at: float | None = None
+
+    # active_source_audio: effective audio details reported for the currently active
+    # (external) source, or None if the active source is Music Assistant itself or no
+    # details are available yet
+    active_source_audio: ActiveSourceAudioDetails | None = None
 
     #############################################################################
     # helper methods and properties                                             #

--- a/tests/test_audio_processing.py
+++ b/tests/test_audio_processing.py
@@ -1,6 +1,7 @@
 """Tests for audio processing models."""
 
 from music_assistant_models.audio_processing import (
+    ActiveSourceAudioDetails,
     AudioDSPDetails,
     AudioFidelity,
     AudioNormalizationDetails,
@@ -139,6 +140,45 @@ def test_audio_dsp_details_legacy_payload() -> None:
         input_gain=-1.0,
         output_gain=-0.5,
     )
+
+
+def test_active_source_audio_details_defaults() -> None:
+    """An active source with no reported state defaults to unknown/no outputs."""
+    input_format = AudioFormat(content_type=ContentType.FLAC, codec_type=ContentType.FLAC)
+    details = ActiveSourceAudioDetails(input_format=input_format)
+
+    assert details.to_dict() == {
+        "input_format": input_format.to_dict(),
+        "input_fidelity": {"quality": "unknown", "bit_perfect": None},
+        "crossfade_mode": "unknown",
+        "volume_normalization_mode": "unknown",
+        "outputs": [],
+    }
+    assert ActiveSourceAudioDetails.from_dict(details.to_dict()) == details
+
+
+def test_active_source_audio_details_roundtrip_with_grouped_outputs() -> None:
+    """Source/disabled modes and multiple grouped output entries survive a round-trip."""
+    details = ActiveSourceAudioDetails(
+        input_format=AudioFormat(content_type=ContentType.MP3, codec_type=ContentType.MP3),
+        input_fidelity=AudioFidelity(quality=AudioQuality.LOSSLESS, bit_perfect=False),
+        crossfade_mode=CrossfadeMode.SOURCE,
+        volume_normalization_mode=VolumeNormalizationMode.DISABLED,
+        outputs=[
+            AudioOutputDetails(player_ids=["player-1", "player-2"]),
+            AudioOutputDetails(player_ids=["player-3"]),
+        ],
+    )
+
+    restored = ActiveSourceAudioDetails.from_dict(details.to_dict())
+
+    assert restored == details
+    assert restored.crossfade_mode is CrossfadeMode.SOURCE
+    assert restored.volume_normalization_mode is VolumeNormalizationMode.DISABLED
+    assert [output.player_ids for output in restored.outputs] == [
+        ["player-1", "player-2"],
+        ["player-3"],
+    ]
 
 
 def test_streamdetails_audio_processing_defaults_to_none() -> None:

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -1,6 +1,14 @@
 """Tests for the Player and PlayerMedia models (serialization/back-compat)."""
 
-from music_assistant_models.enums import MediaType, PlayerType, RepeatMode
+from music_assistant_models.audio_processing import ActiveSourceAudioDetails, AudioOutputDetails
+from music_assistant_models.enums import (
+    ContentType,
+    CrossfadeMode,
+    MediaType,
+    PlayerType,
+    RepeatMode,
+)
+from music_assistant_models.media_items import AudioFormat
 from music_assistant_models.player import DeviceInfo, Player, PlayerMedia, PlayerSource
 
 
@@ -80,6 +88,39 @@ def test_payload_without_private_key_deserializes() -> None:
     legacy = _player().to_dict()
     legacy.pop("private", None)
     assert Player.from_dict(legacy).private is False
+
+
+def test_active_source_audio_serializes_as_explicit_null() -> None:
+    """A player without active source audio details serializes an explicit null.
+
+    Merged PLAYER_UPDATED snapshots rely on the key being present so stale
+    details are cleared rather than left untouched.
+    """
+    serialized = _player().to_dict()
+    assert "active_source_audio" in serialized
+    assert serialized["active_source_audio"] is None
+
+
+def test_active_source_audio_roundtrip() -> None:
+    """Populated active source audio details survive a round-trip."""
+    player = _player()
+    player.active_source_audio = ActiveSourceAudioDetails(
+        input_format=AudioFormat(content_type=ContentType.FLAC, codec_type=ContentType.FLAC),
+        crossfade_mode=CrossfadeMode.SOURCE,
+        outputs=[AudioOutputDetails(player_ids=["test_player"])],
+    )
+
+    restored = Player.from_dict(player.to_dict())
+
+    assert restored.active_source_audio == player.active_source_audio
+    assert restored.active_source_audio.crossfade_mode is CrossfadeMode.SOURCE
+
+
+def test_payload_without_active_source_audio_key_deserializes() -> None:
+    """Payloads from older servers without the key still deserialize to None."""
+    legacy = _player().to_dict()
+    legacy.pop("active_source_audio", None)
+    assert Player.from_dict(legacy).active_source_audio is None
 
 
 def test_player_source_ordering_defaults() -> None:


### PR DESCRIPTION
## What does this implement/fix?

Adds a shared model so player providers can report audio details (format, fidelity, crossfade and volume normalization behavior, output routing) for a player's currently active *external* source (e.g. Spotify Connect, AirPlay), not just for Music Assistant-managed playback. This is the first of a coordinated set of changes across `models` -> `server` -> `frontend`.

- Add `ActiveSourceAudioDetails` dataclass (`music_assistant_models/audio_processing.py`)
- Add optional `active_source_audio` field to `Player`, serialized as an explicit `null` when absent so stale details are cleared on update
- Old payloads without the key still deserialize fine (defaults to `None`)
- Add round-trip and backward-compatibility tests

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] Any consumer of a changed model is updated, and the companion PR in `music-assistant/server` is linked. (follow-up PR)
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
