### PR TITLE
Drop the unused native_crossfade flag from PlayerSource

### DIFF
--- a/music_assistant_models/player.py
+++ b/music_assistant_models/player.py
@@ -169,13 +169,6 @@ class PlayerSource(DataClassDictMixin):
     # the ordering the source reports for itself; None = it has not said
     shuffle_enabled: bool | None = None
     repeat_mode: RepeatMode | None = None
-    # whether the source crossfades its own playback, so Music Assistant's own
-    # crossfade is inert while it plays. None = it has not said and cannot be
-    # asked (a native device's own setting), which is distinct from a known
-    # False — clients must not render "off" for a source that simply cannot tell
-    # them. Known either way for a session Music Assistant spawns itself, since
-    # it writes the preference before playback starts.
-    native_crossfade: bool | None = None
     # the service account this source is signed in to, once established (e.g. a
     # Spotify user id). Lives here as well as on AudioSource because a source the
     # device runs natively has no AudioSource to carry it. None = not established,

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -132,7 +132,6 @@ def test_player_source_ordering_defaults() -> None:
     # must not read as "shuffle off"
     assert source.shuffle_enabled is None
     assert source.repeat_mode is None
-    assert source.native_crossfade is None
     assert source.account_id is None
 
 
@@ -145,7 +144,6 @@ def test_player_source_ordering_roundtrip() -> None:
         can_repeat=True,
         shuffle_enabled=True,
         repeat_mode=RepeatMode.ALL,
-        native_crossfade=True,
         account_id="spotify-user-1",
     )
     data = original.to_dict()
@@ -153,7 +151,6 @@ def test_player_source_ordering_roundtrip() -> None:
     assert restored.to_dict() == data
     assert restored.shuffle_enabled is True
     assert restored.repeat_mode is RepeatMode.ALL
-    assert restored.native_crossfade is True
     assert restored.account_id == "spotify-user-1"
 
 
@@ -165,7 +162,6 @@ def test_player_source_payload_without_ordering_keys() -> None:
         "can_repeat",
         "shuffle_enabled",
         "repeat_mode",
-        "native_crossfade",
         "account_id",
     ):
         data.pop(key, None)
@@ -173,18 +169,4 @@ def test_player_source_payload_without_ordering_keys() -> None:
     assert restored.can_shuffle is False
     assert restored.shuffle_enabled is None
     assert restored.repeat_mode is None
-    assert restored.native_crossfade is None
     assert restored.account_id is None
-
-
-def test_player_source_known_off_is_not_unknown() -> None:
-    """A source reporting crossfade off is distinct from one that cannot say."""
-    known_off = PlayerSource(id="spotify", name="Spotify", native_crossfade=False)
-    cannot_say = PlayerSource(id="line-in", name="Line In")
-
-    # a client renders "off" for the first and nothing for the second, so these
-    # must survive the wire as different values rather than collapsing to falsy
-    assert known_off.native_crossfade is False
-    assert cannot_say.native_crossfade is None
-    assert PlayerSource.from_dict(known_off.to_dict()).native_crossfade is False
-    assert PlayerSource.from_dict(cannot_say.to_dict()).native_crossfade is None


### PR DESCRIPTION
# What does this implement/fix?

`PlayerSource.native_crossfade` has never had a producer: it came from a direction that was abandoned, and neither the server, the frontend nor the Home Assistant integration sets or reads it. What it describes — a source that crossfades its own playback — is now reported as `CrossfadeMode.SOURCE` on `ActiveSourceAudioDetails` (music-assistant/server#5963), alongside the same source's volume normalization, so the two belong together rather than split across two models.

- remove the unused `native_crossfade` field and its tests

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] Any consumer of a changed model is updated, and the companion PR in `music-assistant/server` is linked. (no consumer exists — nothing sets or reads the field)
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
