### PR TITLE
Add an event for when an item's played state changes

### DIFF
--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -604,6 +604,7 @@ class EventType(StrEnum):
     MEDIA_ITEM_ADDED = "media_item_added"
     MEDIA_ITEM_UPDATED = "media_item_updated"
     MEDIA_ITEM_DELETED = "media_item_deleted"
+    PLAYLOG_UPDATED = "playlog_updated"
     PROVIDERS_UPDATED = "providers_updated"
     # generic event emitted by a provider instance;
     # object_id = provider instance_id (optionally suffixed with /sub_scope),

--- a/music_assistant_models/playlog_update.py
+++ b/music_assistant_models/playlog_update.py
@@ -1,0 +1,23 @@
+"""
+Model(s) for PlaylogUpdate.
+
+This data is sent with the PLAYLOG_UPDATED event.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mashumaro import DataClassDictMixin
+
+from .enums import MediaType
+
+
+@dataclass(frozen=True)
+class PlaylogUpdate(DataClassDictMixin):
+    """Object describing the new playlog state of a media item."""
+
+    uri: str
+    media_type: MediaType
+    fully_played: bool
+    seconds_played: int

--- a/tests/test_playlog_update.py
+++ b/tests/test_playlog_update.py
@@ -1,0 +1,43 @@
+"""Tests for the PlaylogUpdate model and the PLAYLOG_UPDATED event type."""
+
+from music_assistant_models.enums import EventType, MediaType
+from music_assistant_models.event import MassEvent
+from music_assistant_models.playlog_update import PlaylogUpdate
+
+
+def test_event_type_playlog_updated_roundtrips() -> None:
+    """EventType.PLAYLOG_UPDATED is reachable and round-trips through StrEnum."""
+    assert EventType("playlog_updated") is EventType.PLAYLOG_UPDATED
+    assert EventType.PLAYLOG_UPDATED.value == "playlog_updated"
+
+
+def test_playlog_update_serialize_roundtrip() -> None:
+    """PlaylogUpdate serializes to plain values and survives a round-trip."""
+    original = PlaylogUpdate(
+        uri="library://track/123",
+        media_type=MediaType.TRACK,
+        fully_played=True,
+        seconds_played=245,
+    )
+    data = original.to_dict()
+    assert data["media_type"] == "track"
+    assert PlaylogUpdate.from_dict(data) == original
+
+
+def test_playlog_update_as_event_payload() -> None:
+    """A PlaylogUpdate serializes as the data of a MassEvent."""
+    update = PlaylogUpdate(
+        uri="library://podcast_episode/9",
+        media_type=MediaType.PODCAST_EPISODE,
+        fully_played=False,
+        seconds_played=0,
+    )
+    event = MassEvent(
+        event=EventType.PLAYLOG_UPDATED,
+        object_id=update.uri,
+        data=update,
+    )
+    data = event.to_dict()
+    assert data["event"] == "playlog_updated"
+    assert data["object_id"] == "library://podcast_episode/9"
+    assert data["data"] == update.to_dict()


### PR DESCRIPTION
# What does this implement/fix?

The home page has an "In progress" row that is built from the playlog. Nothing currently tells clients when that log changes, so a card can keep sitting in the row after the item was finished, marked played, or synced back from another app, until the page is reloaded. The main reason is for when a user clicks on the associated menu item for MARK PLAYED or MARK UNPLAYED without a signal nothing would visually happen.

This adds the event the server needs to announce that change, so clients can refresh just the rows that are built on played state.

- new `PLAYLOG_UPDATED` event type
- new `PlaylogUpdate` payload with the item uri, media type, fully played flag and seconds played
- tests for the payload and for the event it is carried in

The matching server and frontend changes follow once this is released.

**Related issue (if applicable):**

- follow up to music-assistant/frontend#2624
- related discussion https://github.com/orgs/music-assistant/discussions/6158

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] Any consumer of a changed model is updated, and the companion PR in `music-assistant/server` is linked. (server PR follows after the release, nothing existing changes)
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
