### PR TITLE
Identify the affected user on playlog updates

### DIFF
--- a/music_assistant_models/playlog_update.py
+++ b/music_assistant_models/playlog_update.py
@@ -21,3 +21,5 @@ class PlaylogUpdate(DataClassDictMixin):
     media_type: MediaType
     fully_played: bool
     seconds_played: int
+    # the user the playlog change applies to; None when it applies to all users
+    userid: str | None = None

--- a/tests/test_playlog_update.py
+++ b/tests/test_playlog_update.py
@@ -24,6 +24,22 @@ def test_playlog_update_serialize_roundtrip() -> None:
     assert PlaylogUpdate.from_dict(data) == original
 
 
+def test_playlog_update_userid_optional() -> None:
+    """Userid identifies the affected user and defaults to None (all users)."""
+    update = PlaylogUpdate(
+        uri="library://audiobook/5",
+        media_type=MediaType.AUDIOBOOK,
+        fully_played=True,
+        seconds_played=0,
+        userid="user-1",
+    )
+    assert PlaylogUpdate.from_dict(update.to_dict()) == update
+    # payloads from before the field existed deserialize to None
+    legacy = update.to_dict()
+    del legacy["userid"]
+    assert PlaylogUpdate.from_dict(legacy).userid is None
+
+
 def test_playlog_update_as_event_payload() -> None:
     """A PlaylogUpdate serializes as the data of a MassEvent."""
     update = PlaylogUpdate(


### PR DESCRIPTION
# What does this implement/fix?

The playlog is stored per user, but the `PLAYLOG_UPDATED` event introduced in #381 does not say which user a change applies to, so a client cannot tell its own updates apart from another user's. Add an optional `userid` to `PlaylogUpdate`: the affected user, or `None` when the change applies to all users (the server alters the playlog for every user when it cannot determine one).

The field is optional with a `None` default, so existing payloads and consumers are unaffected.

**Related issue (if applicable):**

- related issue https://github.com/orgs/music-assistant/discussions/6158

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] Any consumer of a changed model is updated, and the companion PR in `music-assistant/server` is linked: music-assistant/server#6005 (userid wiring follows there once this is released).
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
