### PR TITLE
Add `needs_approval` and `source_needs_approval` player flags

### DIFF
--- a/music_assistant_models/player.py
+++ b/music_assistant_models/player.py
@@ -465,6 +465,11 @@ class Player(DataClassDictMixin):
     # regardless of whether setup is currently needed
     has_setup_flow: bool = False
 
+    # source_needs_approval: if True, the player offers an audio source that stays
+    # inactive until the user explicitly approves it. Approval is granted through the
+    # player's setup flow, so a provider setting this flag must also offer one
+    source_needs_approval: bool = False
+
     # sleep_timer_expires_at: unix (utc) timestamp at which the active sleep timer will
     # stop playback, or None if no sleep timer is currently set for this player
     sleep_timer_expires_at: float | None = None

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -90,6 +90,25 @@ def test_payload_without_private_key_deserializes() -> None:
     assert Player.from_dict(legacy).private is False
 
 
+def test_source_needs_approval_defaults_to_false() -> None:
+    """A player's source only awaits approval when its provider marks it as such."""
+    assert _player().source_needs_approval is False
+
+
+def test_source_needs_approval_serialize_roundtrip() -> None:
+    """A player with a source awaiting approval keeps the flag across serialization."""
+    player = _player()
+    player.source_needs_approval = True
+    assert Player.from_dict(player.to_dict()).source_needs_approval is True
+
+
+def test_payload_without_source_approval_key_deserializes() -> None:
+    """Payloads from older servers without the source approval key still deserialize."""
+    legacy = _player().to_dict()
+    legacy.pop("source_needs_approval", None)
+    assert Player.from_dict(legacy).source_needs_approval is False
+
+
 def test_active_source_audio_serializes_as_explicit_null() -> None:
     """A player without active source audio details serializes an explicit null.
 


### PR DESCRIPTION
# What does this implement/fix?

Adds a single `Player` flag for the reshaped Sendspin unpaired-access UX (Sendspin/spec#170): `source_needs_approval` marks a player whose audio source (e.g. a line-in) stays inactive until the user explicitly approves it through the player's setup flow. It exists because such a device can be fully usable for playback while its audio input still awaits a decision, which `needs_setup` cannot express since it marks the whole player as unusable.

The rest of the reworked UX (a one-time consent step for devices that allow playback without pairing, with pairing as an opt-in) rides the existing `needs_setup`, `setup_reason` and `has_setup_flow` fields and needs no model changes.

## Types of changes

- [x] New feature (non-breaking change which adds functionality) — `new-feature`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] Any consumer of a changed model is updated, and the companion PR in `music-assistant/server` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.