### PR TITLE
Add a pairing code config entry type

### DIFF
--- a/music_assistant_models/config_entries.py
+++ b/music_assistant_models/config_entries.py
@@ -52,6 +52,7 @@ ConfigEntryTypeMap: dict[ConfigEntryType, type[ConfigValueType]] = {
     ConfigEntryType.BOOLEAN: bool,
     ConfigEntryType.STRING: str,
     ConfigEntryType.SECURE_STRING: str,
+    ConfigEntryType.PAIRING_CODE: str,
     ConfigEntryType.INTEGER: int,
     ConfigEntryType.SPLITTED_STRING: str,
     ConfigEntryType.FLOAT: float,
@@ -125,6 +126,11 @@ class ConfigEntry(DataClassDictMixin):
     options: list[ConfigValueOption] = field(default_factory=list)
     # range [optional]: select values within range
     range: tuple[int, int] | None = None
+    # format [optional]: for PAIRING_CODE entries, the shape of the code:
+    # '#' = digit box, 'X' = alphanumeric box (uppercase), '-' = rendered separator.
+    # The value is the code WITHOUT separators (e.g. "123456" for "###-###").
+    # Submit codes as strings (leading zeros); leave default_value unset.
+    format: str | None = None
     # description [optional]: extended description of the setting.
     description: str | None = None
     # help_link [optional]: link to help article.
@@ -216,6 +222,10 @@ class ConfigEntry(DataClassDictMixin):
         """Run some basic sanity checks after init."""
         if self.type in UI_ONLY:
             self.required = False
+        if self.type == ConfigEntryType.PAIRING_CODE and self.format is not None:
+            has_slot = any(ch in "#X" for ch in self.format)
+            if not self.format or any(ch not in "#X-" for ch in self.format) or not has_slot:
+                raise ValueError(f"{self.key} has an invalid pairing code format: {self.format!r}")
 
     def __post_serialize__(self, d: dict[str, Any]) -> dict[str, Any]:
         """
@@ -327,6 +337,19 @@ class ConfigEntry(DataClassDictMixin):
                 raise ValueError(f"value for {self.key} must be a list")
             value = self.default_value
 
+        # (value can be None again here when a shape check above fell back to an empty default)
+        if (
+            self.type == ConfigEntryType.PAIRING_CODE
+            and value is not None
+            and not isinstance(value, list)
+        ):
+            try:
+                value = self._parse_pairing_code(str(value))
+            except ValueError:
+                if raise_on_error:
+                    raise
+                value = self.default_value
+
         # handle some value type conversions caused by the serialization
         def convert_value(_value: _ConfigValueTypeSingle) -> _ConfigValueTypeSingle:
             if self.type == ConfigEntryType.FLOAT and isinstance(_value, int | str):
@@ -365,6 +388,22 @@ class ConfigEntry(DataClassDictMixin):
             return [tuple(x.split(MULTI_VALUE_SPLITTER, 1)) for x in value]
         assert isinstance(value, str)
         return tuple(value.split(MULTI_VALUE_SPLITTER, 1))
+
+    def _parse_pairing_code(self, value: str) -> str:
+        """Strip separators/whitespace and validate the code against `format`."""
+        code = "".join(ch for ch in value if ch != "-" and not ch.isspace())
+        if not self.format:
+            return code
+        slots = [ch for ch in self.format if ch in "#X"]
+        if len(code) != len(slots):
+            raise ValueError(f"{self.key} must be {len(slots)} characters")
+        code = code.upper()
+        for char, slot in zip(code, slots, strict=True):
+            if slot == "#" and not char.isdigit():
+                raise ValueError(f"{self.key} must contain only digits")
+            if slot == "X" and not char.isalnum():
+                raise ValueError(f"{char!r} is not valid in {self.key}")
+        return code
 
 
 @dataclass(kw_only=True)

--- a/music_assistant_models/config_entries.py
+++ b/music_assistant_models/config_entries.py
@@ -127,8 +127,9 @@ class ConfigEntry(DataClassDictMixin):
     # range [optional]: select values within range
     range: tuple[int, int] | None = None
     # format [optional]: for PAIRING_CODE entries, the shape of the code:
-    # '#' = digit box, 'X' = alphanumeric box (uppercase), '-' = rendered separator.
-    # The value is the code WITHOUT separators (e.g. "123456" for "###-###").
+    # '#' = digit box, 'X' = alphanumeric box (uppercase), any other character
+    # is a rendered separator (e.g. '-'). The value is the code WITHOUT
+    # separators (e.g. "123456" for "###-###").
     # Submit codes as strings (leading zeros); leave default_value unset.
     format: str | None = None
     # description [optional]: extended description of the setting.
@@ -222,10 +223,12 @@ class ConfigEntry(DataClassDictMixin):
         """Run some basic sanity checks after init."""
         if self.type in UI_ONLY:
             self.required = False
-        if self.type == ConfigEntryType.PAIRING_CODE and self.format is not None:
-            has_slot = any(ch in "#X" for ch in self.format)
-            if not self.format or any(ch not in "#X-" for ch in self.format) or not has_slot:
-                raise ValueError(f"{self.key} has an invalid pairing code format: {self.format!r}")
+        if (
+            self.type == ConfigEntryType.PAIRING_CODE
+            and self.format is not None
+            and not any(ch in "#X" for ch in self.format)
+        ):
+            raise ValueError(f"{self.key} has an invalid pairing code format: {self.format!r}")
 
     def __post_serialize__(self, d: dict[str, Any]) -> dict[str, Any]:
         """
@@ -390,8 +393,8 @@ class ConfigEntry(DataClassDictMixin):
         return tuple(value.split(MULTI_VALUE_SPLITTER, 1))
 
     def _parse_pairing_code(self, value: str) -> str:
-        """Strip separators/whitespace and validate the code against `format`."""
-        code = "".join(ch for ch in value if ch != "-" and not ch.isspace())
+        """Strip separators and validate the code against `format`."""
+        code = "".join(ch for ch in value if ch.isalnum())
         if not self.format:
             return code
         slots = [ch for ch in self.format if ch in "#X"]
@@ -399,9 +402,9 @@ class ConfigEntry(DataClassDictMixin):
             raise ValueError(f"{self.key} must be {len(slots)} characters")
         code = code.upper()
         for char, slot in zip(code, slots, strict=True):
-            if slot == "#" and not char.isdigit():
+            if slot == "#" and not (char.isascii() and char.isdigit()):
                 raise ValueError(f"{self.key} must contain only digits")
-            if slot == "X" and not char.isalnum():
+            if slot == "X" and not (char.isascii() and char.isalnum()):
                 raise ValueError(f"{char!r} is not valid in {self.key}")
         return code
 

--- a/music_assistant_models/config_entries.py
+++ b/music_assistant_models/config_entries.py
@@ -130,7 +130,8 @@ class ConfigEntry(DataClassDictMixin):
     # '#' = digit box, 'X' = alphanumeric box (uppercase), any other character
     # is a rendered separator (e.g. '-'). The value is the code WITHOUT
     # separators (e.g. "123456" for "###-###").
-    # Submit codes as strings (leading zeros); leave default_value unset.
+    # Submit codes as strings (leading zeros); leave default_value unset so a
+    # required code blocks submission until the user entered it.
     format: str | None = None
     # description [optional]: extended description of the setting.
     description: str | None = None
@@ -405,7 +406,7 @@ class ConfigEntry(DataClassDictMixin):
             if slot == "#" and not (char.isascii() and char.isdigit()):
                 raise ValueError(f"{self.key} must contain only digits")
             if slot == "X" and not (char.isascii() and char.isalnum()):
-                raise ValueError(f"{char!r} is not valid in {self.key}")
+                raise ValueError(f"{self.key} contains an invalid character: {char!r}")
         return code
 
 

--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -786,6 +786,9 @@ class ConfigEntryType(StrEnum):
     # url: a clickable link; when returned from a config invoke_action response,
     # the frontend opens the value (one-shot) instead of rendering a field
     URL = "url"
+    # pairing_code: a short code (PIN) shown on a device that the user copies over
+    # during pairing; the entry's `format` field describes its shape
+    PAIRING_CODE = "pairing_code"
     UNKNOWN = "unknown"
 
     @classmethod

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -372,16 +372,38 @@ def test_pairing_code_coerces_a_scalar_value() -> None:
     assert entry.parse_value(1234) == "1234"
 
 
-def test_pairing_code_format_rejects_invalid_characters() -> None:
-    """Reject a format containing characters outside '#X-'."""
-    with pytest.raises(ValueError, match="pin has an invalid pairing code format"):
-        _pairing_entry(format="?!")
+def test_pairing_code_format_treats_unknown_characters_as_separators() -> None:
+    """Accept any non-slot character in the format as a rendered separator."""
+    entry = _pairing_entry(format="##:##")
+    assert entry.parse_value("12:34") == "1234"
+    assert entry.parse_value("1234") == "1234"
 
 
 def test_pairing_code_format_requires_at_least_one_slot() -> None:
-    """Reject a format made only of separators, with no '#'/'X' slot."""
-    with pytest.raises(ValueError, match="pin has an invalid pairing code format"):
-        _pairing_entry(format="--")
+    """Reject a format without a single '#'/'X' slot."""
+    for bogus in ("--", "?!"):
+        with pytest.raises(ValueError, match="pin has an invalid pairing code format"):
+            _pairing_entry(format=bogus)
+
+
+def test_pairing_code_rejects_non_ascii_digits() -> None:
+    """Reject non-ASCII digits in a '#' slot; devices expect plain 0-9."""
+    with pytest.raises(ValueError, match="pin must contain only digits"):
+        _pairing_entry(format="####").parse_value("١٢٣٤")
+
+
+def test_pairing_code_is_normalized_before_the_validate_callback() -> None:
+    """Hand the validate callback the stripped and uppercased code, not the raw input."""
+    seen: list[ConfigValueType] = []
+    entry = _pairing_entry(format="XX-XX", validate=_recording(seen))
+
+    assert entry.parse_value("ab-cd") == "ABCD"
+    assert seen == ["ABCD"]
+
+
+def test_pairing_code_fallback_without_a_default_returns_none() -> None:
+    """Fall back to None for an invalid code when no default is set and raising is off."""
+    assert _pairing_entry(format="####").parse_value("123", raise_on_error=False) is None
 
 
 def test_pairing_code_format_roundtrips() -> None:

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -38,8 +38,9 @@ def _player_raw(**overrides: Any) -> dict[str, Any]:
 
 
 def test_config_entry_type_unknown_fallback() -> None:
-    """IMAGE is a known ConfigEntryType member; an unknown value falls back to UNKNOWN."""
+    """IMAGE/PAIRING_CODE are known ConfigEntryType members; an unknown value falls to UNKNOWN."""
     assert ConfigEntryType("image") is ConfigEntryType.IMAGE
+    assert ConfigEntryType("pairing_code") is ConfigEntryType.PAIRING_CODE
     assert ConfigEntryType("does-not-exist") is ConfigEntryType.UNKNOWN
 
 
@@ -313,3 +314,80 @@ def test_a_falsy_value_still_counts_as_a_value() -> None:
     assert seen == [False]
 
     assert _gated().parse_value("", allow_none=False) == ""
+
+
+def _pairing_entry(**overrides: Any) -> ConfigEntry:
+    """Build a PAIRING_CODE entry, with no format unless overridden."""
+    return ConfigEntry(key="pin", type=ConfigEntryType.PAIRING_CODE, **overrides)
+
+
+def test_pairing_code_entry_type_registered() -> None:
+    """PAIRING_CODE resolves, maps to str, is not UI-only, and a required entry stays required."""
+    assert ConfigEntryType("pairing_code") is ConfigEntryType.PAIRING_CODE
+    assert ConfigEntryTypeMap[ConfigEntryType.PAIRING_CODE] is str
+    assert ConfigEntryType.PAIRING_CODE not in UI_ONLY
+    entry = _pairing_entry(required=True)
+    assert entry.required is True
+
+
+def test_pairing_code_strips_separators_and_whitespace() -> None:
+    """Strip the format's rendered separators and any incidental whitespace."""
+    entry = _pairing_entry(format="###-###")
+    assert entry.parse_value("123-456") == "123456"
+    assert entry.parse_value(" 123 456 ") == "123456"
+
+
+def test_pairing_code_strips_without_a_format() -> None:
+    """Strip separators/whitespace even when no format is set to validate against."""
+    entry = _pairing_entry()
+    assert entry.parse_value("123-456") == "123456"
+    assert entry.parse_value(" 123 456 ") == "123456"
+
+
+def test_pairing_code_length_mismatch() -> None:
+    """Reject a code whose length does not match the format's slot count."""
+    entry = _pairing_entry(format="###-###", default_value="000000")
+
+    with pytest.raises(ValueError, match="pin must be 6 characters"):
+        entry.parse_value("12345")
+
+    assert entry.parse_value("12345", raise_on_error=False) == "000000"
+
+
+def test_pairing_code_digit_slot_enforcement() -> None:
+    """Reject a non-digit character in a '#' slot."""
+    with pytest.raises(ValueError, match="pin must contain only digits"):
+        _pairing_entry(format="####").parse_value("12a4")
+
+
+def test_pairing_code_alnum_slots_are_uppercased() -> None:
+    """Uppercase alphanumeric 'X' slots while separators are stripped."""
+    entry = _pairing_entry(format="XXXX-XXXX")
+    assert entry.parse_value("ab12-cd34") == "AB12CD34"
+
+
+def test_pairing_code_coerces_a_scalar_value() -> None:
+    """Coerce a non-string scalar (e.g. an int read back from storage) before validating it."""
+    entry = _pairing_entry(format="####")
+    assert entry.parse_value(1234) == "1234"
+
+
+def test_pairing_code_format_rejects_invalid_characters() -> None:
+    """Reject a format containing characters outside '#X-'."""
+    with pytest.raises(ValueError, match="pin has an invalid pairing code format"):
+        _pairing_entry(format="?!")
+
+
+def test_pairing_code_format_requires_at_least_one_slot() -> None:
+    """Reject a format made only of separators, with no '#'/'X' slot."""
+    with pytest.raises(ValueError, match="pin has an invalid pairing code format"):
+        _pairing_entry(format="--")
+
+
+def test_pairing_code_format_roundtrips() -> None:
+    """Round-trip the `format` field through to_dict/from_dict."""
+    entry = _pairing_entry(format="###-###")
+
+    restored = ConfigEntry.from_dict(entry.to_dict())
+
+    assert restored.format == "###-###"

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -38,7 +38,7 @@ def _player_raw(**overrides: Any) -> dict[str, Any]:
 
 
 def test_config_entry_type_unknown_fallback() -> None:
-    """IMAGE/PAIRING_CODE are known ConfigEntryType members; an unknown value falls to UNKNOWN."""
+    """Known ConfigEntryType members resolve; an unknown value falls back to UNKNOWN."""
     assert ConfigEntryType("image") is ConfigEntryType.IMAGE
     assert ConfigEntryType("pairing_code") is ConfigEntryType.PAIRING_CODE
     assert ConfigEntryType("does-not-exist") is ConfigEntryType.UNKNOWN


### PR DESCRIPTION
# What does this implement/fix?

Adds a `PAIRING_CODE` config entry type plus an optional `format` field on `ConfigEntry`, so clients can render pairing codes (AirPlay PIN, Sendspin PIN) as dedicated per-character input boxes instead of a plain text field.

- `format` describes the shape of the code: `#` = digit, `X` = alphanumeric (uppercased), any other character is a rendered separator (keeps older clients forward-compatible with future format characters) — e.g. `####`, `###-###`, `XXXX-XXXX`
- The value is the bare code without separators; `parse_value` strips separators/whitespace and validates the code against the format, so older clients with a plain text field keep working
- Old clients that don't know the new type fall back to `UNKNOWN` and render a regular text field

**Related issue (if applicable):**

- companion PRs in `music-assistant/frontend` (segmented input field) and `music-assistant/server` (AirPlay + Sendspin pairing flows) follow shortly

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] Any consumer of a changed model is updated, and the companion PR in `music-assistant/server` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.

