### PR TITLE
Add `source` player type for capture-only devices

### DIFF
--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -461,6 +461,8 @@ class PlayerType(StrEnum):
              but does not play audio.
     visualizer: A device that visualizes music on a screen (e.g. animations, LED matrices).
     light: A device that visualizes music through lighting (e.g. Hue sync, WLED).
+    source: A capture-only device that provides audio input (e.g. a line-in client)
+            but does not render audio itself.
     """
 
     PLAYER = "player"
@@ -470,6 +472,7 @@ class PlayerType(StrEnum):
     DISPLAY = "display"
     VISUALIZER = "visualizer"
     LIGHT = "light"
+    SOURCE = "source"
     UNKNOWN = "unknown"
 
     @classmethod

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -27,6 +27,12 @@ def _player() -> Player:
     )
 
 
+def test_player_type_source_resolves() -> None:
+    """The SOURCE member resolves; an unknown value falls back to UNKNOWN."""
+    assert PlayerType("source") is PlayerType.SOURCE
+    assert PlayerType("does-not-exist") is PlayerType.UNKNOWN
+
+
 def test_stream_duration_defaults_to_none() -> None:
     """Media that plays from the start has no separate stream length."""
     assert _media().stream_duration is None


### PR DESCRIPTION
# What does this implement/fix?

Capture-only devices (audio inputs such as a Sendspin line-in client) register as players but never render audio, and until now had no honest `PlayerType`, so they register as `UNKNOWN`.

This adds a dedicated `SOURCE` member so UIs can present and filter these devices properly (icon, player-type filters, the discover-page banner for hidden devices that need setup). Older clients that don't know the value degrade safely, since `PlayerType._missing_` falls back to `UNKNOWN`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] Any consumer of a changed model is updated, and the companion PR in `music-assistant/server` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
