### PR TITLE
Record the playback session on stream details

### DIFF
--- a/music_assistant_models/streamdetails.py
+++ b/music_assistant_models/streamdetails.py
@@ -235,6 +235,14 @@ class StreamDetails(DataClassDictMixin):
         metadata=field_options(serialize="omit", deserialize=pass_through),
         repr=False,
     )
+    # the playback session these details were resolved for, so a teardown can tell the
+    # audio it owns from the audio a session that started after it owns
+    queue_session_id: str | None = field(
+        default=None,
+        compare=False,
+        metadata=field_options(serialize="omit", deserialize=pass_through),
+        repr=False,
+    )
     seconds_streamed: float | None = field(
         default=None,
         compare=False,

--- a/tests/test_streamdetails.py
+++ b/tests/test_streamdetails.py
@@ -67,6 +67,13 @@ def test_is_realtime_is_not_serialized() -> None:
     assert "is_realtime" not in _make_streamdetails(is_realtime=True).to_dict()
 
 
+def test_queue_session_id_is_not_serialized() -> None:
+    """queue_session_id is server-internal and must not be sent to clients."""
+    sd = _make_streamdetails()
+    sd.queue_session_id = "sess-1"
+    assert "queue_session_id" not in sd.to_dict()
+
+
 def test_legacy_dsp_is_not_serialized() -> None:
     """Legacy DSP details are not included in stream details."""
     assert "dsp" not in _make_streamdetails().to_dict()


### PR DESCRIPTION
# What does this implement/fix?

Adds `queue_session_id` to `StreamDetails`, recording which playback session the details
were resolved for.

The server tears down a queue's audio when playback stops. Today that teardown can only
address a queue as a whole, so it cannot tell audio belonging to the session being stopped
from audio a session that started after it already prepared. With the session on the
details, the server can leave the newer session's audio alone. See the companion PR.

Server-internal like the `queue_id` next to it: not serialized, not compared, not in `repr`.

**Related issue (if applicable):**

- Companion PR: music-assistant/server#6082

## Types of changes

- [x] Maintenance / chore — `maintenance`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] Any consumer of a changed model is updated, and the companion PR in `music-assistant/server` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
