### PR TITLE
Add PlaylistMatchPolicy enum

### DIFF
--- a/music_assistant_models/enums.py
+++ b/music_assistant_models/enums.py
@@ -199,6 +199,18 @@ class RecommendationFolderType(StrEnum):
         return cls.DEFAULT
 
 
+class PlaylistMatchPolicy(StrEnum):
+    """Enum with playlist track match policies, from strictest to loosest.
+
+    Controls how loosely a substitute track may be matched on another provider once
+    a playlist entry's original source is confirmed unavailable.
+    """
+
+    EXACT = "exact"
+    SAME_RECORDING = "same_recording"
+    BEST_EFFORT = "best_effort"
+
+
 class ArtistType(StrEnum):
     """Enum for Artist type."""
 

--- a/tests/test_playlist_match_policy.py
+++ b/tests/test_playlist_match_policy.py
@@ -1,0 +1,44 @@
+"""Tests for the PlaylistMatchPolicy enum."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+from mashumaro import DataClassDictMixin
+
+from music_assistant_models.enums import PlaylistMatchPolicy
+
+
+@dataclass
+class _MatchPolicyHolder(DataClassDictMixin):
+    """Minimal dataclass to exercise PlaylistMatchPolicy (de)serialization."""
+
+    match_policy: PlaylistMatchPolicy
+
+
+def test_values() -> None:
+    """The wire values are fixed and must not change without a version bump."""
+    assert PlaylistMatchPolicy.EXACT == "exact"
+    assert PlaylistMatchPolicy.SAME_RECORDING == "same_recording"
+    assert PlaylistMatchPolicy.BEST_EFFORT == "best_effort"
+
+
+@pytest.mark.parametrize("policy", list(PlaylistMatchPolicy))
+def test_roundtrip(policy: PlaylistMatchPolicy) -> None:
+    """Each policy survives a model JSON roundtrip."""
+    holder = _MatchPolicyHolder(match_policy=policy)
+    restored = _MatchPolicyHolder.from_dict(holder.to_dict())
+    assert restored.match_policy is policy
+
+
+def test_deserialize_from_string() -> None:
+    """A raw wire string deserializes to the matching enum member."""
+    restored = _MatchPolicyHolder.from_dict({"match_policy": "same_recording"})
+    assert restored.match_policy is PlaylistMatchPolicy.SAME_RECORDING
+
+
+def test_unknown_value_is_rejected() -> None:
+    """An unrecognized value is rejected rather than silently coerced."""
+    with pytest.raises(ValueError, match="invalid value"):
+        _MatchPolicyHolder.from_dict({"match_policy": "some_future_policy"})


### PR DESCRIPTION
## What does this implement/fix?

Adds a small shared `PlaylistMatchPolicy` enum (`exact`, `same_recording`, `best_effort`) used to control how loosely a substitute track may be matched when a playlist entry's original source is gone. This is the companion model for the playlist-import matching feature in `music-assistant/server`.

- New `PlaylistMatchPolicy` StrEnum in `music_assistant_models/enums.py`
- Tests for its values and model JSON round-trip/deserialization behavior

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] Any consumer of a changed model is updated, and the companion PR in `music-assistant/server` is linked. (server-side companion: music-assistant/server#5986)
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.